### PR TITLE
Add validator for Alternator/DynamoDB migrations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val tests = project.in(file("tests")).settings(
     "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0"
   ),
   Test / parallelExecution := false
-)
+).dependsOn(migrator)
 
 lazy val root = project.in(file("."))
   .aggregate(migrator, tests)

--- a/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
@@ -184,4 +184,13 @@ object DynamoUtils {
     jobConf.set("mapred.input.format.class", "org.apache.hadoop.dynamodb.read.DynamoDBInputFormat")
   }
 
+  def tableThroughput(tableDesc: Option[TableDescription]): Option[String] = {
+    val provisionedThroughput = tableDesc.flatMap(p => Option(p.getProvisionedThroughput))
+    val readThroughput = provisionedThroughput.flatMap(p => Option(p.getReadCapacityUnits))
+    val writeThroughput = provisionedThroughput.flatMap(p => Option(p.getWriteCapacityUnits))
+
+    if (readThroughput.isEmpty || writeThroughput.isEmpty) Some("25")
+    else None
+  }
+
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/Validator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Validator.scala
@@ -1,5 +1,6 @@
 package com.scylladb.migrator
 
+import com.scylladb.migrator.alternator.AlternatorValidator
 import com.scylladb.migrator.config.{ MigratorConfig, SourceSettings, TargetSettings }
 import com.scylladb.migrator.validation.RowComparisonFailure
 import org.apache.log4j.{ Level, LogManager, Logger }
@@ -14,8 +15,10 @@ object Validator {
     (config.source, config.target) match {
       case (cassandraSource: SourceSettings.Cassandra, scyllaTarget: TargetSettings.Scylla) =>
         ScyllaValidator.runValidation(cassandraSource, scyllaTarget, config)
+      case (dynamoSource: SourceSettings.DynamoDB, alternatorTarget: TargetSettings.DynamoDB) =>
+        AlternatorValidator.runValidation(dynamoSource, alternatorTarget, config)
       case _ =>
-        sys.error("Validation only supports validating against Cassandra/Scylla " +
+        sys.error("Unsupported combination of source and target " +
           s"(found ${config.source.getClass.getSimpleName} and ${config.target.getClass.getSimpleName} settings)")
     }
 
@@ -43,6 +46,7 @@ object Validator {
     else {
       log.error("Found the following comparison failures:")
       log.error(failures.mkString("\n"))
+      System.exit(1)
     }
   }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
@@ -11,19 +11,13 @@ import org.apache.spark.streaming.{ Seconds, StreamingContext }
 import scala.util.control.NonFatal
 
 object AlternatorMigrator {
-  val log = LogManager.getLogger("com.scylladb.migrator.alternator")
+  private val log = LogManager.getLogger("com.scylladb.migrator.alternator")
 
   def migrate(source: SourceSettings.DynamoDB,
               target: TargetSettings.DynamoDB,
               renames: List[Rename])(implicit spark: SparkSession): Unit = {
 
-    val sourceTableDesc = DynamoUtils
-      .buildDynamoClient(source.endpoint, source.credentials, source.region)
-      .describeTable(source.table)
-      .getTable
-
-    val sourceRDD =
-      readers.DynamoDB.readRDD(spark, source, sourceTableDesc)
+    val (sourceRDD, sourceTableDesc) = readers.DynamoDB.readRDD(spark, source)
 
     log.info("We need to transfer: " + sourceRDD.getNumPartitions + " partitions in total")
 

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
@@ -1,0 +1,93 @@
+package com.scylladb.migrator.alternator
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import com.scylladb.migrator.DynamoUtils.{ setDynamoDBJobConf, setOptionalConf, tableThroughput }
+import com.scylladb.migrator.config.{ MigratorConfig, SourceSettings, TargetSettings }
+import com.scylladb.migrator.validation.RowComparisonFailure
+import com.scylladb.migrator.readers
+import org.apache.hadoop.dynamodb.DynamoDBConstants
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
+
+import java.util
+import scala.collection.JavaConverters._
+
+object AlternatorValidator {
+
+  /**
+    * Checks that the target Alternator database contains the same data
+    * as the source DynamoDB database.
+    *
+    * @return A list of comparison failures (which is empty if the data
+    *         are the same in both databases).
+    */
+  def runValidation(
+    sourceSettings: SourceSettings.DynamoDB,
+    targetSettings: TargetSettings.DynamoDB,
+    config: MigratorConfig)(implicit spark: SparkSession): List[RowComparisonFailure] = {
+
+    val (source, sourceTableDesc) = readers.DynamoDB.readRDD(spark, sourceSettings)
+    val sourceTableKeys = sourceTableDesc.getKeySchema.asScala.toList
+
+    val sourceByKey: RDD[(List[AttributeValue], util.Map[String, AttributeValue])] =
+      source
+        .map {
+          case (_, item) =>
+            val key = sourceTableKeys
+              .map(keySchemaElement => item.getItem.get(keySchemaElement.getAttributeName))
+            (key, item.getItem)
+        }
+
+    val (target, _) = readers.DynamoDB.readRDD(
+      spark,
+      targetSettings.endpoint,
+      targetSettings.credentials,
+      targetSettings.region,
+      targetSettings.table
+    ) { (jobConf, targetTableDesc) =>
+      setDynamoDBJobConf(
+        jobConf,
+        targetSettings.region,
+        targetSettings.endpoint,
+        targetSettings.scanSegments,
+        targetSettings.maxMapTasks,
+        targetSettings.credentials)
+      jobConf.set(DynamoDBConstants.INPUT_TABLE_NAME, targetSettings.table)
+      setOptionalConf(
+        jobConf,
+        DynamoDBConstants.READ_THROUGHPUT,
+        tableThroughput(Option(targetTableDesc)))
+    }
+
+    // Define some aliases to prevent the Spark engine to try to serialize the whole object graph
+    val renamedColumn = config.renamesMap
+    val configValidation = config.validation
+
+    val targetByKey: RDD[(List[AttributeValue], util.Map[String, AttributeValue])] =
+      target
+        .map {
+          case (_, item) =>
+            val key = sourceTableKeys
+              .map { keySchemaElement =>
+                val columnName = keySchemaElement.getAttributeName
+                item.getItem.get(renamedColumn(columnName))
+              }
+            (key, item.getItem)
+        }
+
+    sourceByKey
+      .leftOuterJoin(targetByKey)
+      .flatMap {
+        case (_, (l, r)) =>
+          RowComparisonFailure.compareDynamoDBRows(
+            l.asScala.toMap,
+            r.map(_.asScala.toMap),
+            renamedColumn,
+            configValidation.floatingPointTolerance
+          )
+      }
+      .take(config.validation.failuresToFetch)
+      .toList
+  }
+
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
@@ -15,6 +15,10 @@ case class MigratorConfig(source: SourceSettings,
                           skipTokenRanges: Set[(Token[_], Token[_])],
                           validation: Validation) {
   def render: String = this.asJson.asYaml.spaces2
+
+  /** The list of renames modelled as a Map from the old column name to the new column name */
+  lazy val renamesMap: Map[String, String] =
+    renames.map(rename => rename.from -> rename.to).toMap.withDefault(identity)
 }
 object MigratorConfig {
   implicit val tokenEncoder: Encoder[Token[_]] = Encoder.instance {

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
@@ -1,50 +1,66 @@
 package com.scylladb.migrator.readers
 
 import com.amazonaws.services.dynamodbv2.model.TableDescription
+import com.scylladb.migrator.DynamoUtils
 import com.scylladb.migrator.DynamoUtils.{ setDynamoDBJobConf, setOptionalConf }
-import com.scylladb.migrator.config.SourceSettings
+import com.scylladb.migrator.config.{ AWSCredentials, DynamoDBEndpoint, SourceSettings }
 import org.apache.hadoop.dynamodb.{ DynamoDBConstants, DynamoDBItemWritable }
 import org.apache.hadoop.dynamodb.read.DynamoDBInputFormat
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapred.JobConf
-import org.apache.log4j.LogManager
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 
 object DynamoDB {
-  val log = LogManager.getLogger("com.scylladb.migrator.readers.DynamoDB")
 
+  def readRDD(
+    spark: SparkSession,
+    source: SourceSettings.DynamoDB): (RDD[(Text, DynamoDBItemWritable)], TableDescription) =
+    readRDD(spark, source.endpoint, source.credentials, source.region, source.table) {
+      (jobConf, description) =>
+        setDynamoDBJobConf(
+          jobConf,
+          source.region,
+          source.endpoint,
+          source.scanSegments,
+          source.maxMapTasks,
+          source.credentials)
+        jobConf.set(DynamoDBConstants.INPUT_TABLE_NAME, source.table)
+        setOptionalConf(
+          jobConf,
+          DynamoDBConstants.READ_THROUGHPUT,
+          DynamoUtils.tableThroughput(Option(description)))
+        setOptionalConf(
+          jobConf,
+          DynamoDBConstants.THROUGHPUT_READ_PERCENT,
+          source.throughputReadPercent.map(_.toString))
+    }
+
+  /**
+    * A lower-level overload of `readRDD` that expects the caller to fully configure the Hadoop JobConf
+    * with the provided `configureJobConf` parameter.
+    */
   def readRDD(spark: SparkSession,
-              source: SourceSettings.DynamoDB,
-              description: TableDescription): RDD[(Text, DynamoDBItemWritable)] = {
-    val provisionedThroughput = Option(description.getProvisionedThroughput)
-    val readThroughput = provisionedThroughput.flatMap(p => Option(p.getReadCapacityUnits))
-    val writeThroughput = provisionedThroughput.flatMap(p => Option(p.getWriteCapacityUnits))
-
-    val throughput =
-      if (readThroughput.isEmpty || writeThroughput.isEmpty) Some("25")
-      else None
+              endpoint: Option[DynamoDBEndpoint],
+              credentials: Option[AWSCredentials],
+              region: Option[String],
+              table: String)(
+    configureJobConf: (JobConf, TableDescription) => Unit
+  ): (RDD[(Text, DynamoDBItemWritable)], TableDescription) = {
+    val description = DynamoUtils
+      .buildDynamoClient(endpoint, credentials, region)
+      .describeTable(table)
+      .getTable
 
     val jobConf = new JobConf(spark.sparkContext.hadoopConfiguration)
-    setDynamoDBJobConf(
-      jobConf,
-      source.region,
-      source.endpoint,
-      source.scanSegments,
-      source.maxMapTasks,
-      source.credentials)
-    jobConf.set(DynamoDBConstants.INPUT_TABLE_NAME, source.table)
-    setOptionalConf(jobConf, DynamoDBConstants.READ_THROUGHPUT, throughput)
-    setOptionalConf(
-      jobConf,
-      DynamoDBConstants.THROUGHPUT_READ_PERCENT,
-      source.throughputReadPercent.map(_.toString))
-
-    spark.sparkContext.hadoopRDD(
-      jobConf,
-      classOf[DynamoDBInputFormat],
-      classOf[Text],
-      classOf[DynamoDBItemWritable])
+    configureJobConf(jobConf, description)
+    val rdd =
+      spark.sparkContext.hadoopRDD(
+        jobConf,
+        classOf[DynamoDBInputFormat],
+        classOf[Text],
+        classOf[DynamoDBItemWritable])
+    (rdd, description)
   }
 
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
@@ -1,29 +1,20 @@
 package com.scylladb.migrator.writers
 
 import com.amazonaws.services.dynamodbv2.model.TableDescription
-import com.scylladb.migrator.DynamoUtils.{ setDynamoDBJobConf, setOptionalConf }
+import com.scylladb.migrator.DynamoUtils.{ setDynamoDBJobConf, setOptionalConf, tableThroughput }
 import com.scylladb.migrator.config.{ Rename, TargetSettings }
 import org.apache.hadoop.dynamodb.{ DynamoDBConstants, DynamoDBItemWritable }
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapred.JobConf
-import org.apache.log4j.LogManager
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 
 object DynamoDB {
-  val log = LogManager.getLogger("com.scylladb.migrator.writers.DynamoDB")
 
   def writeRDD(target: TargetSettings.DynamoDB,
                renames: List[Rename],
                rdd: RDD[(Text, DynamoDBItemWritable)],
                targetTableDesc: Option[TableDescription])(implicit spark: SparkSession): Unit = {
-    val provisionedThroughput = targetTableDesc.flatMap(p => Option(p.getProvisionedThroughput))
-    val readThroughput = provisionedThroughput.flatMap(p => Option(p.getReadCapacityUnits))
-    val writeThroughput = provisionedThroughput.flatMap(p => Option(p.getWriteCapacityUnits))
-
-    val throughput =
-      if (readThroughput.isEmpty || writeThroughput.isEmpty) Some("25")
-      else None
 
     val jobConf = new JobConf(spark.sparkContext.hadoopConfiguration)
 
@@ -35,7 +26,7 @@ object DynamoDB {
       target.maxMapTasks,
       target.credentials)
     jobConf.set(DynamoDBConstants.OUTPUT_TABLE_NAME, target.table)
-    setOptionalConf(jobConf, DynamoDBConstants.WRITE_THROUGHPUT, throughput)
+    setOptionalConf(jobConf, DynamoDBConstants.WRITE_THROUGHPUT, tableThroughput(targetTableDesc))
     setOptionalConf(
       jobConf,
       DynamoDBConstants.THROUGHPUT_WRITE_PERCENT,

--- a/tests/src/test/scala/com/scylladb/migrator/AttributeValueUtils.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/AttributeValueUtils.scala
@@ -1,0 +1,22 @@
+package com.scylladb.migrator
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+
+import scala.jdk.CollectionConverters._
+
+/** Convenient factories to create `AttributeValue` objects */
+object AttributeValueUtils {
+
+  def stringValue(value: String): AttributeValue =
+    new AttributeValue().withS(value)
+
+  def numericalValue(value: String): AttributeValue =
+    new AttributeValue().withN(value)
+
+  def boolValue(value: Boolean): AttributeValue =
+    new AttributeValue().withBOOL(value)
+
+  def mapValue(items: (String, AttributeValue)*): AttributeValue =
+    new AttributeValue().withM(items.toMap.asJava)
+
+}

--- a/tests/src/test/scala/com/scylladb/migrator/CassandraUtils.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/CassandraUtils.scala
@@ -7,14 +7,17 @@ import com.datastax.oss.driver.api.querybuilder.SchemaBuilder
 object CassandraUtils {
 
   /**
-   * Prepare a Scylla table for a test. Drop any existing table of the same name and recreates it.
-   *
-   * @param database   Database session to use
-   * @param keyspace   Keyspace name
-   * @param name       Name of the table to create
-   * @param columnName Function to possible transform the initial name of the columns
-   */
-  def dropAndRecreateTable(database: CqlSession, keyspace: String, name: String, columnName: String => String): Unit = {
+    * Prepare a Scylla table for a test. Drop any existing table of the same name and recreates it.
+    *
+    * @param database   Database session to use
+    * @param keyspace   Keyspace name
+    * @param name       Name of the table to create
+    * @param columnName Function to possible transform the initial name of the columns
+    */
+  def dropAndRecreateTable(database: CqlSession,
+                           keyspace: String,
+                           name: String,
+                           columnName: String => String): Unit = {
     val dropTableStatement =
       SchemaBuilder
         .dropTable(keyspace, name)

--- a/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
@@ -5,40 +5,50 @@ import scala.sys.process.Process
 object SparkUtils {
 
   /**
-   * Run a migration by submitting a Spark job to the Spark cluster
-   * and waiting for its successful completion.
-   *
-   * @param configFile Configuration file to use. Write your
-   *                   configuration files in the directory
-   *                   `src/test/configurations`, which is
-   *                   automatically mounted to the Spark
-   *                   cluster by Docker Compose.
-   */
-  def submitMigrationJob(configFile: String): Unit = {
-    val process =
-      Process(
-        Seq(
-          "docker",
-          "compose",
-          "-f", "docker-compose-tests.yml",
-          "exec",
-          "spark-master",
-          "/spark/bin/spark-submit",
-          "--class", "com.scylladb.migrator.Migrator",
-          "--master", "spark://spark-master:7077",
-          "--conf", "spark.driver.host=spark-master",
-          "--conf", s"spark.scylla.config=/app/configurations/${configFile}",
-          // Uncomment one of the following lines to plug a remote debugger on the Spark master or worker.
-          // "--conf", "spark.driver.extraJavaOptions=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005",
-          // "--conf", "spark.executor.extraJavaOptions=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006",
-          "/jars/scylla-migrator-assembly-0.0.1.jar"
-        )
-      )
-    process
-      .run()
+    * Run a migration by submitting a Spark job to the Spark cluster
+    * and waiting for its successful completion.
+    *
+    * @param migratorConfigFile Configuration file to use. Write your
+    *                           configuration files in the directory
+    *                           `src/test/configurations`, which is
+    *                           automatically mounted to the Spark
+    *                           cluster by Docker Compose.
+    */
+  def successfullyPerformMigration(migratorConfigFile: String): Unit = {
+    submitSparkJob(migratorConfigFile, "com.scylladb.migrator.Migrator")
       .exitValue()
       .ensuring(statusCode => statusCode == 0, "Spark job failed")
     ()
   }
+
+  /**
+    * @param migratorConfigFile Configuration file to use
+    * @param entryPoint         Java entry point of the job
+    * @return The running process
+    */
+  def submitSparkJob(migratorConfigFile: String, entryPoint: String): Process =
+    Process(
+      Seq(
+        "docker",
+        "compose",
+        "-f",
+        "docker-compose-tests.yml",
+        "exec",
+        "spark-master",
+        "/spark/bin/spark-submit",
+        "--class",
+        entryPoint,
+        "--master",
+        "spark://spark-master:7077",
+        "--conf",
+        "spark.driver.host=spark-master",
+        "--conf",
+        s"spark.scylla.config=/app/configurations/${migratorConfigFile}",
+        // Uncomment one of the following lines to plug a remote debugger on the Spark master or worker.
+        // "--conf", "spark.driver.extraJavaOptions=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005",
+        // "--conf", "spark.executor.extraJavaOptions=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006",
+        "/jars/scylla-migrator-assembly-0.0.1.jar"
+      )
+    ).run()
 
 }

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/BasicMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/BasicMigrationTest.scala
@@ -1,7 +1,8 @@
 package com.scylladb.migrator.alternator
 
-import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest}
-import com.scylladb.migrator.SparkUtils.submitMigrationJob
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest
+import com.scylladb.migrator.AttributeValueUtils.stringValue
+import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
 
 import scala.collection.JavaConverters._
 import scala.util.chaining._
@@ -9,15 +10,15 @@ import scala.util.chaining._
 class BasicMigrationTest extends MigratorSuite {
 
   withTable("BasicTest").test("Read from source and write to target") { tableName =>
-    val keys = Map("id"   -> new AttributeValue().withS("12345"))
-    val attrs = Map("foo" -> new AttributeValue().withS("bar"))
+    val keys = Map("id"   -> stringValue("12345"))
+    val attrs = Map("foo" -> stringValue("bar"))
     val itemData = keys ++ attrs
 
     // Insert some items
     sourceDDb.putItem(tableName, itemData.asJava)
 
     // Perform the migration
-    submitMigrationJob("dynamodb-to-alternator-basic.yaml")
+    successfullyPerformMigration("dynamodb-to-alternator-basic.yaml")
 
     // Check that the schema has been replicated to the target table
     val sourceTableDesc = sourceDDb.describeTable(tableName).getTable

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
@@ -1,18 +1,18 @@
 package com.scylladb.migrator.alternator
 
-import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.auth.{ AWSStaticCredentialsProvider, BasicAWSCredentials }
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.dynamodbv2.model._
-import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClientBuilder}
+import com.amazonaws.services.dynamodbv2.{ AmazonDynamoDB, AmazonDynamoDBClientBuilder }
 
 import scala.util.chaining._
 
 /**
- * Base class for implementing end-to-end tests.
- *
- * It expects external services (DynamoDB, Scylla, Spark, etc.) to be running.
- * See the files `CONTRIBUTING.md` and `docker-compose-tests.yml` for more information.
- */
+  * Base class for implementing end-to-end tests.
+  *
+  * It expects external services (DynamoDB, Scylla, Spark, etc.) to be running.
+  * See the files `CONTRIBUTING.md` and `docker-compose-tests.yml` for more information.
+  */
 trait MigratorSuite extends munit.FunSuite {
 
   /** Client of a source DynamoDB instance */
@@ -30,16 +30,16 @@ trait MigratorSuite extends munit.FunSuite {
     .build()
 
   /**
-   * Fixture automating the house-keeping work when migrating a table.
-   *
-   * It deletes the table from both the source and target databases in case it was already
-   * existing, and then recreates it in the source database.
-   *
-   * After the test is executed, it deletes the table from both the source and target
-   * databases.
-   *
-   * @param name Name of the table
-   */
+    * Fixture automating the house-keeping work when migrating a table.
+    *
+    * It deletes the table from both the source and target databases in case it was already
+    * existing, and then recreates it in the source database.
+    *
+    * After the test is executed, it deletes the table from both the source and target
+    * databases.
+    *
+    * @param name Name of the table
+    */
   def withTable(name: String): FunFixture[String] = FunFixture(
     setup = { _ =>
       def deleteTableIfExists(database: AmazonDynamoDB): Unit =

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/RenamedItemsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/RenamedItemsTest.scala
@@ -1,7 +1,8 @@
 package com.scylladb.migrator.alternator
 
-import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest}
-import com.scylladb.migrator.SparkUtils.submitMigrationJob
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest
+import com.scylladb.migrator.AttributeValueUtils.{ boolValue, stringValue }
+import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
 
 import scala.collection.JavaConverters._
 import scala.util.chaining._
@@ -10,14 +11,14 @@ class RenamedItemsTest extends MigratorSuite {
 
   withTable("RenamedItems").test("Rename items along the migration") { tableName =>
     // Insert several items
-    val keys1 = Map("id" -> new AttributeValue().withS("12345"))
-    val attrs1 = Map("foo" -> new AttributeValue().withS("bar"))
+    val keys1 = Map("id"   -> stringValue("12345"))
+    val attrs1 = Map("foo" -> stringValue("bar"))
     val item1Data = keys1 ++ attrs1
 
-    val keys2 = Map("id" -> new AttributeValue().withS("67890"))
+    val keys2 = Map("id" -> stringValue("67890"))
     val attrs2 = Map(
-      "foo" -> new AttributeValue().withS("baz"),
-      "baz" -> new AttributeValue().withBOOL(false)
+      "foo" -> stringValue("baz"),
+      "baz" -> boolValue(false)
     )
     val item2Data = keys2 ++ attrs2
 
@@ -25,7 +26,7 @@ class RenamedItemsTest extends MigratorSuite {
     sourceDDb.putItem(tableName, item2Data.asJava)
 
     // Perform the migration
-    submitMigrationJob("dynamodb-to-alternator-renames.yaml")
+    successfullyPerformMigration("dynamodb-to-alternator-renames.yaml")
 
     val renamedItem1Data =
       item1Data + ("quux" -> item1Data("foo")) - "foo"

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/ValidatorTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/ValidatorTest.scala
@@ -1,0 +1,45 @@
+package com.scylladb.migrator.alternator
+
+import com.amazonaws.services.dynamodbv2.model.{ AttributeAction, AttributeValueUpdate }
+import com.scylladb.migrator.AttributeValueUtils.stringValue
+import com.scylladb.migrator.SparkUtils.{ submitSparkJob, successfullyPerformMigration }
+
+import scala.jdk.CollectionConverters._
+import scala.util.chaining._
+
+class ValidatorTest extends MigratorSuite {
+
+  withTable("BasicTest").test("Validate migration") { tableName =>
+    val configFile = "dynamodb-to-alternator-basic.yaml"
+
+    val keys = Map("id"   -> stringValue("12345"))
+    val attrs = Map("foo" -> stringValue("bar"))
+    val itemData = keys ++ attrs
+
+    // Insert some items
+    sourceDDb.putItem(tableName, itemData.asJava)
+
+    // Perform the migration
+    successfullyPerformMigration(configFile)
+
+    // Perform the validation
+    submitSparkJob(configFile, "com.scylladb.migrator.Validator").exitValue().tap { statusCode =>
+      assertEquals(statusCode, 0, "Validation failed")
+    }
+
+    // Change the value of an item
+    targetAlternator.updateItem(
+      tableName,
+      keys.asJava,
+      Map(
+        "foo" -> new AttributeValueUpdate()
+          .withValue(stringValue("baz"))
+          .withAction(AttributeAction.PUT)).asJava)
+
+    // Check that the validation failed because of the introduced change
+    submitSparkJob(configFile, "com.scylladb.migrator.Validator").exitValue().tap { statusCode =>
+      assertEquals(statusCode, 1)
+    }
+  }
+
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/BasicMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/BasicMigrationTest.scala
@@ -3,7 +3,7 @@ package com.scylladb.migrator.scylla
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal
 import com.datastax.oss.driver.api.querybuilder.term.Term
-import com.scylladb.migrator.SparkUtils.submitMigrationJob
+import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
 
 import scala.jdk.CollectionConverters._
 import scala.util.chaining._
@@ -14,17 +14,18 @@ class BasicMigrationTest extends MigratorSuite(sourcePort = 9043) {
     val insertStatement =
       QueryBuilder
         .insertInto(keyspace, tableName)
-        .values(Map[String, Term](
-          "id" -> literal("12345"),
-          "foo" -> literal("bar")
-        ).asJava)
+        .values(
+          Map[String, Term](
+            "id"  -> literal("12345"),
+            "foo" -> literal("bar")
+          ).asJava)
         .build()
 
     // Insert some items
     sourceCassandra.execute(insertStatement)
 
     // Perform the migration
-    submitMigrationJob("cassandra-to-scylla-basic.yaml")
+    successfullyPerformMigration("cassandra-to-scylla-basic.yaml")
 
     // Check that the item has been migrated to the target table
     val selectAllStatement = QueryBuilder

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/MigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/MigratorSuite.scala
@@ -8,13 +8,13 @@ import java.net.InetSocketAddress
 import scala.jdk.CollectionConverters._
 
 /**
- * Base class for implementing end-to-end tests.
- *
- * It expects external services (Cassandra, Scylla, Spark, etc.) to be running.
- * See the files `CONTRIBUTING.md` and `docker-compose-tests.yml` for more information.
- *
- * @param sourcePort TCP port of the source database. See docker-compose-test.yml.
- */
+  * Base class for implementing end-to-end tests.
+  *
+  * It expects external services (Cassandra, Scylla, Spark, etc.) to be running.
+  * See the files `CONTRIBUTING.md` and `docker-compose-tests.yml` for more information.
+  *
+  * @param sourcePort TCP port of the source database. See docker-compose-test.yml.
+  */
 abstract class MigratorSuite(sourcePort: Int) extends munit.FunSuite {
 
   val keyspace = "test"
@@ -36,43 +36,50 @@ abstract class MigratorSuite(sourcePort: Int) extends munit.FunSuite {
     .build()
 
   /**
-   * Fixture automating the house-keeping work when migrating a table.
-   *
-   * It deletes the table from both the source and target databases in case it was already
-   * existing, and then recreates it in the source database.
-   *
-   * After the test is executed, it deletes the table from both the source and target
-   * databases.
-   *
-   * @param name Name of the table
-   */
-  def withTable(name: String, renames: Map[String, String] = Map.empty): FunFixture[String] = FunFixture(
-    setup = { _ =>
-      // Make sure the source and target databases do not contain the table already
-      try {
-        dropAndRecreateTable(sourceCassandra, keyspace, name, columnName = identity)
-        dropAndRecreateTable(targetScylla, keyspace, name, columnName = originalName => renames.getOrElse(originalName, originalName))
-      } catch {
-        case any: Throwable =>
-          fail(s"Something did not work as expected", any)
+    * Fixture automating the house-keeping work when migrating a table.
+    *
+    * It deletes the table from both the source and target databases in case it was already
+    * existing, and then recreates it in the source database.
+    *
+    * After the test is executed, it deletes the table from both the source and target
+    * databases.
+    *
+    * @param name Name of the table
+    */
+  def withTable(name: String, renames: Map[String, String] = Map.empty): FunFixture[String] =
+    FunFixture(
+      setup = { _ =>
+        // Make sure the source and target databases do not contain the table already
+        try {
+          dropAndRecreateTable(sourceCassandra, keyspace, name, columnName = identity)
+          dropAndRecreateTable(
+            targetScylla,
+            keyspace,
+            name,
+            columnName = originalName => renames.getOrElse(originalName, originalName))
+        } catch {
+          case any: Throwable =>
+            fail(s"Something did not work as expected", any)
+        }
+        name
+      },
+      teardown = { _ =>
+        // Clean-up both the source and target databases
+        val dropTableQuery = SchemaBuilder.dropTable(keyspace, name).build()
+        targetScylla.execute(dropTableQuery)
+        sourceCassandra.execute(dropTableQuery)
+        ()
       }
-      name
-    },
-    teardown = { _ =>
-      // Clean-up both the source and target databases
-      val dropTableQuery = SchemaBuilder.dropTable(keyspace, name).build()
-      targetScylla.execute(dropTableQuery)
-      sourceCassandra.execute(dropTableQuery)
-      ()
-    }
-  )
+    )
 
   override def beforeAll(): Unit = {
     val keyspaceStatement =
       SchemaBuilder
         .createKeyspace(keyspace)
         .ifNotExists()
-        .withReplicationOptions(Map[String, AnyRef]("class" -> "SimpleStrategy", "replication_factor" -> new Integer(1)).asJava)
+        .withReplicationOptions(Map[String, AnyRef](
+          "class"              -> "SimpleStrategy",
+          "replication_factor" -> new Integer(1)).asJava)
         .build()
     sourceCassandra.execute(keyspaceStatement)
     targetScylla.execute(keyspaceStatement)

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetToScyllaBasicMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetToScyllaBasicMigrationTest.scala
@@ -1,10 +1,10 @@
 package com.scylladb.migrator.scylla
 
 import com.datastax.oss.driver.api.core.CqlSession
-import com.datastax.oss.driver.api.querybuilder.{QueryBuilder, SchemaBuilder}
+import com.datastax.oss.driver.api.querybuilder.{ QueryBuilder, SchemaBuilder }
 import com.github.mjakubowski84.parquet4s.ParquetWriter
 import com.scylladb.migrator.CassandraUtils.dropAndRecreateTable
-import com.scylladb.migrator.SparkUtils.submitMigrationJob
+import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
 import com.scylladb.migrator.scylla.ParquetToScyllaBasicMigrationTest.BasicTestSchema
 import org.apache.parquet.hadoop.ParquetFileWriter
 
@@ -29,7 +29,9 @@ class ParquetToScyllaBasicMigrationTest extends munit.FunSuite {
       SchemaBuilder
         .createKeyspace(keyspace)
         .ifNotExists()
-        .withReplicationOptions(Map[String, AnyRef]("class" -> "SimpleStrategy", "replication_factor" -> new Integer(1)).asJava)
+        .withReplicationOptions(Map[String, AnyRef](
+          "class"              -> "SimpleStrategy",
+          "replication_factor" -> new Integer(1)).asJava)
         .build()
     targetScylla.execute(keyspaceStatement)
 
@@ -44,7 +46,7 @@ class ParquetToScyllaBasicMigrationTest extends munit.FunSuite {
     dropAndRecreateTable(targetScylla, keyspace, tableName, identity)
 
     // Perform the migration
-    submitMigrationJob("parquet-to-scylla-basic.yaml")
+    successfullyPerformMigration("parquet-to-scylla-basic.yaml")
 
     // Check that the item has been migrated to the target table
     val selectAllStatement = QueryBuilder

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/RenamedItemsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/RenamedItemsTest.scala
@@ -3,43 +3,45 @@ package com.scylladb.migrator.scylla
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal
 import com.datastax.oss.driver.api.querybuilder.term.Term
-import com.scylladb.migrator.SparkUtils.submitMigrationJob
+import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
 
 import scala.jdk.CollectionConverters._
 import scala.util.chaining._
 
 class RenamedItemsTest extends MigratorSuite(sourcePort = 9043) {
 
-  withTable("RenamedItems", renames = Map("bar" -> "quux")).test("Read from source and write to target") { tableName =>
-    val insertStatement =
-      QueryBuilder
-        .insertInto(keyspace, tableName)
-        .values(Map[String, Term](
-          "id" -> literal("12345"),
-          "foo" -> literal("bar"),
-          "bar" -> literal(42)
-        ).asJava)
+  withTable("RenamedItems", renames = Map("bar" -> "quux"))
+    .test("Read from source and write to target") { tableName =>
+      val insertStatement =
+        QueryBuilder
+          .insertInto(keyspace, tableName)
+          .values(
+            Map[String, Term](
+              "id"  -> literal("12345"),
+              "foo" -> literal("bar"),
+              "bar" -> literal(42)
+            ).asJava)
+          .build()
+
+      // Insert some items
+      sourceCassandra.execute(insertStatement)
+
+      // Perform the migration
+      successfullyPerformMigration("cassandra-to-scylla-renames.yaml")
+
+      // Check that the item has been migrated to the target table
+      val selectAllStatement = QueryBuilder
+        .selectFrom(keyspace, tableName)
+        .all()
         .build()
-
-    // Insert some items
-    sourceCassandra.execute(insertStatement)
-
-    // Perform the migration
-    submitMigrationJob("cassandra-to-scylla-renames.yaml")
-
-    // Check that the item has been migrated to the target table
-    val selectAllStatement = QueryBuilder
-      .selectFrom(keyspace, tableName)
-      .all()
-      .build()
-    targetScylla.execute(selectAllStatement).tap { resultSet =>
-      val rows = resultSet.all().asScala
-      assertEquals(rows.size, 1)
-      val row = rows.head
-      assertEquals(row.getString("id"), "12345")
-      assertEquals(row.getString("foo"), "bar")
-      assertEquals(row.getInt("quux"), 42)
+      targetScylla.execute(selectAllStatement).tap { resultSet =>
+        val rows = resultSet.all().asScala
+        assertEquals(rows.size, 1)
+        val row = rows.head
+        assertEquals(row.getString("id"), "12345")
+        assertEquals(row.getString("foo"), "bar")
+        assertEquals(row.getInt("quux"), 42)
+      }
     }
-  }
 
 }

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaToScyllaBasicMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaToScyllaBasicMigrationTest.scala
@@ -3,7 +3,7 @@ package com.scylladb.migrator.scylla
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal
 import com.datastax.oss.driver.api.querybuilder.term.Term
-import com.scylladb.migrator.SparkUtils.submitMigrationJob
+import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
 
 import scala.jdk.CollectionConverters._
 import scala.util.chaining._
@@ -14,17 +14,18 @@ class ScyllaToScyllaBasicMigrationTest extends MigratorSuite(sourcePort = 9044) 
     val insertStatement =
       QueryBuilder
         .insertInto(keyspace, tableName)
-        .values(Map[String, Term](
-          "id" -> literal("12345"),
-          "foo" -> literal("bar")
-        ).asJava)
+        .values(
+          Map[String, Term](
+            "id"  -> literal("12345"),
+            "foo" -> literal("bar")
+          ).asJava)
         .build()
 
     // Insert some items
     sourceCassandra.execute(insertStatement)
 
     // Perform the migration
-    submitMigrationJob("scylla-to-scylla-basic.yaml")
+    successfullyPerformMigration("scylla-to-scylla-basic.yaml")
 
     // Check that the item has been migrated to the target table
     val selectAllStatement = QueryBuilder

--- a/tests/src/test/scala/com/scylladb/migrator/validation/RowComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/RowComparisonTest.scala
@@ -1,0 +1,121 @@
+package com.scylladb.migrator.validation
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import com.scylladb.migrator.AttributeValueUtils.{ numericalValue, stringValue }
+import com.scylladb.migrator.validation.RowComparisonFailure.{ dynamoDBRowComparisonFailure, Item }
+
+class RowComparisonTest extends munit.FunSuite {
+
+  val sameColumns: String => String = identity
+  val floatingPointTolerance: Double = 0.01
+  val item: Map[String, AttributeValue] = Map("foo" -> stringValue("bar"))
+
+  test("No difference") {
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      item,
+      Some(item),
+      sameColumns,
+      floatingPointTolerance
+    )
+    assertEquals(result, None)
+  }
+
+  test("No difference with renamed column") {
+    // Same as `item` but with column `foo` renamed to `quux`
+    val renamedItem = Map("quux" -> stringValue("bar"))
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      item,
+      Some(renamedItem),
+      Map("foo" -> "quux").withDefault(identity),
+      floatingPointTolerance
+    )
+    assertEquals(result, None)
+  }
+
+  test("Missing row") {
+    val result =
+      RowComparisonFailure.compareDynamoDBRows(
+        item,
+        None,
+        sameColumns,
+        floatingPointTolerance
+      )
+    val expected =
+      Some(dynamoDBRowComparisonFailure(item, None, List(Item.MissingTargetRow)))
+    assertEquals(result, expected)
+  }
+
+  test("Missing column") {
+    val result =
+      RowComparisonFailure.compareDynamoDBRows(
+        item,
+        Some(Map.empty),
+        sameColumns,
+        floatingPointTolerance
+      )
+    val expected =
+      Some(dynamoDBRowComparisonFailure(item, Some(Map.empty), List(Item.MismatchedColumnCount)))
+    assertEquals(result, expected)
+  }
+
+  test("Misspelled column") {
+    val otherItem = Map("baz" -> stringValue("bah"))
+    val result =
+      RowComparisonFailure.compareDynamoDBRows(
+        item,
+        Some(otherItem),
+        sameColumns,
+        floatingPointTolerance
+      )
+    val expected =
+      Some(dynamoDBRowComparisonFailure(item, Some(otherItem), List(Item.MismatchedColumnNames)))
+    assertEquals(result, expected)
+  }
+
+  test("Incorrect value") {
+    val otherItem = Map("foo" -> stringValue("boom"))
+    val result =
+      RowComparisonFailure.compareDynamoDBRows(
+        item,
+        Some(otherItem),
+        sameColumns,
+        floatingPointTolerance
+      )
+    val expected =
+      Some(
+        dynamoDBRowComparisonFailure(
+          item,
+          Some(otherItem),
+          List(Item.DifferingFieldValues(List("foo")))))
+    assertEquals(result, expected)
+  }
+
+  test("Numerical values within the tolerance threshold") {
+    val numericalItem =
+      Map(
+        "foo" -> numericalValue("123.456"),
+        "bar" -> numericalValue("789.012")
+      )
+    val otherNumericalItem =
+      Map(
+        "foo" -> numericalValue("123.457"), // +0.001
+        "bar" -> numericalValue("789.112") // +0.1
+      )
+    val result =
+      RowComparisonFailure.compareDynamoDBRows(
+        numericalItem,
+        Some(otherNumericalItem),
+        sameColumns,
+        floatingPointTolerance
+      )
+    // Only the field `bar` is reported to be different because `foo` is still within the tolerance threshold
+    val expected =
+      Some(
+        dynamoDBRowComparisonFailure(
+          numericalItem,
+          Some(otherNumericalItem),
+          List(Item.DifferingFieldValues(List("bar")))))
+    assertEquals(result, expected)
+  }
+
+}


### PR DESCRIPTION
Fixes #118

There are two types of tests:
- end to end tests on the containerized environment ([ValidatorTest](https://github.com/scylladb/scylla-migrator/pull/126/files#diff-2bbf7f7ec35103413b2e30b82402123ad00c3833cd561c471ae760464bb25498))
- unit tests that are cheaper to execute and check more validation scenarios ([RowComparisonTest](https://github.com/scylladb/scylla-migrator/pull/126/files#diff-f86c5cd3ca0a11c25b6f40f51d21dad3b8eb8d8bca8edd3a18c1226a25f907de))