### PR TITLE
Explicitly specify a temporary directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,11 @@ set -x
 
 git submodule update --init --recursive
 
+TMPDIR="$PWD"/tmpexec
+mkdir -p "$TMPDIR"
+trap "rm -rf $TMPDIR" EXIT
 pushd spark-cassandra-connector
-sbt -Dscala-2.11=true assembly
+sbt -Djava.io.tmpdir="$TMPDIR" -Dscala-2.11=true assembly
 popd
 
 if [ ! -d "./lib" ]; then
@@ -15,4 +18,4 @@ fi
 
 cp ./spark-cassandra-connector/spark-cassandra-connector/target/full/scala-2.11/spark-cassandra-connector-assembly-*.jar ./lib
 
-sbt assembly
+sbt -Djava.io.tmpdir="$TMPDIR" assembly


### PR DESCRIPTION
It is common in restricted enterprise setups that the /tmp directory will
be a tmpfs mountpoint mounted with noexec.

In those situations, sbt will fail because the JVM will try to mmap files
from its temporary location with executable permissions.

Since remounting /tmp may break security policies, we are better off leaving
that untouched, and specifying a tmpdir ourselves.