### PR TITLE
Fix path to spark-submit in docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker-compose exec scylla cqlsh
 
 6. Then, launch `spark-submit` in the master's container to run the job:
 ```shell
-docker-compose exec spark-master spark-submit --class com.scylladb.migrator.Migrator \
+docker-compose exec spark-master /spark/bin/spark-submit --class com.scylladb.migrator.Migrator \
   --master spark://spark-master:7077 \
   --conf spark.driver.host=spark-master \
   --conf spark.scylla.config=/app/config.yaml \


### PR DESCRIPTION
`spark-submit` instead of `/spark/bin/spark-submit` results in the following error:

```
OCI runtime exec failed: exec failed: container_linux.go:345: starting container process caused "exec: \"spark-submit\": executable file not found in $PATH": unknown
```