### PR TITLE
Do not try to infer a schema when migrating from DynamoDB to Alternator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,9 +2,6 @@
 	path = spark-cassandra-connector
 	url = https://github.com/scylladb/spark-cassandra-connector
 	branch = feature/track-token-ranges
-[submodule "spark-dynamodb"]
-	path = spark-dynamodb
-	url = https://github.com/scylladb/spark-dynamodb
 [submodule "spark-kinesis"]
 	path = spark-kinesis
 	url = https://github.com/scylladb/spark-kinesis

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val migrator = (project in file("migrator")).settings(
     "com.amazonaws"    % "aws-java-sdk-dynamodb" % awsSdkVersion,
     ("com.amazonaws" % "dynamodb-streams-kinesis-adapter" % "1.5.2")
       .excludeAll(InclExclRule("com.fasterxml.jackson.core")),
-    "com.amazon.emr" % "emr-dynamodb-hadoop" % "4.8.0",
+    "com.amazon.emr" % "emr-dynamodb-hadoop" % "4.16.0",
     "org.yaml"       % "snakeyaml"      % "1.23",
     "io.circe"       %% "circe-yaml"    % "0.9.0",
     "io.circe"       %% "circe-generic" % "0.9.0",

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ lazy val migrator = (project in file("migrator")).settings(
     "com.amazonaws"    % "aws-java-sdk-dynamodb" % awsSdkVersion,
     ("com.amazonaws" % "dynamodb-streams-kinesis-adapter" % "1.5.2")
       .excludeAll(InclExclRule("com.fasterxml.jackson.core")),
+    "com.amazon.emr" % "emr-dynamodb-hadoop" % "4.8.0",
     "org.yaml"       % "snakeyaml"      % "1.23",
     "io.circe"       %% "circe-yaml"    % "0.9.0",
     "io.circe"       %% "circe-generic" % "0.9.0",

--- a/build.sh
+++ b/build.sh
@@ -14,9 +14,6 @@ trap "rm -rf $TMPDIR" EXIT
 pushd spark-cassandra-connector
 sbt -Djava.io.tmpdir="$TMPDIR" ++2.11.12 assembly
 popd
-pushd spark-dynamodb
-sbt assembly
-popd
 pushd spark-kinesis
 sbt assembly
 popd
@@ -26,7 +23,6 @@ if [ ! -d "./migrator/lib" ]; then
 fi
 
 cp ./spark-cassandra-connector/connector/target/scala-2.11/spark-cassandra-connector-assembly-*.jar ./migrator/lib
-cp ./spark-dynamodb/target/scala-2.11/spark-dynamodb-assembly-*.jar ./migrator/lib
 cp ./spark-kinesis/target/scala-2.11/spark-streaming-kinesis-asl-assembly-*.jar ./migrator/lib
 
 sbt -Djava.io.tmpdir="$TMPDIR" migrator/assembly

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -54,6 +54,8 @@ services:
     volumes:
       - ./migrator/target/scala-2.11:/jars
       - ./tests/src/test/configurations:/app/configurations
+      # Workaround for https://github.com/awslabs/emr-dynamodb-connector/issues/50
+      - ${PWD}/tests/docker/job-flow.json:/mnt/var/lib/info/job-flow.json
 
   spark-worker:
     image: bde2020/spark-worker:2.4.4-hadoop2.7

--- a/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
@@ -64,7 +64,8 @@ object DynamoUtils {
 
   def enableDynamoStream(source: SourceSettings.DynamoDB): Unit = {
     val sourceClient = buildDynamoClient(source.endpoint, source.credentials, source.region)
-    val sourceStreamsClient = buildDynamoStreamsClient(source.credentials, source.region)
+    val sourceStreamsClient =
+      buildDynamoStreamsClient(source.endpoint, source.credentials, source.region)
 
     sourceClient
       .updateTable(
@@ -114,9 +115,18 @@ object DynamoUtils {
     builder.build()
   }
 
-  def buildDynamoStreamsClient(creds: Option[AWSCredentialsProvider], region: Option[String]) = {
+  def buildDynamoStreamsClient(endpoint: Option[DynamoDBEndpoint],
+                               creds: Option[AWSCredentialsProvider],
+                               region: Option[String]) = {
     val builder = AmazonDynamoDBStreamsClientBuilder.standard()
 
+    endpoint.foreach { endpoint =>
+      builder
+        .withEndpointConfiguration(
+          new AwsClientBuilder.EndpointConfiguration(
+            endpoint.renderEndpoint,
+            region.getOrElse("empty")))
+    }
     creds.foreach(builder.withCredentials)
     region.foreach(builder.withRegion)
 

--- a/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
@@ -4,7 +4,6 @@ import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.dynamodbv2.{
   AmazonDynamoDBClientBuilder,
-  AmazonDynamoDBStreamsClient,
   AmazonDynamoDBStreamsClientBuilder
 }
 import com.amazonaws.services.dynamodbv2.model.{
@@ -17,7 +16,14 @@ import com.amazonaws.services.dynamodbv2.model.{
   TableDescription,
   UpdateTableRequest
 }
-import com.scylladb.migrator.config.{ DynamoDBEndpoint, SourceSettings, TargetSettings }
+import com.scylladb.migrator.config.{
+  AWSCredentials,
+  DynamoDBEndpoint,
+  SourceSettings,
+  TargetSettings
+}
+import org.apache.hadoop.dynamodb.DynamoDBConstants
+import org.apache.hadoop.mapred.JobConf
 import org.apache.log4j.LogManager
 
 import scala.util.{ Failure, Success, Try }
@@ -132,4 +138,47 @@ object DynamoUtils {
 
     builder.build()
   }
+
+  /**
+    * Optionally set a configuration. If `maybeValue` is empty, nothing is done. Otherwise,
+    * its value is set to the `name` property on the `jobConf`.
+    *
+    * @param jobConf    Target JobConf to configure
+    * @param name       Name of the Hadoop configuration key
+    * @param maybeValue Optional value to set.
+    */
+  def setOptionalConf(jobConf: JobConf, name: String, maybeValue: Option[String]): Unit =
+    for (value <- maybeValue) {
+      jobConf.set(name, value)
+    }
+
+  /**
+    * Set the common configuration of both read and write DynamoDB jobs.
+    * @param jobConf             Target JobConf to configure
+    * @param maybeRegion         AWS region
+    * @param maybeEndpoint       AWS endpoint
+    * @param maybeScanSegments   Scan segments
+    * @param maybeMaxMapTasks    Max map tasks
+    * @param maybeAwsCredentials AWS credentials
+    */
+  def setDynamoDBJobConf(jobConf: JobConf,
+                         maybeRegion: Option[String],
+                         maybeEndpoint: Option[DynamoDBEndpoint],
+                         maybeScanSegments: Option[Int],
+                         maybeMaxMapTasks: Option[Int],
+                         maybeAwsCredentials: Option[AWSCredentials]): Unit = {
+    setOptionalConf(jobConf, DynamoDBConstants.REGION, maybeRegion)
+    setOptionalConf(jobConf, DynamoDBConstants.ENDPOINT, maybeEndpoint.map(_.renderEndpoint))
+    setOptionalConf(jobConf, DynamoDBConstants.SCAN_SEGMENTS, maybeScanSegments.map(_.toString))
+    setOptionalConf(jobConf, DynamoDBConstants.MAX_MAP_TASKS, maybeMaxMapTasks.map(_.toString))
+    for (credentials <- maybeAwsCredentials) {
+      jobConf.set(DynamoDBConstants.DYNAMODB_ACCESS_KEY_CONF, credentials.accessKey)
+      jobConf.set(DynamoDBConstants.DYNAMODB_SECRET_KEY_CONF, credentials.secretKey)
+    }
+    jobConf.set(
+      "mapred.output.format.class",
+      "org.apache.hadoop.dynamodb.write.DynamoDBOutputFormat")
+    jobConf.set("mapred.input.format.class", "org.apache.hadoop.dynamodb.read.DynamoDBInputFormat")
+  }
+
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
@@ -1,21 +1,10 @@
 package com.scylladb.migrator
 
-import java.nio.charset.StandardCharsets
-import java.nio.file.{ Files, Paths }
-import java.util.concurrent.{ ScheduledThreadPoolExecutor, TimeUnit }
-import com.amazonaws.services.dynamodbv2.streamsadapter.model.RecordAdapter
-import com.datastax.spark.connector.rdd.partitioner.{ CassandraPartition, CqlTokenRange }
-import com.datastax.spark.connector.rdd.partitioner.dht.Token
-import com.datastax.spark.connector.writer._
+import com.scylladb.migrator.alternator.AlternatorMigrator
 import com.scylladb.migrator.config._
-import com.scylladb.migrator.writers.DynamoStreamReplication
+import com.scylladb.migrator.scylla.ScyllaMigrator
 import org.apache.log4j.{ Level, LogManager, Logger }
 import org.apache.spark.sql._
-import org.apache.spark.streaming.{ Seconds, StreamingContext }
-import org.apache.spark.streaming.kinesis.{ KinesisInputDStream, SparkAWSCredentials }
-import sun.misc.{ Signal, SignalHandler }
-
-import scala.util.control.NonFatal
 
 object Migrator {
   val log = LogManager.getLogger("com.scylladb.migrator")
@@ -27,7 +16,6 @@ object Migrator {
       .config("spark.task.maxFailures", "1024")
       .config("spark.stage.maxConsecutiveAttempts", "60")
       .getOrCreate
-    val streamingContext = new StreamingContext(spark.sparkContext, Seconds(5))
 
     Logger.getRootLogger.setLevel(Level.WARN)
     log.setLevel(Level.INFO)
@@ -39,202 +27,26 @@ object Migrator {
 
     log.info(s"Loaded config: ${migratorConfig}")
 
-    val scheduler = new ScheduledThreadPoolExecutor(1)
-
-    val sourceDF =
-      migratorConfig.source match {
-        case cassandraSource: SourceSettings.Cassandra =>
-          readers.Cassandra.readDataframe(
+    try {
+      (migratorConfig.source, migratorConfig.target) match {
+        case (cassandraSource: SourceSettings.Cassandra, scyllaTarget: TargetSettings.Scylla) =>
+          val sourceDF = readers.Cassandra.readDataframe(
             spark,
             cassandraSource,
             cassandraSource.preserveTimestamps,
             migratorConfig.skipTokenRanges)
-        case parquetSource: SourceSettings.Parquet =>
-          readers.Parquet.readDataFrame(spark, parquetSource)
-        case dynamoSource: SourceSettings.DynamoDB =>
-          val tableDesc = DynamoUtils
-            .buildDynamoClient(dynamoSource.endpoint, dynamoSource.credentials, dynamoSource.region)
-            .describeTable(dynamoSource.table)
-            .getTable
-
-          readers.DynamoDB.readDataFrame(spark, dynamoSource, tableDesc)
+          ScyllaMigrator.migrate(migratorConfig, scyllaTarget, sourceDF)
+        case (parquetSource: SourceSettings.Parquet, scyllaTarget: TargetSettings.Scylla) =>
+          val sourceDF = readers.Parquet.readDataFrame(spark, parquetSource)
+          ScyllaMigrator.migrate(migratorConfig, scyllaTarget, sourceDF)
+        case (dynamoSource: SourceSettings.DynamoDB, alternatorTarget: TargetSettings.DynamoDB) =>
+          AlternatorMigrator.migrate(dynamoSource, alternatorTarget, migratorConfig.renames)
+        case _ =>
+          sys.error("Unsupported combination of source and target.")
       }
-
-    log.info("Created source dataframe; resulting schema:")
-    sourceDF.dataFrame.printSchema()
-
-    val tokenRangeAccumulator =
-      if (!sourceDF.savepointsSupported) None
-      else {
-        val tokenRangeAccumulator = TokenRangeAccumulator.empty
-        spark.sparkContext.register(tokenRangeAccumulator, "Token ranges copied")
-
-        addUSR2Handler(migratorConfig, tokenRangeAccumulator)
-        startSavepointSchedule(scheduler, migratorConfig, tokenRangeAccumulator)
-
-        Some(tokenRangeAccumulator)
-      }
-
-    log.info(
-      "We need to transfer: " + sourceDF.dataFrame.rdd.getNumPartitions + " partitions in total")
-
-    if (migratorConfig.source.isInstanceOf[SourceSettings.Cassandra]) {
-      val partitions = sourceDF.dataFrame.rdd.partitions
-      val cassandraPartitions = partitions.map(p => {
-        p.asInstanceOf[CassandraPartition[_, _]]
-      })
-      var allTokenRanges = Set[(Token[_], Token[_])]()
-      cassandraPartitions.foreach(p => {
-        p.tokenRanges
-          .asInstanceOf[Vector[CqlTokenRange[_, _]]]
-          .foreach(tr => {
-            val range =
-              Set((tr.range.start.asInstanceOf[Token[_]], tr.range.end.asInstanceOf[Token[_]]))
-            allTokenRanges = allTokenRanges ++ range
-          })
-
-      })
-
-      log.info("All token ranges extracted from partitions size:" + allTokenRanges.size)
-
-      if (migratorConfig.skipTokenRanges != None) {
-        log.info(
-          "Savepoints array defined, size of the array: " + migratorConfig.skipTokenRanges.size)
-
-        val diff = allTokenRanges.diff(migratorConfig.skipTokenRanges)
-        log.info("Diff ... total diff of full ranges to savepoints is: " + diff.size)
-        log.debug("Dump of the missing tokens: ")
-        log.debug(diff)
-      }
-    }
-
-    log.info("Starting write...")
-
-    try {
-      migratorConfig.target match {
-        case target: TargetSettings.Scylla =>
-          writers.Scylla.writeDataframe(
-            target,
-            migratorConfig.renames,
-            sourceDF.dataFrame,
-            sourceDF.timestampColumns,
-            tokenRangeAccumulator)
-        case target: TargetSettings.DynamoDB =>
-          val sourceAndDescriptions = migratorConfig.source match {
-            case source: SourceSettings.DynamoDB =>
-              if (target.streamChanges) {
-                log.info(
-                  "Source is a Dynamo table and change streaming requested; enabling Dynamo Stream")
-                DynamoUtils.enableDynamoStream(source)
-              }
-              val sourceDesc =
-                DynamoUtils
-                  .buildDynamoClient(source.endpoint, source.credentials, source.region)
-                  .describeTable(source.table)
-                  .getTable
-
-              Some(
-                (
-                  source,
-                  sourceDesc,
-                  DynamoUtils.replicateTableDefinition(
-                    sourceDesc,
-                    target
-                  )
-                ))
-
-            case _ =>
-              None
-          }
-
-          writers.DynamoDB.writeDataframe(
-            target,
-            migratorConfig.renames,
-            sourceDF.dataFrame,
-            sourceAndDescriptions.map(_._3))
-
-          sourceAndDescriptions.foreach {
-            case (source, sourceDesc, targetDesc) =>
-              if (target.streamChanges) {
-                log.info("Done transferring table snapshot. Starting to transfer changes")
-
-                DynamoStreamReplication.createDStream(
-                  spark,
-                  streamingContext,
-                  source,
-                  target,
-                  sourceDF.dataFrame.schema,
-                  sourceDesc,
-                  targetDesc,
-                  migratorConfig.renames)
-
-                streamingContext.start()
-                streamingContext.awaitTermination()
-              }
-          }
-      }
-    } catch {
-      case NonFatal(e) => // Catching everything on purpose to try and dump the accumulator state
-        log.error(
-          "Caught error while writing the DataFrame. Will create a savepoint before exiting",
-          e)
     } finally {
-      tokenRangeAccumulator.foreach(dumpAccumulatorState(migratorConfig, _, "final"))
-      scheduler.shutdown()
       spark.stop()
     }
   }
 
-  def savepointFilename(path: String): String =
-    s"${path}/savepoint_${System.currentTimeMillis / 1000}.yaml"
-
-  def dumpAccumulatorState(config: MigratorConfig,
-                           accumulator: TokenRangeAccumulator,
-                           reason: String): Unit = {
-    val filename =
-      Paths.get(savepointFilename(config.savepoints.path)).normalize
-    val rangesToSkip = accumulator.value.get.map(range =>
-      (range.range.start.asInstanceOf[Token[_]], range.range.end.asInstanceOf[Token[_]]))
-
-    val modifiedConfig = config.copy(
-      skipTokenRanges = config.skipTokenRanges ++ rangesToSkip
-    )
-
-    Files.write(filename, modifiedConfig.render.getBytes(StandardCharsets.UTF_8))
-
-    log.info(
-      s"Created a savepoint config at ${filename} due to ${reason}. Ranges added: ${rangesToSkip}")
-  }
-
-  def startSavepointSchedule(svc: ScheduledThreadPoolExecutor,
-                             config: MigratorConfig,
-                             acc: TokenRangeAccumulator): Unit = {
-    val runnable = new Runnable {
-      override def run(): Unit =
-        try dumpAccumulatorState(config, acc, "schedule")
-        catch {
-          case e: Throwable =>
-            log.error("Could not create the savepoint. This will be retried.", e)
-        }
-    }
-
-    log.info(
-      s"Starting savepoint schedule; will write a savepoint every ${config.savepoints.intervalSeconds} seconds")
-
-    svc.scheduleAtFixedRate(runnable, 0, config.savepoints.intervalSeconds, TimeUnit.SECONDS)
-  }
-
-  def addUSR2Handler(config: MigratorConfig, acc: TokenRangeAccumulator) = {
-    log.info(
-      "Installing SIGINT/TERM/USR2 handler. Send this to dump the current progress to a savepoint.")
-
-    val handler = new SignalHandler {
-      override def handle(signal: Signal): Unit =
-        dumpAccumulatorState(config, acc, signal.toString)
-    }
-
-    Signal.handle(new Signal("USR2"), handler)
-    Signal.handle(new Signal("TERM"), handler)
-    Signal.handle(new Signal("INT"), handler)
-  }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
@@ -1,0 +1,70 @@
+package com.scylladb.migrator.alternator
+
+import com.scylladb.migrator.DynamoUtils
+import com.scylladb.migrator.config.{ Rename, SourceSettings, TargetSettings }
+import com.scylladb.migrator.{ readers, writers }
+import com.scylladb.migrator.writers.DynamoStreamReplication
+import org.apache.log4j.LogManager
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.streaming.{ Seconds, StreamingContext }
+
+import scala.util.control.NonFatal
+
+object AlternatorMigrator {
+  val log = LogManager.getLogger("com.scylladb.migrator.alternator")
+
+  def migrate(source: SourceSettings.DynamoDB,
+              target: TargetSettings.DynamoDB,
+              renames: List[Rename])(implicit spark: SparkSession): Unit = {
+
+    val sourceTableDesc = DynamoUtils
+      .buildDynamoClient(source.endpoint, source.credentials, source.region)
+      .describeTable(source.table)
+      .getTable
+
+    val sourceRDD =
+      readers.DynamoDB.readRDD(spark, source, sourceTableDesc)
+
+    log.info("We need to transfer: " + sourceRDD.getNumPartitions + " partitions in total")
+
+    log.info("Starting write...")
+
+    try {
+      val targetTableDesc = {
+        if (target.streamChanges) {
+          log.info(
+            "Source is a Dynamo table and change streaming requested; enabling Dynamo Stream")
+          DynamoUtils.enableDynamoStream(source)
+        }
+
+        DynamoUtils.replicateTableDefinition(
+          sourceTableDesc,
+          target
+        )
+      }
+
+      writers.DynamoDB.writeRDD(target, renames, sourceRDD, Some(targetTableDesc))
+
+      if (target.streamChanges) {
+        log.info("Done transferring table snapshot. Starting to transfer changes")
+        val streamingContext = new StreamingContext(spark.sparkContext, Seconds(5))
+
+        DynamoStreamReplication.createDStream(
+          spark,
+          streamingContext,
+          source,
+          target,
+          targetTableDesc,
+          renames)
+
+        streamingContext.start()
+        streamingContext.awaitTermination()
+      }
+    } catch {
+      case NonFatal(e) =>
+        log.error("Caught error while writing the RDD.", e)
+    }
+
+  }
+
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -15,6 +15,7 @@ import org.apache.spark.sql.types.{ IntegerType, LongType, StructField, StructTy
 import org.apache.spark.sql.{ DataFrame, Row, SparkSession }
 import org.apache.spark.unsafe.types.UTF8String
 import com.datastax.oss.driver.api.core.ConsistencyLevel
+import com.scylladb.migrator.scylla.SourceDataFrame
 
 import scala.collection.mutable.ArrayBuffer
 

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
@@ -1,19 +1,21 @@
 package com.scylladb.migrator.readers
 
-import cats.implicits._
-import com.amazonaws.services.dynamodbv2.document.Table
 import com.amazonaws.services.dynamodbv2.model.TableDescription
-import com.audienceproject.spark.dynamodb.implicits._
-import com.scylladb.migrator.config.{ AWSCredentials, SourceSettings }
+import com.scylladb.migrator.config.SourceSettings
+import org.apache.hadoop.dynamodb.{ DynamoDBConstants, DynamoDBItemWritable }
+import org.apache.hadoop.dynamodb.read.DynamoDBInputFormat
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.mapred.JobConf
 import org.apache.log4j.LogManager
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 
 object DynamoDB {
   val log = LogManager.getLogger("com.scylladb.migrator.readers.DynamoDB")
 
-  def readDataFrame(spark: SparkSession,
-                    source: SourceSettings.DynamoDB,
-                    description: TableDescription): SourceDataFrame = {
+  def readRDD(spark: SparkSession,
+              source: SourceSettings.DynamoDB,
+              description: TableDescription): RDD[(Text, DynamoDBItemWritable)] = {
     val provisionedThroughput = Option(description.getProvisionedThroughput)
     val readThroughput = provisionedThroughput.flatMap(p => Option(p.getReadCapacityUnits))
     val writeThroughput = provisionedThroughput.flatMap(p => Option(p.getWriteCapacityUnits))
@@ -22,23 +24,32 @@ object DynamoDB {
       if (readThroughput.isEmpty || writeThroughput.isEmpty) Some("25")
       else None
 
-    val df = spark.read
-      .options(
-        (List(
-          source.region.map("region" -> _),
-          source.endpoint.map(ep => "endpoint"                     -> ep.renderEndpoint),
-          source.scanSegments.map(segs => "readPartitions"         -> segs.toString),
-          source.throughputReadPercent.map(pct => "targetCapacity" -> pct.toString),
-          source.maxMapTasks.map(tasks => "defaultParallelism"     -> tasks.toString),
-          throughput.map("throughput" -> _)
-        ).flatten ++ source.credentials.toList.flatMap {
-          case AWSCredentials(accessKey, secretKey) =>
-            List("accesskey" -> accessKey, "secretkey" -> secretKey)
-        }).toMap
-      )
-      .dynamodb(source.table)
+    val jobConf = new JobConf(spark.sparkContext.hadoopConfiguration)
+    def setOptionalConf(name: String, maybeValue: Option[String]): Unit =
+      for (value <- maybeValue) {
+        jobConf.set(name, value)
+      }
+    jobConf.set(DynamoDBConstants.INPUT_TABLE_NAME, source.table)
+    setOptionalConf(DynamoDBConstants.REGION, source.region)
+    setOptionalConf(DynamoDBConstants.ENDPOINT, source.endpoint.map(_.renderEndpoint))
+    setOptionalConf(DynamoDBConstants.READ_THROUGHPUT, throughput)
+    setOptionalConf(
+      DynamoDBConstants.THROUGHPUT_READ_PERCENT,
+      source.throughputReadPercent.map(_.toString))
+    setOptionalConf(DynamoDBConstants.SCAN_SEGMENTS, source.scanSegments.map(_.toString))
+    setOptionalConf(DynamoDBConstants.MAX_MAP_TASKS, source.maxMapTasks.map(_.toString))
+    setOptionalConf(DynamoDBConstants.DYNAMODB_ACCESS_KEY_CONF, source.credentials.map(_.accessKey))
+    setOptionalConf(DynamoDBConstants.DYNAMODB_SECRET_KEY_CONF, source.credentials.map(_.secretKey))
+    jobConf.set(
+      "mapred.output.format.class",
+      "org.apache.hadoop.dynamodb.write.DynamoDBOutputFormat")
+    jobConf.set("mapred.input.format.class", "org.apache.hadoop.dynamodb.read.DynamoDBInputFormat")
 
-    SourceDataFrame(df, None, false)
+    spark.sparkContext.hadoopRDD(
+      jobConf,
+      classOf[DynamoDBInputFormat],
+      classOf[Text],
+      classOf[DynamoDBItemWritable])
   }
 
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
@@ -1,8 +1,9 @@
 package com.scylladb.migrator.readers
 
 import com.scylladb.migrator.config.SourceSettings
+import com.scylladb.migrator.scylla.SourceDataFrame
 import org.apache.log4j.LogManager
-import org.apache.spark.sql.{ DataFrame, SparkSession }
+import org.apache.spark.sql.SparkSession
 
 object Parquet {
   val log = LogManager.getLogger("com.scylladb.migrator.readers.Parquet")

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/SourceDataFrame.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/SourceDataFrame.scala
@@ -1,8 +1,0 @@
-package com.scylladb.migrator.readers
-
-import org.apache.spark.sql.DataFrame
-
-case class TimestampColumns(ttl: String, writeTime: String)
-case class SourceDataFrame(dataFrame: DataFrame,
-                           timestampColumns: Option[TimestampColumns],
-                           savepointsSupported: Boolean)

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/TimestampColumns.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/TimestampColumns.scala
@@ -1,0 +1,3 @@
+package com.scylladb.migrator.readers
+
+case class TimestampColumns(ttl: String, writeTime: String)

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
@@ -1,0 +1,152 @@
+package com.scylladb.migrator.scylla
+
+import com.datastax.spark.connector.rdd.partitioner.{ CassandraPartition, CqlTokenRange }
+import com.datastax.spark.connector.rdd.partitioner.dht.Token
+import com.datastax.spark.connector.writer.TokenRangeAccumulator
+import com.scylladb.migrator.config.{ MigratorConfig, SourceSettings, TargetSettings }
+import com.scylladb.migrator.readers.TimestampColumns
+import com.scylladb.migrator.writers
+import org.apache.log4j.LogManager
+import org.apache.spark.sql.{ DataFrame, SparkSession }
+import sun.misc.{ Signal, SignalHandler }
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Paths }
+import java.util.concurrent.{ ScheduledThreadPoolExecutor, TimeUnit }
+import scala.util.control.NonFatal
+
+case class SourceDataFrame(dataFrame: DataFrame,
+                           timestampColumns: Option[TimestampColumns],
+                           savepointsSupported: Boolean)
+
+object ScyllaMigrator {
+  val log = LogManager.getLogger("com.scylladb.migrator.scylla")
+
+  def migrate(migratorConfig: MigratorConfig,
+              target: TargetSettings.Scylla,
+              sourceDF: SourceDataFrame)(implicit spark: SparkSession): Unit = {
+
+    val scheduler = new ScheduledThreadPoolExecutor(1)
+
+    log.info("Created source dataframe; resulting schema:")
+    sourceDF.dataFrame.printSchema()
+
+    val tokenRangeAccumulator =
+      if (!sourceDF.savepointsSupported) None
+      else {
+        val tokenRangeAccumulator = TokenRangeAccumulator.empty
+        spark.sparkContext.register(tokenRangeAccumulator, "Token ranges copied")
+
+        addUSR2Handler(migratorConfig, tokenRangeAccumulator)
+        startSavepointSchedule(scheduler, migratorConfig, tokenRangeAccumulator)
+
+        Some(tokenRangeAccumulator)
+      }
+
+    log.info(
+      "We need to transfer: " + sourceDF.dataFrame.rdd.getNumPartitions + " partitions in total")
+
+    if (migratorConfig.source.isInstanceOf[SourceSettings.Cassandra]) {
+      val partitions = sourceDF.dataFrame.rdd.partitions
+      val cassandraPartitions = partitions.map(p => {
+        p.asInstanceOf[CassandraPartition[_, _]]
+      })
+      var allTokenRanges = Set[(Token[_], Token[_])]()
+      cassandraPartitions.foreach(p => {
+        p.tokenRanges
+          .asInstanceOf[Vector[CqlTokenRange[_, _]]]
+          .foreach(tr => {
+            val range =
+              Set((tr.range.start.asInstanceOf[Token[_]], tr.range.end.asInstanceOf[Token[_]]))
+            allTokenRanges = allTokenRanges ++ range
+          })
+
+      })
+
+      log.info("All token ranges extracted from partitions size:" + allTokenRanges.size)
+
+      if (migratorConfig.skipTokenRanges != None) {
+        log.info(
+          "Savepoints array defined, size of the array: " + migratorConfig.skipTokenRanges.size)
+
+        val diff = allTokenRanges.diff(migratorConfig.skipTokenRanges)
+        log.info("Diff ... total diff of full ranges to savepoints is: " + diff.size)
+        log.debug("Dump of the missing tokens: ")
+        log.debug(diff)
+      }
+    }
+
+    log.info("Starting write...")
+
+    try {
+      writers.Scylla.writeDataframe(
+        target,
+        migratorConfig.renames,
+        sourceDF.dataFrame,
+        sourceDF.timestampColumns,
+        tokenRangeAccumulator)
+    } catch {
+      case NonFatal(e) => // Catching everything on purpose to try and dump the accumulator state
+        log.error(
+          "Caught error while writing the DataFrame. Will create a savepoint before exiting",
+          e)
+    } finally {
+      tokenRangeAccumulator.foreach(dumpAccumulatorState(migratorConfig, _, "final"))
+      scheduler.shutdown()
+    }
+  }
+
+  def startSavepointSchedule(svc: ScheduledThreadPoolExecutor,
+                             config: MigratorConfig,
+                             acc: TokenRangeAccumulator): Unit = {
+    val runnable = new Runnable {
+      override def run(): Unit =
+        try dumpAccumulatorState(config, acc, "schedule")
+        catch {
+          case e: Throwable =>
+            log.error("Could not create the savepoint. This will be retried.", e)
+        }
+    }
+
+    log.info(
+      s"Starting savepoint schedule; will write a savepoint every ${config.savepoints.intervalSeconds} seconds")
+
+    svc.scheduleAtFixedRate(runnable, 0, config.savepoints.intervalSeconds, TimeUnit.SECONDS)
+  }
+
+  def addUSR2Handler(config: MigratorConfig, acc: TokenRangeAccumulator) = {
+    log.info(
+      "Installing SIGINT/TERM/USR2 handler. Send this to dump the current progress to a savepoint.")
+
+    val handler = new SignalHandler {
+      override def handle(signal: Signal): Unit =
+        dumpAccumulatorState(config, acc, signal.toString)
+    }
+
+    Signal.handle(new Signal("USR2"), handler)
+    Signal.handle(new Signal("TERM"), handler)
+    Signal.handle(new Signal("INT"), handler)
+  }
+
+  def savepointFilename(path: String): String =
+    s"${path}/savepoint_${System.currentTimeMillis / 1000}.yaml"
+
+  def dumpAccumulatorState(config: MigratorConfig,
+                           accumulator: TokenRangeAccumulator,
+                           reason: String): Unit = {
+    val filename =
+      Paths.get(savepointFilename(config.savepoints.path)).normalize
+    val rangesToSkip = accumulator.value.get.map(range =>
+      (range.range.start.asInstanceOf[Token[_]], range.range.end.asInstanceOf[Token[_]]))
+
+    val modifiedConfig = config.copy(
+      skipTokenRanges = config.skipTokenRanges ++ rangesToSkip
+    )
+
+    Files.write(filename, modifiedConfig.render.getBytes(StandardCharsets.UTF_8))
+
+    log.info(
+      s"Created a savepoint config at ${filename} due to ${reason}. Ranges added: ${rangesToSkip}")
+  }
+
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
@@ -1,20 +1,21 @@
 package com.scylladb.migrator.writers
 
-import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model.TableDescription
-import com.audienceproject.spark.dynamodb.implicits._
-import com.scylladb.migrator.config.{ AWSCredentials, Rename, TargetSettings }
+import com.scylladb.migrator.config.{ Rename, TargetSettings }
+import org.apache.hadoop.dynamodb.{ DynamoDBConstants, DynamoDBItemWritable }
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.mapred.JobConf
 import org.apache.log4j.LogManager
-import org.apache.spark.sql.{ DataFrame, SparkSession }
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
 
 object DynamoDB {
   val log = LogManager.getLogger("com.scylladb.migrator.writers.DynamoDB")
 
-  def writeDataframe(
-    target: TargetSettings.DynamoDB,
-    renames: List[Rename],
-    df: DataFrame,
-    targetTableDesc: Option[TableDescription])(implicit spark: SparkSession): Unit = {
+  def writeRDD(target: TargetSettings.DynamoDB,
+               renames: List[Rename],
+               rdd: RDD[(Text, DynamoDBItemWritable)],
+               targetTableDesc: Option[TableDescription])(implicit spark: SparkSession): Unit = {
     val provisionedThroughput = targetTableDesc.flatMap(p => Option(p.getProvisionedThroughput))
     val readThroughput = provisionedThroughput.flatMap(p => Option(p.getReadCapacityUnits))
     val writeThroughput = provisionedThroughput.flatMap(p => Option(p.getWriteCapacityUnits))
@@ -23,27 +24,39 @@ object DynamoDB {
       if (readThroughput.isEmpty || writeThroughput.isEmpty) Some("25")
       else None
 
-    val renamedDf = renames
-      .foldLeft(df) {
-        case (acc, Rename(from, to)) => acc.withColumnRenamed(from, to)
+    val jobConf = new JobConf(spark.sparkContext.hadoopConfiguration)
+
+    def setOptionalConf(name: String, maybeValue: Option[String]): Unit =
+      for (value <- maybeValue) {
+        jobConf.set(name, value)
       }
 
-    log.info(s"Schema after renames:\n${renamedDf.schema.treeString}")
+    jobConf.set(DynamoDBConstants.OUTPUT_TABLE_NAME, target.table)
+    setOptionalConf(DynamoDBConstants.REGION, target.region)
+    setOptionalConf(DynamoDBConstants.ENDPOINT, target.endpoint.map(_.renderEndpoint))
+    setOptionalConf(DynamoDBConstants.READ_THROUGHPUT, throughput)
+    setOptionalConf(
+      DynamoDBConstants.THROUGHPUT_WRITE_PERCENT,
+      target.throughputWritePercent.map(_.toString))
+    setOptionalConf(DynamoDBConstants.SCAN_SEGMENTS, target.scanSegments.map(_.toString))
+    setOptionalConf(DynamoDBConstants.MAX_MAP_TASKS, target.maxMapTasks.map(_.toString))
+    setOptionalConf(DynamoDBConstants.DYNAMODB_ACCESS_KEY_CONF, target.credentials.map(_.accessKey))
+    setOptionalConf(DynamoDBConstants.DYNAMODB_SECRET_KEY_CONF, target.credentials.map(_.secretKey))
+    jobConf.set(
+      "mapred.output.format.class",
+      "org.apache.hadoop.dynamodb.write.DynamoDBOutputFormat")
+    jobConf.set("mapred.input.format.class", "org.apache.hadoop.dynamodb.read.DynamoDBInputFormat")
 
-    renamedDf.write
-      .options(
-        (List(
-          target.region.map("region" -> _),
-          target.endpoint.map(ep => "endpoint"                      -> ep.renderEndpoint),
-          target.scanSegments.map(segs => "readPartitions"          -> segs.toString),
-          target.throughputWritePercent.map(pct => "targetCapacity" -> pct.toString),
-          target.maxMapTasks.map(tasks => "defaultParallelism"      -> tasks.toString),
-          throughput.map("throughput" -> _)
-        ).flatten ++ target.credentials.toList.flatMap {
-          case AWSCredentials(accessKey, secretKey) =>
-            List("accesskey" -> accessKey, "secretkey" -> secretKey)
-        }).toMap
-      )
-      .dynamodb(target.table)
+    rdd
+      .mapValues { itemWritable =>
+        val item = itemWritable.getItem
+        for (rename <- renames) {
+          item.put(rename.to, item.get(rename.from))
+          item.remove(rename.from)
+        }
+        itemWritable
+      }
+      .saveAsHadoopDataset(jobConf)
+
   }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
@@ -65,10 +65,11 @@ object DynamoStreamReplication {
         case _ => None
       }
       .foreachRDD { msgs =>
-        val rdd = msgs.collect {
-          case Some(item) => (new Text(), new DynamoDBItemWritable(item))
-        }
-        // FIXME re-partition by columns? msgs.repartition(???)
+        val rdd = msgs
+          .collect {
+            case Some(item) => (new Text(), new DynamoDBItemWritable(item))
+          }
+          .repartition(Runtime.getRuntime.availableProcessors() * 2)
 
         log.info("Changes to be applied:")
         rdd

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -3,10 +3,10 @@ package com.scylladb.migrator.writers
 import com.datastax.spark.connector.writer._
 import com.datastax.spark.connector._
 import com.scylladb.migrator.Connectors
-import com.scylladb.migrator.config.{Rename, TargetSettings}
+import com.scylladb.migrator.config.{ Rename, TargetSettings }
 import com.scylladb.migrator.readers.TimestampColumns
-import org.apache.log4j.{LogManager, Logger}
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.log4j.{ LogManager, Logger }
+import org.apache.spark.sql.{ DataFrame, Row, SparkSession }
 import com.datastax.oss.driver.api.core.ConsistencyLevel
 
 object Scylla {

--- a/tests/docker/job-flow.json
+++ b/tests/docker/job-flow.json
@@ -1,0 +1,27 @@
+{
+  "jobFlowId": "j-2AO77MNLG17NW",
+  "jobFlowCreationInstant": 1429046932628,
+  "instanceCount": 2,
+  "masterInstanceId": "i-08dea4f4",
+  "masterPrivateDnsName": "localhost",
+  "masterInstanceType": "m1.medium",
+  "slaveInstanceType": "m1.xlarge",
+  "hadoopVersion": "2.4.0",
+  "instanceGroups": [
+    {
+      "instanceGroupId": "ig-16NXM94TY33LB",
+      "instanceGroupName": "CORE",
+      "instanceRole": "Core",
+      "marketType": "OnDemand",
+      "instanceType": "m3.xlarge",
+      "requestedInstanceCount": 1
+    },
+    {
+      "instanceGroupId": "ig-2XQ29JGCTKLBL",
+      "instanceGroupName": "MASTER",
+      "instanceRole": "Master",
+      "marketType": "OnDemand",
+      "instanceType": "m1.medium",
+      "requestedInstanceCount": 1
+    }]
+}

--- a/tests/src/test/configurations/dynamodb-to-alternator-issue-103.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-issue-103.yaml
@@ -1,0 +1,38 @@
+source:
+  type: dynamodb
+  table: Issue103Items
+  endpoint:
+    host: http://dynamodb
+    port: 8000
+  credentials:
+    accessKey: dummy
+    secretKey: dummy
+  maxMapTasks: 2
+  scanSegments: 10
+
+target:
+  type: dynamodb
+  table: Issue103Items
+  endpoint:
+    host: http://scylla
+    port: 8000
+  credentials:
+    accessKey: dummy
+    secretKey: dummy
+  maxMapTasks: 1
+  streamChanges: false
+
+renames: []
+
+# Below are unused but mandatory settings
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300
+skipTokenRanges: []
+validation:
+  compareTimestamps: true
+  ttlToleranceMillis: 60000
+  writetimeToleranceMillis: 1000
+  failuresToFetch: 100
+  floatingPointTolerance: 0.001
+  timestampMsTolerance: 0

--- a/tests/src/test/scala/com/scylladb/migrator/Issue103Test.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/Issue103Test.scala
@@ -1,0 +1,47 @@
+package com.scylladb.migrator
+
+import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest}
+
+import scala.collection.JavaConverters._
+import scala.util.chaining._
+
+// Reproduction of https://github.com/scylladb/scylla-migrator/issues/103
+class Issue103Test extends MigratorSuite {
+
+  withTable("Issue103Items").test("Issue #103 is fixed") { tableName =>
+    // Insert two items
+    val keys1 = Map("id" -> new AttributeValue().withS("4"))
+    val attrs1 = Map(
+      "AlbumTitle" -> new AttributeValue().withS("aaaaa"),
+      "Awards" -> new AttributeValue().withN("4")
+    )
+    val item1Data = keys1 ++ attrs1
+
+    val keys2 = Map("id" -> new AttributeValue().withS("999"))
+    val attrs2 = Map(
+      "asdfg" -> new AttributeValue().withM(
+        Map("fffff" -> new AttributeValue().withS("asdfasdfs")).asJava
+      )
+    )
+    val item2Data = keys2 ++ attrs2
+
+    sourceDDb.putItem(tableName, item1Data.asJava)
+    sourceDDb.putItem(tableName, item2Data.asJava)
+
+    // Perform the migration
+    submitSparkJob("dynamodb-to-alternator-issue-103.yaml")
+
+    // Check that both items have been correctly migrated to the target table
+    targetAlternator
+      .getItem(new GetItemRequest(tableName, keys1.asJava))
+      .tap { itemResult =>
+        assertEquals(itemResult.getItem.asScala.toMap, item1Data)
+      }
+    targetAlternator
+      .getItem(new GetItemRequest(tableName, keys2.asJava))
+      .tap { itemResult =>
+        assertEquals(itemResult.getItem.asScala.toMap, item2Data)
+      }
+  }
+
+}


### PR DESCRIPTION
Fixes #103.

Instead of using `com.audienceproject:spark-dynamodb` to migrate the data, we use `com.amazon.emr:emr-dynamodb-hadoop` as described in https://aws.amazon.com/fr/blogs/big-data/analyze-your-data-on-amazon-dynamodb-with-apache-spark/.

The former approach used to load the data as a `DataFrame`, which required us to infer the data schema, but that was not doable in a reliable way.

The new approach still benefits from the Spark infrastructure to handle the data transfer efficiently, but the data is loaded as an `RDD`.

To achieve this, I had to de-unify the migrators for Scylla and Alternator (so, in a sense, I am undoing what was done in #23). The benefit is that the Alternator migrator is not anymore constrained by the requirements of the Scylla migrator.