### PR TITLE
Improve the robustness of the migrator

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
@@ -50,12 +50,17 @@ object DynamoUtils {
           .withTableName(target.table)
           .withKeySchema(sourceDescription.getKeySchema)
           .withAttributeDefinitions(sourceDescription.getAttributeDefinitions)
-          .withProvisionedThroughput(
-            new ProvisionedThroughput(
-              sourceDescription.getProvisionedThroughput.getReadCapacityUnits,
-              sourceDescription.getProvisionedThroughput.getWriteCapacityUnits
+        if (sourceDescription.getProvisionedThroughput.getReadCapacityUnits != 0L && sourceDescription.getProvisionedThroughput.getWriteCapacityUnits != 0) {
+          request
+            .setProvisionedThroughput(
+              new ProvisionedThroughput(
+                sourceDescription.getProvisionedThroughput.getReadCapacityUnits,
+                sourceDescription.getProvisionedThroughput.getWriteCapacityUnits
+              )
             )
-          )
+        } else {
+          request.setBillingMode(BillingMode.PAY_PER_REQUEST.toString)
+        }
 
         log.info(
           s"Table ${target.table} does not exist at destination - creating it according to definition:")

--- a/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
@@ -16,6 +16,7 @@ import com.amazonaws.services.dynamodbv2.model.{
   StreamSpecification,
   StreamViewType,
   TableDescription,
+  TableStatus,
   UpdateTableRequest
 }
 import com.scylladb.migrator.config.{
@@ -67,6 +68,13 @@ object DynamoUtils {
         log.info(sourceDescription.toString)
         targetClient.createTable(request)
         log.info(s"Table ${target.table} created.")
+
+        var targetTableDesc = targetClient.describeTable(target.table).getTable
+        while (TableStatus.ACTIVE.toString != targetTableDesc.getTableStatus) {
+          log.debug(s"Target table not ready yet. Waiting 1 second.")
+          Thread.sleep(1000)
+          targetTableDesc = targetClient.describeTable(target.table).getTable
+        }
 
         targetClient.describeTable(target.table).getTable
 

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
@@ -49,6 +49,7 @@ object DynamoDB {
     val maybeAvgItemSize =
       for {
         itemCount <- maybeItemCount
+        if itemCount != 0L
         tableSize <- Option(description.getTableSizeBytes)
       } yield tableSize / itemCount
 


### PR DESCRIPTION
- Prevent division by zero
- Don’t set the target table provisioned throughput when the source table billing mode is on-demand
- Wait for the replicated target table to be active before moving forward with the next step