### PR TITLE
Add writetimeToleranceMillis config option

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -56,6 +56,8 @@ validation:
   compareTimestamps: true
   # What difference should we allow between TTLs?
   ttlToleranceMillis: 60000
+  # What difference should we allow between WRITETIMEs?
+  writetimeToleranceMillis: 1000
   # How many differences to fetch and print
   failuresToFetch: 100
   # What difference should we allow between floating point numbers?

--- a/src/main/scala/com/scylladb/migrator/Config.scala
+++ b/src/main/scala/com/scylladb/migrator/Config.scala
@@ -91,6 +91,7 @@ object Savepoints {
 
 case class Validation(compareTimestamps: Boolean,
                       ttlToleranceMillis: Long,
+                      writetimeToleranceMillis: Long,
                       failuresToFetch: Int,
                       floatingPointTolerance: Double)
 object Validation {

--- a/src/main/scala/com/scylladb/migrator/Validator.scala
+++ b/src/main/scala/com/scylladb/migrator/Validator.scala
@@ -119,9 +119,9 @@ object RowComparisonFailure {
             for {
               name <- names
               if name.endsWith("_writetime")
-              leftTtl  = left.getLongOption(name)
-              rightTtl = right.getLongOption(name)
-              result <- (leftTtl, rightTtl) match {
+              leftWritetime  = left.getLongOption(name)
+              rightWritetime = right.getLongOption(name)
+              result <- (leftWritetime, rightWritetime) match {
                          case (Some(l), Some(r)) if math.abs(l - r) > writetimeToleranceMicros =>
                            Some(name -> math.abs(l - r))
                          case (Some(l), None)    => Some(name -> l)


### PR DESCRIPTION
In the case of double-writing from a piece of software,
it's unlikely that writes will reach both databases at the exact same
time. Adding a tolerance allows for the validator to be used in this
situation.