### PR TITLE
Add Validator tests to cover C* migrations

### DIFF
--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ValidatorTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ValidatorTest.scala
@@ -1,0 +1,52 @@
+package com.scylladb.migrator.scylla
+
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal
+import com.datastax.oss.driver.api.querybuilder.term.Term
+import com.scylladb.migrator.SparkUtils.{submitSparkJob, successfullyPerformMigration}
+
+import scala.jdk.CollectionConverters._
+import scala.util.chaining.scalaUtilChainingOps
+
+class ValidatorTest extends MigratorSuite(sourcePort = 9043) {
+
+  withTable("BasicTest").test("Validate migration") { tableName =>
+    val configFile = "cassandra-to-scylla-basic.yaml"
+
+    // Insert some items
+    val insertStatement =
+      QueryBuilder
+        .insertInto(keyspace, tableName)
+        .values(
+          Map[String, Term](
+            "id"  -> literal("12345"),
+            "foo" -> literal("bar")
+          ).asJava)
+        .build()
+    sourceCassandra.execute(insertStatement)
+
+    // Perform the migration
+    successfullyPerformMigration(configFile)
+
+    // Perform the validation
+    submitSparkJob(configFile, "com.scylladb.migrator.Validator").exitValue().tap { statusCode =>
+      assertEquals(statusCode, 0, "Validation failed")
+    }
+
+    // Change the value of an item
+    val updateStatement =
+      QueryBuilder
+        .update(keyspace, tableName)
+        .setColumn("foo", literal("baz"))
+        .whereColumn("id").isEqualTo(literal("12345"))
+        .build()
+    targetScylla.execute(updateStatement)
+
+    // Check that the validation failed because of the introduced change
+    submitSparkJob(configFile, "com.scylladb.migrator.Validator").exitValue().tap { statusCode =>
+      assertEquals(statusCode, 1)
+    }
+
+  }
+
+}

--- a/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
@@ -1,0 +1,99 @@
+package com.scylladb.migrator.validation
+
+import com.datastax.spark.connector.CassandraRow
+import com.scylladb.migrator.validation.RowComparisonFailure.{ cassandraRowComparisonFailure, Item }
+
+class CassandraRowComparisonTest extends munit.FunSuite {
+
+  val item: CassandraRow = CassandraRow.fromMap(Map("foo" -> "bar"))
+
+  def compareItems(
+    item: CassandraRow,
+    maybeOther: Option[CassandraRow],
+    floatingPointTolerance: Double = 0.0001,
+    timestampMsTolerance: Long = 1L,
+    ttlToleranceMillis: Long = 1L,
+    writetimeToleranceMillis: Long = 1L,
+    compareTimestamps: Boolean = true
+  ): Option[RowComparisonFailure] =
+    RowComparisonFailure.compareCassandraRows(
+      item,
+      maybeOther,
+      floatingPointTolerance,
+      timestampMsTolerance,
+      ttlToleranceMillis,
+      writetimeToleranceMillis,
+      compareTimestamps
+    )
+
+  test("No difference") {
+    val result = compareItems(item, Some(item))
+    assertEquals(result, None)
+  }
+
+  test("Missing row") {
+    val result = compareItems(item, None)
+    val expected =
+      Some(cassandraRowComparisonFailure(item, None, List(Item.MissingTargetRow)))
+    assertEquals(result, expected)
+  }
+
+  test("Missing column") {
+    val otherItem = CassandraRow.fromMap(Map.empty)
+    val result =
+      compareItems(item, Some(otherItem))
+    val expected =
+      Some(cassandraRowComparisonFailure(item, Some(otherItem), List(Item.MismatchedColumnCount)))
+    assertEquals(result, expected)
+  }
+
+  test("Misspelled column") {
+    val otherItem = CassandraRow.fromMap(Map("baz" -> "bah"))
+    val result = compareItems(item, Some(otherItem))
+    val expected =
+      Some(cassandraRowComparisonFailure(item, Some(otherItem), List(Item.MismatchedColumnNames)))
+    assertEquals(result, expected)
+  }
+
+  test("Incorrect value") {
+    val otherItem = CassandraRow.fromMap(Map("foo" -> "boom"))
+    val result = compareItems(item, Some(otherItem))
+    val expected =
+      Some(
+        cassandraRowComparisonFailure(
+          item,
+          Some(otherItem),
+          List(Item.DifferingFieldValues(List("foo")))))
+    assertEquals(result, expected)
+  }
+
+  test("Numerical values within the tolerance threshold") {
+    val numericalItem =
+      CassandraRow.fromMap(
+        Map(
+          "foo" -> 123.456,
+          "bar" -> 789.012
+        ))
+    val otherNumericalItem =
+      CassandraRow.fromMap(
+        Map(
+          "foo" -> 123.457, // +0.001
+          "bar" -> 789.112 // +0.1
+        ))
+    val result =
+      compareItems(
+        numericalItem,
+        Some(otherNumericalItem),
+        floatingPointTolerance = 0.01
+      )
+    // Only the field `bar` is reported to be different because `foo` is still within the tolerance threshold
+    val expected =
+      Some(
+        cassandraRowComparisonFailure(
+          numericalItem,
+          Some(otherNumericalItem),
+          List(Item.DifferingFieldValues(List("bar")))))
+    assertEquals(result, expected)
+  }
+
+}

--- a/tests/src/test/scala/com/scylladb/migrator/validation/DynamoDBRowComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/DynamoDBRowComparisonTest.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import com.scylladb.migrator.AttributeValueUtils.{ numericalValue, stringValue }
 import com.scylladb.migrator.validation.RowComparisonFailure.{ dynamoDBRowComparisonFailure, Item }
 
-class RowComparisonTest extends munit.FunSuite {
+class DynamoDBRowComparisonTest extends munit.FunSuite {
 
   val sameColumns: String => String = identity
   val floatingPointTolerance: Double = 0.01


### PR DESCRIPTION
Complete our validator tests to also cover migrations from Cassandra.