### PR TITLE
Support reading the credentials from the ~/.aws/credentials file within the Spark cluster

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
@@ -176,6 +176,9 @@ object DynamoUtils {
       jobConf.set(DynamoDBConstants.DYNAMODB_SECRET_KEY_CONF, credentials.secretKey)
     }
     jobConf.set(
+      DynamoDBConstants.CUSTOM_CREDENTIALS_PROVIDER_CONF,
+      "com.amazonaws.auth.profile.ProfileCredentialsProvider")
+    jobConf.set(
       "mapred.output.format.class",
       "org.apache.hadoop.dynamodb.write.DynamoDBOutputFormat")
     jobConf.set("mapred.input.format.class", "org.apache.hadoop.dynamodb.read.DynamoDBInputFormat")


### PR DESCRIPTION
Currently, the users of the migrator have to provide their AWS credentials through the `config.yaml` file. According to the description of #122, in some cases it is desirable to also read the AWS credentials from the user profile (`~/.aws/credentials`).

This PR addresses this need by using a capability of the Hadoop connector to set a custom AWS credentials provider. We set it to `com.amazonaws.auth.profile.ProfileCredentialsProvider`, which is the standard profile credentials provider from the AWS SDK.

Ultimately, if necessary we could make this configurable and allow our users to supply which credentials provider to use. This would give them full control on that.

According to https://github.com/scylladb/scylla-migrator/issues/122#issuecomment-2028190781, this PR fixes #122.
