### PR TITLE
Explain what to do when unsupported TTL/writetime for collections is

### DIFF
--- a/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -28,7 +28,7 @@ object Cassandra {
                         preserveTimesRequest: Boolean): Either[Throwable, CopyType] =
     if (tableDef.columnTypes.exists(_.isCollection) && preserveTimesRequest)
       Left(
-        new Exception("TTL/Writetime preservation is unsupported for tables with collection types"))
+        new Exception("TTL/Writetime preservation is unsupported for tables with collection types. Please check in your config the option 'preserveTimestamps' and set it to false to continue."))
     else if (preserveTimesRequest && tableDef.regularColumns.nonEmpty)
       Right(CopyType.WithTimestampPreservation)
     else if (preserveTimesRequest && tableDef.regularColumns.isEmpty) {


### PR DESCRIPTION
enabled for table.