### PR TITLE
Start transfer of stream only when target.streamChanges is enabled

### DIFF
--- a/src/main/scala/com/scylladb/migrator/Migrator.scala
+++ b/src/main/scala/com/scylladb/migrator/Migrator.scala
@@ -155,20 +155,22 @@ object Migrator {
 
           sourceAndDescriptions.foreach {
             case (source, sourceDesc, targetDesc) =>
-              log.info("Done transferring table snapshot. Starting to transfer changes")
+              if (target.streamChanges) {
+                log.info("Done transferring table snapshot. Starting to transfer changes")
 
-              DynamoStreamReplication.createDStream(
-                spark,
-                streamingContext,
-                source,
-                target,
-                sourceDF.dataFrame.schema,
-                sourceDesc,
-                targetDesc,
-                migratorConfig.renames)
+                DynamoStreamReplication.createDStream(
+                  spark,
+                  streamingContext,
+                  source,
+                  target,
+                  sourceDF.dataFrame.schema,
+                  sourceDesc,
+                  targetDesc,
+                  migratorConfig.renames)
 
-              streamingContext.start()
-              streamingContext.awaitTermination()
+                streamingContext.start()
+                streamingContext.awaitTermination()
+              }
           }
       }
     } catch {


### PR DESCRIPTION
Currently, code that transfer "changed" data from DynamoDB into Alternator is always called. Insert a conditional to only call this transfer when streamChanges on target is enabled.

Solves #69 