### PR TITLE
Support all token types for savepoints

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/src/main/scala/com/scylladb/migrator/Config.scala
+++ b/src/main/scala/com/scylladb/migrator/Config.scala
@@ -1,21 +1,42 @@
 package com.scylladb.migrator
 
 import cats.implicits._
-import java.nio.charset.StandardCharsets
-import java.nio.file.{ Files, Paths }
-import io.circe._, io.circe.syntax._, io.circe.generic.auto._
-import io.circe.yaml._, io.circe.yaml.syntax._
+import com.datastax.spark.connector.rdd.partitioner.dht.{ BigIntToken, LongToken, Token }
+import io.circe._
+import io.circe.generic.semiauto._
+import io.circe.syntax._
+import io.circe.yaml._
+import io.circe.yaml.syntax._
 
 case class MigratorConfig(source: SourceSettings,
                           target: TargetSettings,
                           preserveTimestamps: Boolean,
                           renames: List[Rename],
                           savepoints: Savepoints,
-                          skipTokenRanges: Set[(Long, Long)]) {
+                          skipTokenRanges: Set[(Token[_], Token[_])]) {
   def render: String = this.asJson.asYaml.spaces2
 }
 
 object MigratorConfig {
+  implicit val tokenEncoder: Encoder[Token[_]] = Encoder.instance {
+    case LongToken(value)   => Json.obj("type" := "long", "value"   := value)
+    case BigIntToken(value) => Json.obj("type" := "bigint", "value" := value)
+  }
+
+  implicit val tokenDecoder: Decoder[Token[_]] = Decoder.instance { cursor =>
+    for {
+      tpe <- cursor.get[String]("type").right
+      result <- tpe match {
+                 case "long"    => cursor.get[Long]("value").right.map(LongToken(_))
+                 case "bigint"  => cursor.get[BigInt]("value").right.map(BigIntToken(_))
+                 case otherwise => Left(DecodingFailure(s"Unknown token type '$otherwise'", Nil))
+               }
+    } yield result
+  }
+
+  implicit val migratorConfigDecoder: Decoder[MigratorConfig] = deriveDecoder[MigratorConfig]
+  implicit val migratorConfigEncoder: Encoder[MigratorConfig] = deriveEncoder[MigratorConfig]
+
   def loadFrom(path: String): MigratorConfig = {
     val configData = scala.io.Source.fromFile(path).mkString
 
@@ -28,6 +49,10 @@ object MigratorConfig {
 }
 
 case class Credentials(username: String, password: String)
+object Credentials {
+  implicit val encoder: Encoder[Credentials] = deriveEncoder
+  implicit val decoder: Decoder[Credentials] = deriveDecoder
+}
 
 case class SourceSettings(host: String,
                           port: Int,
@@ -37,6 +62,10 @@ case class SourceSettings(host: String,
                           splitCount: Option[Int],
                           connections: Option[Int],
                           fetchSize: Int)
+object SourceSettings {
+  implicit val encoder: Encoder[SourceSettings] = deriveEncoder
+  implicit val decoder: Decoder[SourceSettings] = deriveDecoder
+}
 
 case class TargetSettings(host: String,
                           port: Int,
@@ -44,7 +73,19 @@ case class TargetSettings(host: String,
                           keyspace: String,
                           table: String,
                           connections: Option[Int])
+object TargetSettings {
+  implicit val encoder: Encoder[TargetSettings] = deriveEncoder
+  implicit val decoder: Decoder[TargetSettings] = deriveDecoder
+}
 
 case class Rename(from: String, to: String)
+object Rename {
+  implicit val encoder: Encoder[Rename] = deriveEncoder
+  implicit val decoder: Decoder[Rename] = deriveDecoder
+}
 
 case class Savepoints(intervalSeconds: Int, path: String)
+object Savepoints {
+  implicit val encoder: Encoder[Savepoints] = deriveEncoder
+  implicit val decoder: Decoder[Savepoints] = deriveDecoder
+}


### PR DESCRIPTION
Resolves #6.

@tarzanek to your question why we're modifying the C* connector itself: this was the shortest path to achieving the savepoint functionality. It is possible that we could get this functionality without modifying the connector (e.g. adding a `WHERE TOKEN != ...` predicate to the query).