### PR TITLE
Support skipping the snapshot transfer when streaming changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,9 +34,8 @@ lazy val migrator = (project in file("migrator")).settings(
     ("com.amazonaws" % "dynamodb-streams-kinesis-adapter" % "1.5.2")
       .excludeAll(InclExclRule("com.fasterxml.jackson.core")),
     "com.amazon.emr" % "emr-dynamodb-hadoop" % "4.16.0",
-    "org.yaml"       % "snakeyaml"      % "1.23",
-    "io.circe"       %% "circe-yaml"    % "0.9.0",
-    "io.circe"       %% "circe-generic" % "0.9.0",
+    "io.circe"       %% "circe-yaml"         % "0.10.1",
+    "io.circe"       %% "circe-generic"      % "0.11.1",
   ),
   assembly / assemblyShadeRules := Seq(
     ShadeRule.rename("org.yaml.snakeyaml.**" -> "com.scylladb.shaded.@1").inAll

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -87,19 +87,6 @@ source:
 #
 #   # how many tasks per executor?
 #   maxMapTasks: 1
-#
-#   # When transferring DynamoDB sources to DynamoDB targets (such as other DynamoDB tables or Alternator tables),
-#   # the migrator supports transferring live changes occuring on the source table after transferring an initial
-#   # snapshot. This is done using DynamoDB streams and incurs additional charges due to the Kinesis streams created.
-#   # Enable this flag to transfer live changes after transferring an initial snapshot. The migrator will continue
-#   # replicating changes endlessly; it must be stopped manually.
-#   #
-#   # NOTE: For the migration to be performed losslessly, the initial snapshot transfer must complete within 24 hours.
-#   # Otherwise, some captured changes may be lost due to the retention period of the table's stream.
-#   #
-#   # NOTE2: The migrator does not currently delete the created Dynamo stream. Delete it manually after ending the
-#   # migrator run.
-#   streamChanges: false
 
 # Configuration for the database you're copying into
 target:
@@ -185,6 +172,23 @@ target:
 #
 #   # how many tasks per executor?
 #   maxMapTasks: 1
+#
+#   # When transferring DynamoDB sources to DynamoDB targets (such as other DynamoDB tables or Alternator tables),
+#   # the migrator supports transferring live changes occuring on the source table after transferring an initial
+#   # snapshot. This is done using DynamoDB streams and incurs additional charges due to the Kinesis streams created.
+#   # Enable this flag to transfer live changes after transferring an initial snapshot. The migrator will continue
+#   # replicating changes endlessly; it must be stopped manually.
+#   #
+#   # NOTE: For the migration to be performed losslessly, the initial snapshot transfer must complete within 24 hours.
+#   # Otherwise, some captured changes may be lost due to the retention period of the table's stream.
+#   #
+#   # NOTE2: The migrator does not currently delete the created Dynamo stream. Delete it manually after ending the
+#   # migrator run.
+#   streamChanges: false
+#
+#   # Optional - when streamChanges is true, skip the initial snapshot transfer and only stream changes.
+#   # This setting is ignored if streamChanges is false.
+#   #skipInitialSnapshotTransfer: false
 
 # Savepoints are configuration files (like this one), saved by the migrator as it
 # runs. Their purpose is to skip token ranges that have already been copied. This

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
@@ -37,10 +37,15 @@ object AlternatorMigrator {
         )
       }
 
-      writers.DynamoDB.writeRDD(target, renames, sourceRDD, Some(targetTableDesc))
+      if (target.streamChanges && target.skipInitialSnapshotTransfer.contains(true)) {
+        log.info("Skip transferring table snapshot")
+      } else {
+        writers.DynamoDB.writeRDD(target, renames, sourceRDD, Some(targetTableDesc))
+        log.info("Done transferring table snapshot")
+      }
 
       if (target.streamChanges) {
-        log.info("Done transferring table snapshot. Starting to transfer changes")
+        log.info("Starting to transfer changes")
         val streamingContext = new StreamingContext(spark.sparkContext, Seconds(5))
 
         DynamoStreamReplication.createDStream(

--- a/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
@@ -29,7 +29,8 @@ object TargetSettings {
                       writeThroughput: Option[Int],
                       throughputWritePercent: Option[Float],
                       maxMapTasks: Option[Int],
-                      streamChanges: Boolean)
+                      streamChanges: Boolean,
+                      skipInitialSnapshotTransfer: Option[Boolean])
       extends TargetSettings
 
   implicit val decoder: Decoder[TargetSettings] =

--- a/tests/src/test/scala/com/scylladb/migrator/config/DynamoDBTargetSettingParserTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/DynamoDBTargetSettingParserTest.scala
@@ -1,0 +1,49 @@
+package com.scylladb.migrator.config
+
+import io.circe.yaml
+
+class DynamoDBTargetSettingParserTest extends munit.FunSuite {
+
+  test("skipInitialSnapshotTransfer is optional") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |scanSegments: 1
+        |readThroughput: 1
+        |throughputReadPercent: 1.0
+        |maxMapTasks: 1
+        |streamChanges: false
+        |""".stripMargin
+
+    val parsedSettings = parseDynamoDBTargetSettings(config)
+    assertEquals(parsedSettings.skipInitialSnapshotTransfer, None)
+  }
+
+  test("explicit skipInitialSnapshotTransfer is taken into account") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |scanSegments: 1
+        |readThroughput: 1
+        |throughputReadPercent: 1.0
+        |maxMapTasks: 1
+        |streamChanges: false
+        |skipInitialSnapshotTransfer: true
+        |""".stripMargin
+
+    val parsedSettings = parseDynamoDBTargetSettings(config)
+    assertEquals(parsedSettings.skipInitialSnapshotTransfer, Some(true))
+  }
+
+  private def parseDynamoDBTargetSettings(yamlContent: String): TargetSettings.DynamoDB =
+    yaml.parser
+      .parse(yamlContent)
+      .right
+      .flatMap(_.as[TargetSettings])
+      .right
+      .get match {
+      case dynamoDB: TargetSettings.DynamoDB => dynamoDB
+      case other                             => fail(s"Failed to parse type TargetSettings.DynamoDB. Got ${other}.")
+    }
+
+}


### PR DESCRIPTION
- Introduce a new configuration setting, `skipInitialSnapshotTransfer`, allowing the users to skip the initial snapshot transfer
- Fixed the `config.yaml.example` by moving the `streamChanges` section to the right place
- Ideally, `skipInitialSnapshotTransfer` should have type `Boolean` instead of `Option[Boolean]` but using an `Option` here allows us to keep backwards compatibility because the property is optional
- Also note that `skipInitialSnapshotTransfer` is ignored if `streamChanges` is `false`
- Updated Circe dependency to the latest version supported by circe-yaml

Fixes #120