### PR TITLE
Conditionally strip trailing zeros from Decimal values written to Scylla

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -91,6 +91,11 @@ target:
   table: stocks
   # Number of connections to use to Scylla when copying
   connections: 16
+  # Spark pads decimals with zeros appropriate to their scale. This causes values
+  # like '3.5' to be copied as '3.5000000000...' to the target. There's no good way
+  # currently to preserve the original value, so this flag can strip trailing zeros
+  # on decimal values before they are written.
+  stripTrailingZerosForDecimals: false
 
 # Example for loading into a DynamoDB target (for example, Scylla's Alternator):
 # target:

--- a/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
+++ b/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
@@ -12,7 +12,8 @@ object TargetSettings {
                     credentials: Option[Credentials],
                     keyspace: String,
                     table: String,
-                    connections: Option[Int])
+                    connections: Option[Int],
+                    stripTrailingZerosForDecimals: Boolean)
       extends TargetSettings
 
   case class DynamoDB(endpoint: Option[DynamoDBEndpoint],


### PR DESCRIPTION
Spark pads Decimal values with trailing zeros corresponding to the
scale of the column. Some users don't like this, so we offer a flag to
strip trailing zeros.

Resolves #33.