### PR TITLE
Expand the tests to cover migrations from Cassandra, ScyllaDB, and Parquet

### DIFF
--- a/.github/attempt.sh
+++ b/.github/attempt.sh
@@ -1,4 +1,4 @@
-insist () {
+attempt () {
   command=$1
   attempts=0
   max_attempts=240

--- a/.github/insist.sh
+++ b/.github/insist.sh
@@ -1,0 +1,11 @@
+insist () {
+  command=$1
+  attempts=0
+  max_attempts=240
+  while ! eval "$command" ; do
+      [[ $attempts -ge $max_attempts ]] && echo "Failed!" && exit 1
+      attempts=$((attempts+1))
+      sleep 1;
+      echo "waiting... (${attempts}/${max_attempts})"
+  done
+}

--- a/.github/wait-for-cql.sh
+++ b/.github/wait-for-cql.sh
@@ -2,7 +2,7 @@
 
 service=$1
 
-source .github/insist.sh
+source .github/attempt.sh
 
 echo "Waiting for CQL to be ready in service ${service}"
-insist 'docker compose -f docker-compose-tests.yml exec ${service} bash -c "cqlsh -e '"'"'describe cluster'"'"'" > /dev/null'
+attempt 'docker compose -f docker-compose-tests.yml exec ${service} bash -c "cqlsh -e '"'"'describe cluster'"'"'" > /dev/null'

--- a/.github/wait-for-cql.sh
+++ b/.github/wait-for-cql.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+service=$1
+
+source .github/insist.sh
+
+echo "Waiting for CQL to be ready in service ${service}"
+insist 'docker compose -f docker-compose-tests.yml exec ${service} bash -c "cqlsh -e '"'"'describe cluster'"'"'" > /dev/null'

--- a/.github/wait-for-port.sh
+++ b/.github/wait-for-port.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
 port=$1
+
+source .github/insist.sh
+
 echo "Waiting for successful HTTP status code on port ${port}"
-attempts=0
-max_attempts=240
-while ! curl -s "http://127.0.0.1:$port" > /dev/null ; do
-    [[ $attempts -ge $max_attempts ]] && echo "Failed!" && exit 1
-    attempts=$((attempts+1))
-    sleep 1;
-    echo "waiting... (${attempts}/${max_attempts})"
-done
+insist 'curl -s "http://127.0.0.1:$port" > /dev/null'

--- a/.github/wait-for-port.sh
+++ b/.github/wait-for-port.sh
@@ -2,7 +2,7 @@
 
 port=$1
 
-source .github/insist.sh
+source .github/attempt.sh
 
 echo "Waiting for successful HTTP status code on port ${port}"
-insist 'curl -s "http://127.0.0.1:$port" > /dev/null'
+attempt 'curl -s "http://127.0.0.1:$port" > /dev/null'

--- a/.github/wait-for-port.sh
+++ b/.github/wait-for-port.sh
@@ -3,7 +3,7 @@
 port=$1
 echo "Waiting for successful HTTP status code on port ${port}"
 attempts=0
-max_attempts=60
+max_attempts=240
 while ! curl -s "http://127.0.0.1:$port" > /dev/null ; do
     [[ $attempts -ge $max_attempts ]] && echo "Failed!" && exit 1
     attempts=$((attempts+1))

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,11 +25,11 @@ jobs:
       - name: Set up services
         run: |
           docker compose -f docker-compose-tests.yml up &
-          .github/wait-for-port.sh 9042 # ScyllaDB
           .github/wait-for-port.sh 8000 # ScyllaDB Alternator
           .github/wait-for-port.sh 8001 # DynamoDB
-          .github/wait-for-port.sh 9043 # Cassandra
-          .github/wait-for-port.sh 9044 # ScyllaDB (used as a source)
+          .github/wait-for-cql.sh scylla
+          .github/wait-for-cql.sh cassandra
+          .github/wait-for-cql.sh scylla-source
           .github/wait-for-port.sh 8080 # Spark master
           .github/wait-for-port.sh 8081 # Spark worker
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
           .github/wait-for-port.sh 8000 # ScyllaDB Alternator
           .github/wait-for-port.sh 8001 # DynamoDB
           .github/wait-for-port.sh 9043 # Cassandra
+          .github/wait-for-port.sh 9044 # ScyllaDB (used as a source)
           .github/wait-for-port.sh 8080 # Spark master
           .github/wait-for-port.sh 8081 # Spark worker
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         run: ./build.sh
       - name: Set up services
         run: |
-          docker compose -f docker-compose-tests.yml up -d
+          docker compose -f docker-compose-tests.yml up &
           .github/wait-for-port.sh 9042 # ScyllaDB
           .github/wait-for-port.sh 8000 # ScyllaDB Alternator
           .github/wait-for-port.sh 8001 # DynamoDB

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,10 @@ jobs:
       - name: Set up services
         run: |
           docker compose -f docker-compose-tests.yml up -d
-          .github/wait-for-port.sh 8000 # ScyllaDB
+          .github/wait-for-port.sh 9042 # ScyllaDB
+          .github/wait-for-port.sh 8000 # ScyllaDB Alternator
           .github/wait-for-port.sh 8001 # DynamoDB
+          .github/wait-for-port.sh 9043 # Cassandra
           .github/wait-for-port.sh 8080 # Spark master
           .github/wait-for-port.sh 8081 # Spark worker
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         run: ./build.sh
       - name: Set up services
         run: |
-          docker compose -f docker-compose-tests.yml up &
+          docker compose -f docker-compose-tests.yml up -d
           .github/wait-for-port.sh 8000 # ScyllaDB Alternator
           .github/wait-for-port.sh 8001 # DynamoDB
           .github/wait-for-cql.sh scylla

--- a/build.sbt
+++ b/build.sbt
@@ -76,6 +76,8 @@ lazy val tests = project.in(file("tests")).settings(
   libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
     "org.apache.cassandra" % "java-driver-query-builder" % "4.18.0",
+    "com.github.mjakubowski84" %% "parquet4s-core" % "1.9.4",
+    "org.apache.hadoop" % "hadoop-client" % "2.9.2",
     "org.scalameta" %% "munit" % "0.7.29",
     "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0"
   ),

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,8 @@ val sparkVersion = "2.4.4"
 inThisBuild(
   List(
     organization := "com.scylladb",
-    scalaVersion := "2.11.12"
+    scalaVersion := "2.11.12",
+    scalacOptions += "-target:jvm-1.8"
   )
 )
 
@@ -74,6 +75,7 @@ lazy val migrator = (project in file("migrator")).settings(
 lazy val tests = project.in(file("tests")).settings(
   libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
+    "org.apache.cassandra" % "java-driver-query-builder" % "4.18.0",
     "org.scalameta" %% "munit" % "0.7.29",
     "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0"
   ),

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -14,6 +14,17 @@ services:
       - "8001:8000"
     working_dir: /home/dynamodblocal
 
+  cassandra:
+    image: cassandra:latest
+    networks:
+      - scylla
+    volumes:
+      - ./tests/docker/cassandra:/var/lib/cassandra
+    ports:
+      - "9043:9042"
+    expose:
+      - 9043
+
   scylla:
     image: scylladb/scylla:latest
     networks:
@@ -22,6 +33,7 @@ services:
       - "./tests/docker/scylla:/var/lib/scylla"
     ports:
       - "8000:8000"
+      - "9042:9042"
     command: "--smp 2 --memory 2048M --alternator-port 8000 --alternator-write-isolation always_use_lwt"
 
   spark-master:
@@ -54,6 +66,7 @@ services:
     volumes:
       - ./migrator/target/scala-2.11:/jars
       - ./tests/src/test/configurations:/app/configurations
+      - ./tests/docker/spark-master:/app/savepoints
       # Workaround for https://github.com/awslabs/emr-dynamodb-connector/issues/50
       - ${PWD}/tests/docker/job-flow.json:/mnt/var/lib/info/job-flow.json
 

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -80,6 +80,7 @@ services:
       - ./migrator/target/scala-2.11:/jars
       - ./tests/src/test/configurations:/app/configurations
       - ./tests/docker/spark-master:/app/savepoints
+      - ./tests/docker/parquet:/app/parquet
       # Workaround for https://github.com/awslabs/emr-dynamodb-connector/issues/50
       - ${PWD}/tests/docker/job-flow.json:/mnt/var/lib/info/job-flow.json
 
@@ -104,6 +105,8 @@ services:
     ports:
       - 5006:5006
       - 8081:8081
+    volumes:
+      - ./tests/docker/parquet:/app/parquet
     depends_on:
       - spark-master
 

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -25,6 +25,19 @@ services:
     expose:
       - 9043
 
+  scylla-source:
+    image: scylladb/scylla:latest
+    networks:
+      - scylla
+    volumes:
+      - "./tests/docker/scylla-source:/var/lib/scylla"
+    ports:
+      - "8002:8000"
+      - "9044:9042"
+    expose:
+      - 9044
+    command: "--smp 1 --memory 2048M --alternator-port 8000 --alternator-write-isolation always_use_lwt"
+
   scylla:
     image: scylladb/scylla:latest
     networks:
@@ -34,7 +47,7 @@ services:
     ports:
       - "8000:8000"
       - "9042:9042"
-    command: "--smp 2 --memory 2048M --alternator-port 8000 --alternator-write-isolation always_use_lwt"
+    command: "--smp 1 --memory 2048M --alternator-port 8000 --alternator-write-isolation always_use_lwt"
 
   spark-master:
     image: bde2020/spark-master:2.4.4-hadoop2.7

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -36,7 +36,7 @@ services:
       - "9044:9042"
     expose:
       - 9044
-    command: "--smp 1 --memory 2048M --alternator-port 8000 --alternator-write-isolation always_use_lwt"
+    command: "--smp 1 --memory 2048M --alternator-port 8000 --alternator-write-isolation only_rmw_uses_lwt"
 
   scylla:
     image: scylladb/scylla:latest
@@ -47,7 +47,7 @@ services:
     ports:
       - "8000:8000"
       - "9042:9042"
-    command: "--smp 1 --memory 2048M --alternator-port 8000 --alternator-write-isolation always_use_lwt"
+    command: "--smp 1 --memory 2048M --alternator-port 8000 --alternator-write-isolation only_rmw_uses_lwt"
 
   spark-master:
     image: bde2020/spark-master:2.4.4-hadoop2.7

--- a/tests/docker/.gitignore
+++ b/tests/docker/.gitignore
@@ -1,0 +1,3 @@
+cassandra/
+scylla/
+spark-master/

--- a/tests/docker/parquet/.gitignore
+++ b/tests/docker/parquet/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tests/src/test/configurations/cassandra-to-scylla-basic.yaml
+++ b/tests/src/test/configurations/cassandra-to-scylla-basic.yaml
@@ -1,0 +1,43 @@
+source:
+  type: cassandra
+  host: cassandra
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: basictest
+  consistencyLevel: LOCAL_QUORUM
+  preserveTimestamps: true
+  splitCount: 8
+  connections: 8
+  fetchSize: 1000
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: basictest
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+renames: []
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300
+skipTokenRanges: []
+validation:
+  compareTimestamps: true
+  ttlToleranceMillis: 60000
+  writetimeToleranceMillis: 1000
+  failuresToFetch: 100
+  floatingPointTolerance: 0.001
+  timestampMsTolerance: 0

--- a/tests/src/test/configurations/cassandra-to-scylla-renames.yaml
+++ b/tests/src/test/configurations/cassandra-to-scylla-renames.yaml
@@ -1,0 +1,45 @@
+source:
+  type: cassandra
+  host: cassandra
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: renameditems
+  consistencyLevel: LOCAL_QUORUM
+  preserveTimestamps: true
+  splitCount: 8
+  connections: 8
+  fetchSize: 1000
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: renameditems
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+renames:
+  - from: bar
+    to: quux
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300
+skipTokenRanges: []
+validation:
+  compareTimestamps: true
+  ttlToleranceMillis: 60000
+  writetimeToleranceMillis: 1000
+  failuresToFetch: 100
+  floatingPointTolerance: 0.001
+  timestampMsTolerance: 0

--- a/tests/src/test/configurations/parquet-to-scylla-basic.yaml
+++ b/tests/src/test/configurations/parquet-to-scylla-basic.yaml
@@ -1,0 +1,31 @@
+source:
+  type: parquet
+  path: /app/parquet/basic.parquet
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: basictest
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+renames: []
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300
+skipTokenRanges: []
+validation:
+  compareTimestamps: true
+  ttlToleranceMillis: 60000
+  writetimeToleranceMillis: 1000
+  failuresToFetch: 100
+  floatingPointTolerance: 0.001
+  timestampMsTolerance: 0

--- a/tests/src/test/configurations/scylla-to-scylla-basic.yaml
+++ b/tests/src/test/configurations/scylla-to-scylla-basic.yaml
@@ -1,0 +1,43 @@
+source:
+  type: scylla
+  host: scylla-source
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: basictest
+  consistencyLevel: LOCAL_QUORUM
+  preserveTimestamps: true
+  splitCount: 8
+  connections: 8
+  fetchSize: 1000
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: basictest
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+renames: []
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300
+skipTokenRanges: []
+validation:
+  compareTimestamps: true
+  ttlToleranceMillis: 60000
+  writetimeToleranceMillis: 1000
+  failuresToFetch: 100
+  floatingPointTolerance: 0.001
+  timestampMsTolerance: 0

--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+datastax-java-driver {
+  basic.request {
+    timeout = 10 seconds
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/CassandraUtils.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/CassandraUtils.scala
@@ -1,0 +1,37 @@
+package com.scylladb.migrator
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.`type`.DataTypes
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder
+
+object CassandraUtils {
+
+  /**
+   * Prepare a Scylla table for a test. Drop any existing table of the same name and recreates it.
+   *
+   * @param database   Database session to use
+   * @param keyspace   Keyspace name
+   * @param name       Name of the table to create
+   * @param columnName Function to possible transform the initial name of the columns
+   */
+  def dropAndRecreateTable(database: CqlSession, keyspace: String, name: String, columnName: String => String): Unit = {
+    val dropTableStatement =
+      SchemaBuilder
+        .dropTable(keyspace, name)
+        .ifExists()
+        .build()
+    database
+      .execute(dropTableStatement)
+      .ensuring(_.wasApplied())
+    val createTableStatement =
+      SchemaBuilder
+        .createTable(keyspace, name)
+        .withPartitionKey("id", DataTypes.TEXT)
+        .withColumn(columnName("foo"), DataTypes.TEXT)
+        .withColumn(columnName("bar"), DataTypes.INT)
+        .build()
+    database
+      .execute(createTableStatement)
+      .ensuring(_.wasApplied())
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
@@ -1,0 +1,44 @@
+package com.scylladb.migrator
+
+import scala.sys.process.Process
+
+object SparkUtils {
+
+  /**
+   * Run a migration by submitting a Spark job to the Spark cluster
+   * and waiting for its successful completion.
+   *
+   * @param configFile Configuration file to use. Write your
+   *                   configuration files in the directory
+   *                   `src/test/configurations`, which is
+   *                   automatically mounted to the Spark
+   *                   cluster by Docker Compose.
+   */
+  def submitMigrationJob(configFile: String): Unit = {
+    val process =
+      Process(
+        Seq(
+          "docker",
+          "compose",
+          "-f", "docker-compose-tests.yml",
+          "exec",
+          "spark-master",
+          "/spark/bin/spark-submit",
+          "--class", "com.scylladb.migrator.Migrator",
+          "--master", "spark://spark-master:7077",
+          "--conf", "spark.driver.host=spark-master",
+          "--conf", s"spark.scylla.config=/app/configurations/${configFile}",
+          // Uncomment one of the following lines to plug a remote debugger on the Spark master or worker.
+          // "--conf", "spark.driver.extraJavaOptions=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005",
+          // "--conf", "spark.executor.extraJavaOptions=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006",
+          "/jars/scylla-migrator-assembly-0.0.1.jar"
+        )
+      )
+    process
+      .run()
+      .exitValue()
+      .ensuring(statusCode => statusCode == 0, "Spark job failed")
+    ()
+  }
+
+}

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/BasicMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/BasicMigrationTest.scala
@@ -1,4 +1,4 @@
-package com.scylladb.migrator
+package com.scylladb.migrator.alternator
 
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest}
 

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/BasicMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/BasicMigrationTest.scala
@@ -1,6 +1,7 @@
 package com.scylladb.migrator.alternator
 
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest}
+import com.scylladb.migrator.SparkUtils.submitMigrationJob
 
 import scala.collection.JavaConverters._
 import scala.util.chaining._
@@ -16,7 +17,7 @@ class BasicMigrationTest extends MigratorSuite {
     sourceDDb.putItem(tableName, itemData.asJava)
 
     // Perform the migration
-    submitSparkJob("dynamodb-to-alternator-basic.yaml")
+    submitMigrationJob("dynamodb-to-alternator-basic.yaml")
 
     // Check that the schema has been replicated to the target table
     val sourceTableDesc = sourceDDb.describeTable(tableName).getTable

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/Issue103Test.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/Issue103Test.scala
@@ -1,4 +1,4 @@
-package com.scylladb.migrator
+package com.scylladb.migrator.alternator
 
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest}
 

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/Issue103Test.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/Issue103Test.scala
@@ -1,6 +1,7 @@
 package com.scylladb.migrator.alternator
 
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest}
+import com.scylladb.migrator.SparkUtils.submitMigrationJob
 
 import scala.collection.JavaConverters._
 import scala.util.chaining._
@@ -29,7 +30,7 @@ class Issue103Test extends MigratorSuite {
     sourceDDb.putItem(tableName, item2Data.asJava)
 
     // Perform the migration
-    submitSparkJob("dynamodb-to-alternator-issue-103.yaml")
+    submitMigrationJob("dynamodb-to-alternator-issue-103.yaml")
 
     // Check that both items have been correctly migrated to the target table
     targetAlternator

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
@@ -1,12 +1,10 @@
 package com.scylladb.migrator.alternator
 
-import com.amazonaws.auth.{AWSCredentials, AWSStaticCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.dynamodbv2.model._
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClientBuilder}
 
-import scala.collection.JavaConverters._
-import scala.sys.process.Process
 import scala.util.chaining._
 
 /**
@@ -91,37 +89,5 @@ trait MigratorSuite extends munit.FunSuite {
       ()
     }
   )
-
-  /**
-   * Run a migration by submitting a Spark job to the Spark cluster.
-   * @param migratorConfigFile Configuration file to use. Write your
-   *                           configuration files in the directory
-   *                           `src/test/configurations`, which is
-   *                           automatically mounted to the Spark
-   *                           cluster by Docker Compose.
-   */
-  def submitSparkJob(migratorConfigFile: String): Unit = {
-    Process(
-      Seq(
-        "docker",
-        "compose",
-        "-f", "docker-compose-tests.yml",
-        "exec",
-        "spark-master",
-        "/spark/bin/spark-submit",
-        "--class", "com.scylladb.migrator.Migrator",
-        "--master", "spark://spark-master:7077",
-        "--conf", "spark.driver.host=spark-master",
-        "--conf", s"spark.scylla.config=/app/configurations/${migratorConfigFile}",
-        // Uncomment one of the following lines to plug a remote debugger on the Spark master or worker.
-        // "--conf", "spark.driver.extraJavaOptions=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005",
-        // "--conf", "spark.executor.extraJavaOptions=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006",
-        "/jars/scylla-migrator-assembly-0.0.1.jar"
-      )
-    ).run().exitValue().tap { statusCode =>
-      assertEquals(statusCode, 0, "Spark job failed")
-    }
-    ()
-  }
 
 }

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
@@ -1,4 +1,4 @@
-package com.scylladb.migrator
+package com.scylladb.migrator.alternator
 
 import com.amazonaws.auth.{AWSCredentials, AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
@@ -79,7 +79,7 @@ trait MigratorSuite extends munit.FunSuite {
         }
       } catch {
         case any: Throwable =>
-          fail(s"Failed to created table ${name} in database ${sourceDDb}: ${any}")
+          fail(s"Failed to created table ${name} in database ${sourceDDb}", any)
       }
       name
     },

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/RenamedItemsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/RenamedItemsTest.scala
@@ -1,4 +1,4 @@
-package com.scylladb.migrator
+package com.scylladb.migrator.alternator
 
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest}
 import scala.collection.JavaConverters._

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/RenamedItemsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/RenamedItemsTest.scala
@@ -1,6 +1,8 @@
 package com.scylladb.migrator.alternator
 
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest}
+import com.scylladb.migrator.SparkUtils.submitMigrationJob
+
 import scala.collection.JavaConverters._
 import scala.util.chaining._
 
@@ -23,7 +25,7 @@ class RenamedItemsTest extends MigratorSuite {
     sourceDDb.putItem(tableName, item2Data.asJava)
 
     // Perform the migration
-    submitSparkJob("dynamodb-to-alternator-renames.yaml")
+    submitMigrationJob("dynamodb-to-alternator-renames.yaml")
 
     val renamedItem1Data =
       item1Data + ("quux" -> item1Data("foo")) - "foo"

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/BasicMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/BasicMigrationTest.scala
@@ -7,7 +7,7 @@ import com.datastax.oss.driver.api.querybuilder.term.Term
 import scala.jdk.CollectionConverters._
 import scala.util.chaining._
 
-class BasicMigrationTest extends MigratorSuite {
+class BasicMigrationTest extends MigratorSuite(sourcePort = 9043) {
 
   withTable("BasicTest").test("Read from source and write to target") { tableName =>
     val insertStatement =

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/BasicMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/BasicMigrationTest.scala
@@ -1,0 +1,43 @@
+package com.scylladb.migrator.scylla
+
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal
+import com.datastax.oss.driver.api.querybuilder.term.Term
+
+import scala.jdk.CollectionConverters._
+import scala.util.chaining._
+
+class BasicMigrationTest extends MigratorSuite {
+
+  withTable("BasicTest").test("Read from source and write to target") { tableName =>
+    val insertStatement =
+      QueryBuilder
+        .insertInto(keyspace, tableName)
+        .values(Map[String, Term](
+          "id" -> literal("12345"),
+          "foo" -> literal("bar")
+        ).asJava)
+        .build()
+
+    // Insert some items
+    sourceCassandra.execute(insertStatement)
+
+    // Perform the migration
+    submitSparkJob("cassandra-to-scylla-basic.yaml")
+
+    // Check that the item has been migrated to the target table
+    val selectAllStatement = QueryBuilder
+      .selectFrom(keyspace, tableName)
+      .all()
+      .build()
+    targetScylla.execute(selectAllStatement).tap { resultSet =>
+      val rows = resultSet.all().asScala
+      assertEquals(rows.size, 1)
+      val row = rows.head
+      assertEquals(row.getColumnDefinitions.size(), 2)
+      assertEquals(row.getString("id"), "12345")
+      assertEquals(row.getString("foo"), "bar")
+    }
+  }
+
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/BasicMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/BasicMigrationTest.scala
@@ -3,6 +3,7 @@ package com.scylladb.migrator.scylla
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal
 import com.datastax.oss.driver.api.querybuilder.term.Term
+import com.scylladb.migrator.SparkUtils.submitMigrationJob
 
 import scala.jdk.CollectionConverters._
 import scala.util.chaining._
@@ -23,7 +24,7 @@ class BasicMigrationTest extends MigratorSuite(sourcePort = 9043) {
     sourceCassandra.execute(insertStatement)
 
     // Perform the migration
-    submitSparkJob("cassandra-to-scylla-basic.yaml")
+    submitMigrationJob("cassandra-to-scylla-basic.yaml")
 
     // Check that the item has been migrated to the target table
     val selectAllStatement = QueryBuilder

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/MigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/MigratorSuite.scala
@@ -14,15 +14,17 @@ import scala.util.chaining._
  *
  * It expects external services (Cassandra, Scylla, Spark, etc.) to be running.
  * See the files `CONTRIBUTING.md` and `docker-compose-tests.yml` for more information.
+ *
+ * @param sourcePort TCP port of the source database. See docker-compose-test.yml.
  */
-trait MigratorSuite extends munit.FunSuite {
+abstract class MigratorSuite(sourcePort: Int) extends munit.FunSuite {
 
   val keyspace = "test"
 
   /** Client of a source Cassandra instance */
   val sourceCassandra: CqlSession = CqlSession
     .builder()
-    .addContactPoint(new InetSocketAddress("localhost", 9043))
+    .addContactPoint(new InetSocketAddress("localhost", sourcePort))
     .withLocalDatacenter("datacenter1")
     .withAuthCredentials("dummy", "dummy")
     .build()

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/MigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/MigratorSuite.scala
@@ -1,0 +1,136 @@
+package com.scylladb.migrator.scylla
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.`type`.DataTypes
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder
+
+import java.net.InetSocketAddress
+import scala.sys.process.Process
+import scala.jdk.CollectionConverters._
+import scala.util.chaining._
+
+/**
+ * Base class for implementing end-to-end tests.
+ *
+ * It expects external services (Cassandra, Scylla, Spark, etc.) to be running.
+ * See the files `CONTRIBUTING.md` and `docker-compose-tests.yml` for more information.
+ */
+trait MigratorSuite extends munit.FunSuite {
+
+  val keyspace = "test"
+
+  /** Client of a source Cassandra instance */
+  val sourceCassandra: CqlSession = CqlSession
+    .builder()
+    .addContactPoint(new InetSocketAddress("localhost", 9043))
+    .withLocalDatacenter("datacenter1")
+    .withAuthCredentials("dummy", "dummy")
+    .build()
+
+  /** Client of a target ScyllaDB instance */
+  val targetScylla: CqlSession = CqlSession
+    .builder()
+    .addContactPoint(new InetSocketAddress("localhost", 9042))
+    .withLocalDatacenter("datacenter1")
+    .withAuthCredentials("dummy", "dummy")
+    .build()
+
+  /**
+   * Fixture automating the house-keeping work when migrating a table.
+   *
+   * It deletes the table from both the source and target databases in case it was already
+   * existing, and then recreates it in the source database.
+   *
+   * After the test is executed, it deletes the table from both the source and target
+   * databases.
+   *
+   * @param name Name of the table
+   */
+  def withTable(name: String): FunFixture[String] = FunFixture(
+    setup = { _ =>
+      def dropAndRecreateTable(database: CqlSession): Unit =
+        try {
+          val dropTableStatement =
+            SchemaBuilder
+              .dropTable(keyspace, name)
+              .ifExists()
+              .build()
+          database
+            .execute(dropTableStatement)
+            .ensuring(_.wasApplied())
+          val createTableStatement =
+            SchemaBuilder
+              .createTable(keyspace, name)
+              .withPartitionKey("id", DataTypes.TEXT)
+              .withColumn("foo", DataTypes.TEXT)
+              .build()
+          database
+            .execute(createTableStatement)
+            .ensuring(_.wasApplied())
+        } catch {
+          case any: Throwable =>
+            fail(s"Something did not work as expected", any)
+        }
+      // Make sure the source and target databases do not contain the table already
+      dropAndRecreateTable(sourceCassandra)
+      dropAndRecreateTable(targetScylla)
+      name
+    },
+    teardown = { _ =>
+      // Clean-up both the source and target databases
+      val dropTableQuery = SchemaBuilder.dropTable(keyspace, name).build()
+      targetScylla.execute(dropTableQuery)
+      sourceCassandra.execute(dropTableQuery)
+      ()
+    }
+  )
+
+  /**
+   * Run a migration by submitting a Spark job to the Spark cluster.
+   * @param migratorConfigFile Configuration file to use. Write your
+   *                           configuration files in the directory
+   *                           `src/test/configurations`, which is
+   *                           automatically mounted to the Spark
+   *                           cluster by Docker Compose.
+   */
+  def submitSparkJob(migratorConfigFile: String): Unit = {
+    Process(
+      Seq(
+        "docker",
+        "compose",
+        "-f", "docker-compose-tests.yml",
+        "exec",
+        "spark-master",
+        "/spark/bin/spark-submit",
+        "--class", "com.scylladb.migrator.Migrator",
+        "--master", "spark://spark-master:7077",
+        "--conf", "spark.driver.host=spark-master",
+        "--conf", s"spark.scylla.config=/app/configurations/${migratorConfigFile}",
+        // Uncomment one of the following lines to plug a remote debugger on the Spark master or worker.
+        // "--conf", "spark.driver.extraJavaOptions=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005",
+        // "--conf", "spark.executor.extraJavaOptions=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006",
+        "/jars/scylla-migrator-assembly-0.0.1.jar"
+      )
+    ).run().exitValue().tap { statusCode =>
+      assertEquals(statusCode, 0, "Spark job failed")
+    }
+    ()
+  }
+
+  override def beforeAll(): Unit = {
+    val keyspaceStatement =
+      SchemaBuilder
+        .createKeyspace(keyspace)
+        .ifNotExists()
+        .withReplicationOptions(Map[String, AnyRef]("class" -> "SimpleStrategy", "replication_factor" -> new Integer(1)).asJava)
+        .build()
+    sourceCassandra.execute(keyspaceStatement)
+    targetScylla.execute(keyspaceStatement)
+  }
+
+  override def afterAll(): Unit = {
+    sourceCassandra.close()
+    targetScylla.close()
+  }
+
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetToScyllaBasicMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetToScyllaBasicMigrationTest.scala
@@ -1,0 +1,77 @@
+package com.scylladb.migrator.scylla
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.querybuilder.{QueryBuilder, SchemaBuilder}
+import com.github.mjakubowski84.parquet4s.ParquetWriter
+import com.scylladb.migrator.CassandraUtils.dropAndRecreateTable
+import com.scylladb.migrator.SparkUtils.submitMigrationJob
+import com.scylladb.migrator.scylla.ParquetToScyllaBasicMigrationTest.BasicTestSchema
+import org.apache.parquet.hadoop.ParquetFileWriter
+
+import java.net.InetSocketAddress
+import scala.jdk.CollectionConverters._
+import scala.util.chaining._
+
+class ParquetToScyllaBasicMigrationTest extends munit.FunSuite {
+
+  test("Basic migration from Parquet to ScyllaDB") {
+    val keyspace = "test"
+    val tableName = "BasicTest"
+
+    val targetScylla: CqlSession = CqlSession
+      .builder()
+      .addContactPoint(new InetSocketAddress("localhost", 9042))
+      .withLocalDatacenter("datacenter1")
+      .withAuthCredentials("dummy", "dummy")
+      .build()
+
+    val keyspaceStatement =
+      SchemaBuilder
+        .createKeyspace(keyspace)
+        .ifNotExists()
+        .withReplicationOptions(Map[String, AnyRef]("class" -> "SimpleStrategy", "replication_factor" -> new Integer(1)).asJava)
+        .build()
+    targetScylla.execute(keyspaceStatement)
+
+    // Create the Parquet data source
+    ParquetWriter.writeAndClose(
+      "tests/docker/parquet/basic.parquet",
+      List(BasicTestSchema(id = "12345", foo = "bar")),
+      ParquetWriter.Options(writeMode = ParquetFileWriter.Mode.OVERWRITE)
+    )
+
+    // Create the target table in the target database
+    dropAndRecreateTable(targetScylla, keyspace, tableName, identity)
+
+    // Perform the migration
+    submitMigrationJob("parquet-to-scylla-basic.yaml")
+
+    // Check that the item has been migrated to the target table
+    val selectAllStatement = QueryBuilder
+      .selectFrom(keyspace, tableName)
+      .all()
+      .build()
+    targetScylla.execute(selectAllStatement).tap { resultSet =>
+      val rows = resultSet.all().asScala
+      assertEquals(rows.size, 1)
+      val row = rows.head
+      assertEquals(row.getString("id"), "12345")
+      assertEquals(row.getString("foo"), "bar")
+    }
+
+    // Clean the target table
+    val dropTableQuery = SchemaBuilder.dropTable(keyspace, tableName).build()
+    targetScylla.execute(dropTableQuery)
+    // Close the database driver
+    targetScylla.close()
+  }
+
+}
+
+object ParquetToScyllaBasicMigrationTest {
+
+  // parquet4s automatically derives the Parquet schema from this class definition.
+  // It must be consistent with the definition of the table from `dropAndRecreateTable`.
+  case class BasicTestSchema(id: String, foo: String)
+
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/RenamedItemsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/RenamedItemsTest.scala
@@ -3,6 +3,7 @@ package com.scylladb.migrator.scylla
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal
 import com.datastax.oss.driver.api.querybuilder.term.Term
+import com.scylladb.migrator.SparkUtils.submitMigrationJob
 
 import scala.jdk.CollectionConverters._
 import scala.util.chaining._
@@ -24,7 +25,7 @@ class RenamedItemsTest extends MigratorSuite(sourcePort = 9043) {
     sourceCassandra.execute(insertStatement)
 
     // Perform the migration
-    submitSparkJob("cassandra-to-scylla-renames.yaml")
+    submitMigrationJob("cassandra-to-scylla-renames.yaml")
 
     // Check that the item has been migrated to the target table
     val selectAllStatement = QueryBuilder

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaToScyllaBasicMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaToScyllaBasicMigrationTest.scala
@@ -7,16 +7,15 @@ import com.datastax.oss.driver.api.querybuilder.term.Term
 import scala.jdk.CollectionConverters._
 import scala.util.chaining._
 
-class RenamedItemsTest extends MigratorSuite(sourcePort = 9043) {
+class ScyllaToScyllaBasicMigrationTest extends MigratorSuite(sourcePort = 9044) {
 
-  withTable("RenamedItems", renames = Map("bar" -> "quux")).test("Read from source and write to target") { tableName =>
+  withTable("BasicTest").test("Read from source and write to target") { tableName =>
     val insertStatement =
       QueryBuilder
         .insertInto(keyspace, tableName)
         .values(Map[String, Term](
           "id" -> literal("12345"),
-          "foo" -> literal("bar"),
-          "bar" -> literal(42)
+          "foo" -> literal("bar")
         ).asJava)
         .build()
 
@@ -24,7 +23,7 @@ class RenamedItemsTest extends MigratorSuite(sourcePort = 9043) {
     sourceCassandra.execute(insertStatement)
 
     // Perform the migration
-    submitSparkJob("cassandra-to-scylla-renames.yaml")
+    submitSparkJob("scylla-to-scylla-basic.yaml")
 
     // Check that the item has been migrated to the target table
     val selectAllStatement = QueryBuilder
@@ -37,7 +36,6 @@ class RenamedItemsTest extends MigratorSuite(sourcePort = 9043) {
       val row = rows.head
       assertEquals(row.getString("id"), "12345")
       assertEquals(row.getString("foo"), "bar")
-      assertEquals(row.getInt("quux"), 42)
     }
   }
 

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaToScyllaBasicMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaToScyllaBasicMigrationTest.scala
@@ -3,6 +3,7 @@ package com.scylladb.migrator.scylla
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal
 import com.datastax.oss.driver.api.querybuilder.term.Term
+import com.scylladb.migrator.SparkUtils.submitMigrationJob
 
 import scala.jdk.CollectionConverters._
 import scala.util.chaining._
@@ -23,7 +24,7 @@ class ScyllaToScyllaBasicMigrationTest extends MigratorSuite(sourcePort = 9044) 
     sourceCassandra.execute(insertStatement)
 
     // Perform the migration
-    submitSparkJob("scylla-to-scylla-basic.yaml")
+    submitMigrationJob("scylla-to-scylla-basic.yaml")
 
     // Check that the item has been migrated to the target table
     val selectAllStatement = QueryBuilder


### PR DESCRIPTION
To test more migration scenarios, we now spawn containers providing a Cassandra instance and second ScyllaDB instance (used as a source database in a test).

We also added new library dependencies to interact with those databases during test preparation.

As a result, running the full test suite requires significant resources. It seems to work fine on the GitHub Actions runners, but we could split things apart (e.g. first create the containers for the DynamoDB to Alternator scenario, and then for the C* to Scylla scenarios).

- [x] https://github.com/scylladb/scylla-migrator/pull/124
- [x] Added tests from Cassandra to ScyllaDB
- [x] Added tests from ScyllaDB to ScyllaDB
- [x] Added tests from Parquet to ScyllaDB

Fixes #114