### PR TITLE
Upgrade to scala 2.12 and spark 3.0.1 and fix SSL set-up issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,18 @@
 import sbt.librarymanagement.InclExclRule
 
+
+assemblyMergeStrategy in assembly := {
+  case "module-info.class" => MergeStrategy.discard
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}
+
 lazy val root = (project in file(".")).settings(
   inThisBuild(
     List(
       organization := "com.scylladb",
-      scalaVersion := "2.11.12"
+      scalaVersion := "2.12.11"
     )),
   name      := "scylla-migrator",
   version   := "0.0.1",
@@ -20,13 +28,14 @@ lazy val root = (project in file(".")).settings(
   fork                      := true,
   scalafmtOnCompile         := true,
   libraryDependencies ++= Seq(
-    "org.apache.spark" %% "spark-streaming"      % "2.4.4" % "provided",
-    "org.apache.spark" %% "spark-sql"            % "2.4.4" % "provided",
-    "org.apache.spark" %% "spark-sql"            % "2.4.4" % "provided",
-    "com.amazonaws"    % "aws-java-sdk-sts"      % "1.11.728",
-    "com.amazonaws"    % "aws-java-sdk-dynamodb" % "1.11.728",
-    ("com.amazonaws" % "dynamodb-streams-kinesis-adapter" % "1.5.2")
-      .excludeAll(InclExclRule("com.fasterxml.jackson.core")),
+    "org.apache.spark" %% "spark-streaming"      % "3.0.1" % "provided",
+    "org.apache.spark" %% "spark-sql"            % "3.0.1" % "provided",
+    "org.apache.spark" %% "spark-sql"            % "3.0.1" % "provided",
+    "com.datastax.spark" %% "spark-cassandra-connector-assembly" % "3.0.1",
+//    "com.amazonaws"    % "aws-java-sdk-sts"      % "1.11.728",
+//    "com.amazonaws"    % "aws-java-sdk-dynamodb" % "1.11.728",
+//    ("com.amazonaws" % "dynamodb-streams-kinesis-adapter" % "1.5.2")
+//      .excludeAll(InclExclRule("com.fasterxml.jackson.core")),
     "org.yaml"       % "snakeyaml"      % "1.23",
     "io.circe"       %% "circe-yaml"    % "0.9.0",
     "io.circe"       %% "circe-generic" % "0.9.0",

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ set -x
 #workaround for number exceptions, once new sbt will be used + 2.12 scala below won't be needed
 export TERM=xterm-color 
 
-git submodule update --init --recursive
+#git submodule update --init --recursive
 
 TMPDIR="$PWD"/tmpexec
 mkdir -p "$TMPDIR"

--- a/src/main/scala/com/scylladb/migrator/Migrator.scala
+++ b/src/main/scala/com/scylladb/migrator/Migrator.scala
@@ -4,15 +4,15 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, Paths }
 import java.util.concurrent.{ ScheduledThreadPoolExecutor, TimeUnit }
 
-import com.amazonaws.services.dynamodbv2.streamsadapter.model.RecordAdapter
+//import com.amazonaws.services.dynamodbv2.streamsadapter.model.RecordAdapter
 import com.datastax.spark.connector.rdd.partitioner.dht.Token
 import com.datastax.spark.connector.writer._
 import com.scylladb.migrator.config._
-import com.scylladb.migrator.writers.DynamoStreamReplication
+import com.scylladb.migrator.readers.Cassandra
 import org.apache.log4j.{ Level, LogManager, Logger }
 import org.apache.spark.sql._
 import org.apache.spark.streaming.{ Seconds, StreamingContext }
-import org.apache.spark.streaming.kinesis.{ KinesisInputDStream, SparkAWSCredentials }
+//import org.apache.spark.streaming.kinesis.{ KinesisInputDStream, SparkAWSCredentials }
 import sun.misc.{ Signal, SignalHandler }
 
 import scala.util.control.NonFatal
@@ -49,31 +49,31 @@ object Migrator {
             cassandraSource,
             cassandraSource.preserveTimestamps,
             migratorConfig.skipTokenRanges)
-        case parquetSource: SourceSettings.Parquet =>
-          readers.Parquet.readDataFrame(spark, parquetSource)
-        case dynamoSource: SourceSettings.DynamoDB =>
-          val tableDesc = DynamoUtils
-            .buildDynamoClient(dynamoSource.endpoint, dynamoSource.credentials, dynamoSource.region)
-            .describeTable(dynamoSource.table)
-            .getTable
-
-          readers.DynamoDB.readDataFrame(spark, dynamoSource, tableDesc)
+//        case parquetSource: SourceSettings.Parquet =>
+//          readers.Parquet.readDataFrame(spark, parquetSource)
+//        case dynamoSource: SourceSettings.DynamoDB =>
+//          val tableDesc = DynamoUtils
+//            .buildDynamoClient(dynamoSource.endpoint, dynamoSource.credentials, dynamoSource.region)
+//            .describeTable(dynamoSource.table)
+//            .getTable
+//
+//          readers.DynamoDB.readDataFrame(spark, dynamoSource, tableDesc)
       }
 
     log.info("Created source dataframe; resulting schema:")
     sourceDF.dataFrame.printSchema()
 
-    val tokenRangeAccumulator =
-      if (!sourceDF.savepointsSupported) None
-      else {
-        val tokenRangeAccumulator = TokenRangeAccumulator.empty
-        spark.sparkContext.register(tokenRangeAccumulator, "Token ranges copied")
-
-        addUSR2Handler(migratorConfig, tokenRangeAccumulator)
-        startSavepointSchedule(scheduler, migratorConfig, tokenRangeAccumulator)
-
-        Some(tokenRangeAccumulator)
-      }
+//    val tokenRangeAccumulator =
+//      if (!sourceDF.savepointsSupported) None
+//      else {
+//        val tokenRangeAccumulator = TokenRangeAccumulator.empty
+//        spark.sparkContext.register(tokenRangeAccumulator, "Token ranges copied")
+//
+//        addUSR2Handler(migratorConfig, tokenRangeAccumulator)
+//        startSavepointSchedule(scheduler, migratorConfig, tokenRangeAccumulator)
+//
+//        Some(tokenRangeAccumulator)
+//      }
 
     log.info("Starting write...")
 
@@ -84,59 +84,59 @@ object Migrator {
             target,
             migratorConfig.renames,
             sourceDF.dataFrame,
-            sourceDF.timestampColumns,
-            tokenRangeAccumulator)
-        case target: TargetSettings.DynamoDB =>
-          val sourceAndDescriptions = migratorConfig.source match {
-            case source: SourceSettings.DynamoDB =>
-              if (target.streamChanges) {
-                log.info(
-                  "Source is a Dynamo table and change streaming requested; enabling Dynamo Stream")
-                DynamoUtils.enableDynamoStream(source)
-              }
-              val sourceDesc =
-                DynamoUtils
-                  .buildDynamoClient(source.endpoint, source.credentials, source.region)
-                  .describeTable(source.table)
-                  .getTable
-
-              Some(
-                (
-                  source,
-                  sourceDesc,
-                  DynamoUtils.replicateTableDefinition(
-                    sourceDesc,
-                    target
-                  )
-                ))
-
-            case _ =>
-              None
-          }
-
-          writers.DynamoDB.writeDataframe(
-            target,
-            migratorConfig.renames,
-            sourceDF.dataFrame,
-            sourceAndDescriptions.map(_._3))
-
-          sourceAndDescriptions.foreach {
-            case (source, sourceDesc, targetDesc) =>
-              log.info("Done transferring table snapshot. Starting to transfer changes")
-
-              DynamoStreamReplication.createDStream(
-                spark,
-                streamingContext,
-                source,
-                target,
-                sourceDF.dataFrame.schema,
-                sourceDesc,
-                targetDesc,
-                migratorConfig.renames)
-
-              streamingContext.start()
-              streamingContext.awaitTermination()
-          }
+            sourceDF.timestampColumns)
+//            tokenRangeAccumulator)
+//        case target: TargetSettings.DynamoDB =>
+//          val sourceAndDescriptions = migratorConfig.source match {
+//            case source: SourceSettings.DynamoDB =>
+//              if (target.streamChanges) {
+//                log.info(
+//                  "Source is a Dynamo table and change streaming requested; enabling Dynamo Stream")
+//                DynamoUtils.enableDynamoStream(source)
+//              }
+//              val sourceDesc =
+//                DynamoUtils
+//                  .buildDynamoClient(source.endpoint, source.credentials, source.region)
+//                  .describeTable(source.table)
+//                  .getTable
+//
+//              Some(
+//                (
+//                  source,
+//                  sourceDesc,
+//                  DynamoUtils.replicateTableDefinition(
+//                    sourceDesc,
+//                    target
+//                  )
+//                ))
+//
+//            case _ =>
+//              None
+//          }
+//
+//          writers.DynamoDB.writeDataframe(
+//            target,
+//            migratorConfig.renames,
+//            sourceDF.dataFrame,
+//            sourceAndDescriptions.map(_._3))
+//
+//          sourceAndDescriptions.foreach {
+//            case (source, sourceDesc, targetDesc) =>
+//              log.info("Done transferring table snapshot. Starting to transfer changes")
+//
+//              DynamoStreamReplication.createDStream(
+//                spark,
+//                streamingContext,
+//                source,
+//                target,
+//                sourceDF.dataFrame.schema,
+//                sourceDesc,
+//                targetDesc,
+//                migratorConfig.renames)
+//
+//              streamingContext.start()
+//              streamingContext.awaitTermination()
+//          }
       }
     } catch {
       case NonFatal(e) => // Catching everything on purpose to try and dump the accumulator state
@@ -144,7 +144,7 @@ object Migrator {
           "Caught error while writing the DataFrame. Will create a savepoint before exiting",
           e)
     } finally {
-      tokenRangeAccumulator.foreach(dumpAccumulatorState(migratorConfig, _, "final"))
+//      tokenRangeAccumulator.foreach(dumpAccumulatorState(migratorConfig, _, "final"))
       scheduler.shutdown()
       spark.stop()
     }
@@ -154,52 +154,54 @@ object Migrator {
     s"${path}/savepoint_${System.currentTimeMillis / 1000}.yaml"
 
   def dumpAccumulatorState(config: MigratorConfig,
-                           accumulator: TokenRangeAccumulator,
+//                           accumulator: TokenRangeAccumulator,
                            reason: String): Unit = {
     val filename =
       Paths.get(savepointFilename(config.savepoints.path)).normalize
-    val rangesToSkip = accumulator.value.get.map(range =>
-      (range.range.start.asInstanceOf[Token[_]], range.range.end.asInstanceOf[Token[_]]))
+//    val rangesToSkip = accumulator.value.get.map(range =>
+//      (range.range.start.asInstanceOf[Token[_]], range.range.end.asInstanceOf[Token[_]]))
 
     val modifiedConfig = config.copy(
-      skipTokenRanges = config.skipTokenRanges ++ rangesToSkip
+      skipTokenRanges = config.skipTokenRanges
+//        ++ rangesToSkip
     )
 
     Files.write(filename, modifiedConfig.render.getBytes(StandardCharsets.UTF_8))
 
-    log.info(
-      s"Created a savepoint config at ${filename} due to ${reason}. Ranges added: ${rangesToSkip}")
+//    log.info(
+//      s"Created a savepoint config at ${filename} due to ${reason}. Ranges added: ${rangesToSkip}")
   }
 
-  def startSavepointSchedule(svc: ScheduledThreadPoolExecutor,
-                             config: MigratorConfig,
-                             acc: TokenRangeAccumulator): Unit = {
-    val runnable = new Runnable {
-      override def run(): Unit =
-        try dumpAccumulatorState(config, acc, "schedule")
-        catch {
-          case e: Throwable =>
-            log.error("Could not create the savepoint. This will be retried.", e)
-        }
-    }
+//  def startSavepointSchedule(svc: ScheduledThreadPoolExecutor,
+//                             config: MigratorConfig//,
+////                             acc: TokenRangeAccumulator
+//                            ): Unit = {
+//    val runnable = new Runnable {
+//      override def run(): Unit =
+//        try dumpAccumulatorState(config,"schedule")
+//        catch {
+//          case e: Throwable =>
+//            log.error("Could not create the savepoint. This will be retried.", e)
+//        }
+//    }
+//
+//    log.info(
+//      s"Starting savepoint schedule; will write a savepoint every ${config.savepoints.intervalSeconds} seconds")
+//
+//    svc.scheduleAtFixedRate(runnable, 0, config.savepoints.intervalSeconds, TimeUnit.SECONDS)
+//  }
 
-    log.info(
-      s"Starting savepoint schedule; will write a savepoint every ${config.savepoints.intervalSeconds} seconds")
-
-    svc.scheduleAtFixedRate(runnable, 0, config.savepoints.intervalSeconds, TimeUnit.SECONDS)
-  }
-
-  def addUSR2Handler(config: MigratorConfig, acc: TokenRangeAccumulator) = {
-    log.info(
-      "Installing SIGINT/TERM/USR2 handler. Send this to dump the current progress to a savepoint.")
-
-    val handler = new SignalHandler {
-      override def handle(signal: Signal): Unit =
-        dumpAccumulatorState(config, acc, signal.toString)
-    }
-
-    Signal.handle(new Signal("USR2"), handler)
-    Signal.handle(new Signal("TERM"), handler)
-    Signal.handle(new Signal("INT"), handler)
-  }
+//  def addUSR2Handler(config: MigratorConfig, acc: TokenRangeAccumulator) = {
+//    log.info(
+//      "Installing SIGINT/TERM/USR2 handler. Send this to dump the current progress to a savepoint.")
+//
+//    val handler = new SignalHandler {
+//      override def handle(signal: Signal): Unit =
+//        dumpAccumulatorState(config, acc, signal.toString)
+//    }
+//
+//    Signal.handle(new Signal("USR2"), handler)
+//    Signal.handle(new Signal("TERM"), handler)
+//    Signal.handle(new Signal("INT"), handler)
+//  }
 }

--- a/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
+++ b/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
@@ -54,12 +54,12 @@ object SourceSettings {
             "preserveTimestamps",
             "where")(Cassandra.apply)
           .apply(cursor)
-      case "parquet" =>
-        Decoder
-          .forProduct2("path", "credentials")(Parquet.apply)
-          .apply(cursor)
-      case "dynamo" | "dynamodb" =>
-        deriveDecoder[DynamoDB].apply(cursor)
+//      case "parquet" =>
+//        Decoder
+//          .forProduct2("path", "credentials")(Parquet.apply)
+//          .apply(cursor)
+//      case "dynamo" | "dynamodb" =>
+//        deriveDecoder[DynamoDB].apply(cursor)
       case otherwise =>
         Left(DecodingFailure(s"Unknown source type: ${otherwise}", cursor.history))
     }

--- a/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
+++ b/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
@@ -16,24 +16,24 @@ object TargetSettings {
                     stripTrailingZerosForDecimals: Boolean)
       extends TargetSettings
 
-  case class DynamoDB(endpoint: Option[DynamoDBEndpoint],
-                      region: Option[String],
-                      credentials: Option[AWSCredentials],
-                      table: String,
-                      scanSegments: Option[Int],
-                      writeThroughput: Option[Int],
-                      throughputWritePercent: Option[Float],
-                      maxMapTasks: Option[Int],
-                      streamChanges: Boolean)
-      extends TargetSettings
+//  case class DynamoDB(endpoint: Option[DynamoDBEndpoint],
+//                      region: Option[String],
+//                      credentials: Option[AWSCredentials],
+//                      table: String,
+//                      scanSegments: Option[Int],
+//                      writeThroughput: Option[Int],
+//                      throughputWritePercent: Option[Float],
+//                      maxMapTasks: Option[Int],
+//                      streamChanges: Boolean)
+//      extends TargetSettings
 
   implicit val decoder: Decoder[TargetSettings] =
     Decoder.instance { cursor =>
       cursor.get[String]("type").flatMap {
         case "scylla" | "cassandra" =>
           deriveDecoder[Scylla].apply(cursor)
-        case "dynamodb" | "dynamo" =>
-          deriveDecoder[DynamoDB].apply(cursor)
+//        case "dynamodb" | "dynamo" =>
+//          deriveDecoder[DynamoDB].apply(cursor)
         case otherwise =>
           Left(DecodingFailure(s"Invalid target type: ${otherwise}", cursor.history))
       }
@@ -44,7 +44,7 @@ object TargetSettings {
       case t: Scylla =>
         deriveEncoder[Scylla].encodeObject(t).add("type", Json.fromString("scylla")).asJson
 
-      case t: DynamoDB =>
-        deriveEncoder[DynamoDB].encodeObject(t).add("type", Json.fromString("dynamodb")).asJson
+//      case t: DynamoDB =>
+//        deriveEncoder[DynamoDB].encodeObject(t).add("type", Json.fromString("dynamodb")).asJson
     }
 }

--- a/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -222,10 +222,8 @@ object Cassandra {
     val selection = createSelection(tableDef, origSchema, preserveTimes).fold(throw _, identity)
 
     val selectCassandraRDD = spark.sparkContext
-      .cassandraTable[CassandraSQLRow](
-        source.keyspace,
-        source.table,
-        (s, e) => !tokenRangesToSkip.contains((s, e)))
+      .cassandraTable[CassandraSQLRow](source.keyspace, source.table)
+//        (s, e) => !tokenRangesToSkip.contains((s, e)))
       .withConnector(connector)
       .withReadConf(readConf)
       .select(selection.columnRefs: _*)

--- a/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
+++ b/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
@@ -4,17 +4,17 @@ import com.scylladb.migrator.config.SourceSettings
 import org.apache.log4j.LogManager
 import org.apache.spark.sql.{ DataFrame, SparkSession }
 
-object Parquet {
-  val log = LogManager.getLogger("com.scylladb.migrator.readers.Parquet")
-
-  def readDataFrame(spark: SparkSession, source: SourceSettings.Parquet): SourceDataFrame = {
-    source.credentials.foreach { credentials =>
-      log.info("Loaded AWS credentials from config file")
-      spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", credentials.accessKey)
-      spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", credentials.secretKey)
-    }
-
-    SourceDataFrame(spark.read.parquet(source.path), None, false)
-  }
-
-}
+//object Parquet {
+//  val log = LogManager.getLogger("com.scylladb.migrator.readers.Parquet")
+//
+//  def readDataFrame(spark: SparkSession, source: SourceSettings.Parquet): SourceDataFrame = {
+//    source.credentials.foreach { credentials =>
+//      log.info("Loaded AWS credentials from config file")
+//      spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", credentials.accessKey)
+//      spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", credentials.secretKey)
+//    }
+//
+//    SourceDataFrame(spark.read.parquet(source.path), None, false)
+//  }
+//
+//}

--- a/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -60,8 +60,8 @@ object Scylla {
         target.keyspace,
         target.table,
         columnSelector,
-        writeConf,
-        tokenRangeAccumulator = tokenRangeAccumulator
+        writeConf
+//        tokenRangeAccumulator = tokenRangeAccumulator
       )(connector, SqlRowWriter.Factory)
   }
 


### PR DESCRIPTION
This PR makes scylla-migrator compatible with `spark-cassandra-connector-assembly 3.0.1`. Since there is no `TokenRangeAccumulator` in the 3.0.1 spark connector, any related stuff is commented out. 

And it also fixes SSL support issue. The default SSL protocol in scylla is TLS. However, some Cassandra clusters are using TLSv1.2. So SSL protocol should be set when using scylla. 
