### PR TITLE
Improve jobs configuration

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
@@ -40,7 +40,7 @@ object AlternatorMigrator {
       if (target.streamChanges && target.skipInitialSnapshotTransfer.contains(true)) {
         log.info("Skip transferring table snapshot")
       } else {
-        writers.DynamoDB.writeRDD(target, renames, sourceRDD, Some(targetTableDesc))
+        writers.DynamoDB.writeRDD(target, renames, sourceRDD, targetTableDesc)
         log.info("Done transferring table snapshot")
       }
 

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
@@ -43,25 +43,12 @@ object AlternatorValidator {
       targetSettings.endpoint,
       targetSettings.credentials,
       targetSettings.region,
-      targetSettings.table
-    ) { (jobConf, targetTableDesc) =>
-      setDynamoDBJobConf(
-        jobConf,
-        targetSettings.region,
-        targetSettings.endpoint,
-        targetSettings.scanSegments,
-        targetSettings.maxMapTasks,
-        targetSettings.credentials)
-      jobConf.set(DynamoDBConstants.INPUT_TABLE_NAME, targetSettings.table)
-      jobConf.set(DynamoDBConstants.ITEM_COUNT, targetTableDesc.getItemCount.toString)
-      jobConf.set(DynamoDBConstants.AVG_ITEM_SIZE,
-        (targetTableDesc.getTableSizeBytes / targetTableDesc.getItemCount).toString)
-      jobConf.set(
-        DynamoDBConstants.READ_THROUGHPUT,
-        sourceSettings.readThroughput
-          .getOrElse(DynamoUtils.tableReadThroughput(targetTableDesc))
-          .toString)
-    }
+      targetSettings.table,
+      targetSettings.scanSegments,
+      targetSettings.maxMapTasks,
+      readThroughput        = None,
+      throughputReadPercent = None
+    )
 
     // Define some aliases to prevent the Spark engine to try to serialize the whole object graph
     val renamedColumn = config.renamesMap

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
@@ -53,6 +53,9 @@ object AlternatorValidator {
         targetSettings.maxMapTasks,
         targetSettings.credentials)
       jobConf.set(DynamoDBConstants.INPUT_TABLE_NAME, targetSettings.table)
+      jobConf.set(DynamoDBConstants.ITEM_COUNT, targetTableDesc.getItemCount.toString)
+      jobConf.set(DynamoDBConstants.AVG_ITEM_SIZE,
+        (targetTableDesc.getTableSizeBytes / targetTableDesc.getItemCount).toString)
       jobConf.set(
         DynamoDBConstants.READ_THROUGHPUT,
         sourceSettings.readThroughput

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
@@ -26,6 +26,10 @@ object DynamoDB {
           source.maxMapTasks,
           source.credentials)
         jobConf.set(DynamoDBConstants.INPUT_TABLE_NAME, source.table)
+        jobConf.set(DynamoDBConstants.ITEM_COUNT,
+          description.getItemCount.toString)
+        jobConf.set(DynamoDBConstants.AVG_ITEM_SIZE,
+          (description.getTableSizeBytes / description.getItemCount).toString)
         val readThroughput =
           source.readThroughput.getOrElse(DynamoUtils.tableReadThroughput(description))
         jobConf.set(DynamoDBConstants.READ_THROUGHPUT, readThroughput.toString)

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
@@ -26,10 +26,9 @@ object DynamoDB {
           source.maxMapTasks,
           source.credentials)
         jobConf.set(DynamoDBConstants.INPUT_TABLE_NAME, source.table)
-        setOptionalConf(
-          jobConf,
-          DynamoDBConstants.READ_THROUGHPUT,
-          DynamoUtils.tableThroughput(Option(description)))
+        val readThroughput =
+          source.readThroughput.getOrElse(DynamoUtils.tableReadThroughput(description))
+        jobConf.set(DynamoDBConstants.READ_THROUGHPUT, readThroughput.toString)
         setOptionalConf(
           jobConf,
           DynamoDBConstants.THROUGHPUT_READ_PERCENT,

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
@@ -16,47 +16,61 @@ object DynamoDB {
   def readRDD(
     spark: SparkSession,
     source: SourceSettings.DynamoDB): (RDD[(Text, DynamoDBItemWritable)], TableDescription) =
-    readRDD(spark, source.endpoint, source.credentials, source.region, source.table) {
-      (jobConf, description) =>
-        setDynamoDBJobConf(
-          jobConf,
-          source.region,
-          source.endpoint,
-          source.scanSegments,
-          source.maxMapTasks,
-          source.credentials)
-        jobConf.set(DynamoDBConstants.INPUT_TABLE_NAME, source.table)
-        jobConf.set(DynamoDBConstants.ITEM_COUNT,
-          description.getItemCount.toString)
-        jobConf.set(DynamoDBConstants.AVG_ITEM_SIZE,
-          (description.getTableSizeBytes / description.getItemCount).toString)
-        val readThroughput =
-          source.readThroughput.getOrElse(DynamoUtils.tableReadThroughput(description))
-        jobConf.set(DynamoDBConstants.READ_THROUGHPUT, readThroughput.toString)
-        setOptionalConf(
-          jobConf,
-          DynamoDBConstants.THROUGHPUT_READ_PERCENT,
-          source.throughputReadPercent.map(_.toString))
-    }
+    readRDD(
+      spark,
+      source.endpoint,
+      source.credentials,
+      source.region,
+      source.table,
+      source.scanSegments,
+      source.maxMapTasks,
+      source.readThroughput,
+      source.throughputReadPercent
+    )
 
   /**
-    * A lower-level overload of `readRDD` that expects the caller to fully configure the Hadoop JobConf
-    * with the provided `configureJobConf` parameter.
+    * Overload of `readRDD` that does not depend on `SourceSettings.DynamoDB`
     */
-  def readRDD(spark: SparkSession,
-              endpoint: Option[DynamoDBEndpoint],
-              credentials: Option[AWSCredentials],
-              region: Option[String],
-              table: String)(
-    configureJobConf: (JobConf, TableDescription) => Unit
-  ): (RDD[(Text, DynamoDBItemWritable)], TableDescription) = {
+  def readRDD(
+    spark: SparkSession,
+    endpoint: Option[DynamoDBEndpoint],
+    credentials: Option[AWSCredentials],
+    region: Option[String],
+    table: String,
+    scanSegments: Option[Int],
+    maxMapTasks: Option[Int],
+    readThroughput: Option[Int],
+    throughputReadPercent: Option[Float]): (RDD[(Text, DynamoDBItemWritable)], TableDescription) = {
     val description = DynamoUtils
       .buildDynamoClient(endpoint, credentials, region)
       .describeTable(table)
       .getTable
 
     val jobConf = new JobConf(spark.sparkContext.hadoopConfiguration)
-    configureJobConf(jobConf, description)
+
+    setDynamoDBJobConf(
+      jobConf,
+      region,
+      endpoint,
+      scanSegments,
+      maxMapTasks,
+      credentials
+    )
+    jobConf.set(DynamoDBConstants.INPUT_TABLE_NAME, table)
+    jobConf.set(DynamoDBConstants.ITEM_COUNT, description.getItemCount.toString)
+    jobConf.set(
+      DynamoDBConstants.AVG_ITEM_SIZE,
+      (description.getTableSizeBytes / description.getItemCount).toString)
+    jobConf.set(
+      DynamoDBConstants.READ_THROUGHPUT,
+      readThroughput
+        .getOrElse(DynamoUtils.tableReadThroughput(description))
+        .toString)
+    setOptionalConf(
+      jobConf,
+      DynamoDBConstants.THROUGHPUT_READ_PERCENT,
+      throughputReadPercent.map(_.toString))
+
     val rdd =
       spark.sparkContext.hadoopRDD(
         jobConf,

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
@@ -88,7 +88,7 @@ object DynamoStreamReplication {
         log.info("No changes to apply")
       }
 
-      DynamoDB.writeRDD(target, renames, rdd, Some(targetTableDesc))(spark)
+      DynamoDB.writeRDD(target, renames, rdd, targetTableDesc)(spark)
     }
 
 }

--- a/tests/src/test/configurations/dynamodb-to-alternator-basic.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-basic.yaml
@@ -7,7 +7,6 @@ source:
   credentials:
     accessKey: dummy
     secretKey: dummy
-  maxMapTasks: 1
 
 target:
   type: dynamodb
@@ -18,7 +17,6 @@ target:
   credentials:
     accessKey: dummy
     secretKey: dummy
-  maxMapTasks: 1
   streamChanges: false
 
 renames: []

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
@@ -68,7 +68,7 @@ trait MigratorSuite extends munit.FunSuite {
             .withTableName(name)
             .withKeySchema(new KeySchemaElement("id", "HASH"))
             .withAttributeDefinitions(new AttributeDefinition("id", "S"))
-            .withProvisionedThroughput(new ProvisionedThroughput(5L, 5L))
+            .withProvisionedThroughput(new ProvisionedThroughput(25L, 25L))
         sourceDDb.createTable(createTableRequest)
         // TODO Replace with “waiters” after we upgrade the AWS SDK
         Thread.sleep(5000)


### PR DESCRIPTION
- Use configured readThroughput/writeThroughput in the Hadoop job
- If the configuration is not provided, fallback to a default value based on the table read/write capacity units
- provide the average item size and the item count to the Hadoop job

These settings are used by the emr-dynamodb-connector to adjust the resource usage.

Relates to #130 and #133 