### PR TITLE
Add support for temporary AWS credentials via AssumeRole

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,7 @@ lazy val tests = project.in(file("tests")).settings(
     "org.apache.spark"         %% "spark-sql"                % sparkVersion,
     "org.apache.cassandra"     % "java-driver-query-builder" % "4.18.0",
     "com.github.mjakubowski84" %% "parquet4s-core"           % "1.9.4",
-    "org.apache.hadoop"        % "hadoop-client"             % "2.9.2",
+    "org.apache.hadoop"        % "hadoop-client"             % "2.6.5",
     "org.scalameta"            %% "munit"                    % "0.7.29",
     "org.scala-lang.modules"   %% "scala-collection-compat"  % "2.11.0"
   ),

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -54,9 +54,10 @@ source:
 #   credentials:
 #     accessKey: <user>
 #     secretKey: <pass>
-#     # Optional - assume role
+#     # Optional - assume role, see https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
 #     assumeRole:
 #       arn: <roleArn>
+#       # Optional - the session name to use. If not set, we use 'scylla-migrator'
 #       sessionName: <roleSessionName>
 #   # Optional - specify the region:
 #   region: <region>
@@ -83,9 +84,10 @@ source:
 #   credentials:
 #     accessKey: <user>
 #     secretKey: <pass>
-#     # Optional - assume role
+#     # Optional - assume role, see https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
 #     assumeRole:
 #       arn: <roleArn>
+#       # Optional - the session name to use. If not set, we use 'scylla-migrator'
 #       sessionName: <sessionName>
 #
 #   # below controls split factor
@@ -132,9 +134,10 @@ source:
 #   credentials:
 #     accessKey: <user>
 #     secretKey: <pass>
-#     # Optional - assume role
+#     # Optional - assume role, see https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
 #     assumeRole:
 #       arn: <roleArn>
+#       # Optional - the session name to use. If not set, we use 'scylla-migrator'
 #       sessionName: <roleSessionName>
 #
 #   # Optional - use path-style access in S3 (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html)
@@ -209,9 +212,10 @@ target:
 #   credentials:
 #     accessKey: <user>
 #     secretKey: <pass>
-#     # Optional - assume role
+#     # Optional - assume role, see https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
 #     assumeRole:
 #       arn: <roleArn>
+#       # Optional - the session name to use. If not set, we use 'scylla-migrator'
 #       sessionName: <roleSessionName>
 #
 #   # Split factor for reading/writing. This is required for Scylla targets.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -50,22 +50,10 @@ source:
 #   path: s3a://bucket-name/path/to/parquet-directory
 #   # Optional AWS access/secret key for loading from S3.
 #   # This section can be left out if running on EC2 instances that have instance profiles with the
-#   # appropriate permissions.
+#   # appropriate permissions. Assuming roles is not supported currently.
 #   credentials:
 #     accessKey: <user>
 #     secretKey: <pass>
-#     # Optional - assume role, see https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
-#     assumeRole:
-#       arn: <roleArn>
-#       # Optional - the session name to use. If not set, we use 'scylla-migrator'
-#       sessionName: <roleSessionName>
-#   # Optional - specify the region:
-#   region: <region>
-#   # Optional - specify the endpoint
-#   endpoint:
-#     # Specify the hostname without a protocol
-#     host: <host>
-#     port: <port>
 
 # Example for loading from DynamoDB:
 # source:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -50,10 +50,21 @@ source:
 #   path: s3a://bucket-name/path/to/parquet-directory
 #   # Optional AWS access/secret key for loading from S3.
 #   # This section can be left out if running on EC2 instances that have instance profiles with the
-#   # appropriate permissions. Assuming roles is not supported currently.
+#   # appropriate permissions.
 #   credentials:
-#     accessKey:
-#     secretKey:
+#     accessKey: <user>
+#     secretKey: <pass>
+#     # Optional - assume role
+#     assumeRole:
+#       arn: <roleArn>
+#       sessionName: <roleSessionName>
+#   # Optional - specify the region:
+#   region: <region>
+#   # Optional - specify the endpoint
+#   endpoint:
+#     # Specify the hostname without a protocol
+#     host: <host>
+#     port: <port>
 
 # Example for loading from DynamoDB:
 # source:
@@ -72,6 +83,10 @@ source:
 #   credentials:
 #     accessKey: <user>
 #     secretKey: <pass>
+#     # Optional - assume role
+#     assumeRole:
+#       arn: <roleArn>
+#       sessionName: <sessionName>
 #
 #   # below controls split factor
 #   scanSegments: 1
@@ -117,6 +132,10 @@ source:
 #   credentials:
 #     accessKey: <user>
 #     secretKey: <pass>
+#     # Optional - assume role
+#     assumeRole:
+#       arn: <roleArn>
+#       sessionName: <roleSessionName>
 #
 #   # Optional - use path-style access in S3 (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html)
 #   usePathStyleAccess: true
@@ -190,6 +209,10 @@ target:
 #   credentials:
 #     accessKey: <user>
 #     secretKey: <pass>
+#     # Optional - assume role
+#     assumeRole:
+#       arn: <roleArn>
+#       sessionName: <roleSessionName>
 #
 #   # Split factor for reading/writing. This is required for Scylla targets.
 #   scanSegments: 1

--- a/migrator/src/main/scala/com/scylladb/migrator/AwsUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/AwsUtils.scala
@@ -1,9 +1,15 @@
 package com.scylladb.migrator
 
-import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.{
+  AWSCredentialsProvider,
+  AWSStaticCredentialsProvider,
+  BasicAWSCredentials,
+  BasicSessionCredentials
+}
 import com.amazonaws.client.builder.AwsClientBuilder
-import com.scylladb.migrator.config.DynamoDBEndpoint
-
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest
+import com.scylladb.migrator.config.{ AWSAssumeRole, DynamoDBEndpoint }
 object AwsUtils {
 
   /** Configure an AWS SDK builder to use the provided endpoint, region and credentials provider */
@@ -23,6 +29,61 @@ object AwsUtils {
     maybeRegion.foreach(builder.setRegion)
 
     builder
+  }
+
+  /**
+    * Compute the final AWS credentials to use to call any AWS API.
+    *
+    * The credentials provided in the configuration may require acquiring temporary credentials by
+    * delegation (“AssumeRole” in AWS jargon).
+    */
+  def computeFinalCredentials(maybeConfiguredCredentials: Option[config.AWSCredentials],
+                              endpoint: Option[DynamoDBEndpoint],
+                              region: Option[String]): Option[AWSCredentials] =
+    maybeConfiguredCredentials.map { configuredCredentials =>
+      val baseCredentials =
+        AWSCredentials(configuredCredentials.accessKey, configuredCredentials.secretKey, None)
+      configuredCredentials.assumeRole match {
+        case None => baseCredentials
+        case Some(AWSAssumeRole(roleArn, roleSessionName)) =>
+          val stsClient =
+            configureClientBuilder(
+              AWSSecurityTokenServiceClientBuilder.standard(),
+              endpoint,
+              region,
+              Some(
+                new AWSStaticCredentialsProvider(
+                  new BasicAWSCredentials(
+                    configuredCredentials.accessKey,
+                    configuredCredentials.secretKey)))
+            ).build()
+          val response =
+            stsClient.assumeRole(
+              new AssumeRoleRequest()
+                .withRoleArn(roleArn)
+                .withRoleSessionName(roleSessionName)
+            )
+          val assumedCredentials = response.getCredentials
+          AWSCredentials(
+            assumedCredentials.getAccessKeyId,
+            assumedCredentials.getSecretAccessKey,
+            Some(assumedCredentials.getSessionToken)
+          )
+      }
+    }
+
+}
+
+/** Bare AWS credentials */
+case class AWSCredentials(accessKey: String, secretKey: String, maybeSessionToken: Option[String]) {
+  /** Convenient method to use our credentials with the AWS SDK */
+  def toProvider: AWSCredentialsProvider = {
+    val staticCredentials =
+      maybeSessionToken match {
+        case Some(sessionToken) => new BasicSessionCredentials(accessKey, secretKey, sessionToken)
+        case None               => new BasicAWSCredentials(accessKey, secretKey)
+      }
+    new AWSStaticCredentialsProvider(staticCredentials)
   }
 
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/AwsUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/AwsUtils.scala
@@ -45,7 +45,7 @@ object AwsUtils {
         AWSCredentials(configuredCredentials.accessKey, configuredCredentials.secretKey, None)
       configuredCredentials.assumeRole match {
         case None => baseCredentials
-        case Some(AWSAssumeRole(roleArn, roleSessionName)) =>
+        case Some(role) =>
           val stsClient =
             configureClientBuilder(
               AWSSecurityTokenServiceClientBuilder.standard(),
@@ -60,8 +60,8 @@ object AwsUtils {
           val response =
             stsClient.assumeRole(
               new AssumeRoleRequest()
-                .withRoleArn(roleArn)
-                .withRoleSessionName(roleSessionName)
+                .withRoleArn(role.arn)
+                .withRoleSessionName(role.getSessionName)
             )
           val assumedCredentials = response.getCredentials
           AWSCredentials(
@@ -76,6 +76,7 @@ object AwsUtils {
 
 /** Bare AWS credentials */
 case class AWSCredentials(accessKey: String, secretKey: String, maybeSessionToken: Option[String]) {
+
   /** Convenient method to use our credentials with the AWS SDK */
   def toProvider: AWSCredentialsProvider = {
     val staticCredentials =

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
@@ -1,11 +1,9 @@
 package com.scylladb.migrator.alternator
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
-import com.scylladb.migrator.DynamoUtils.setDynamoDBJobConf
 import com.scylladb.migrator.config.{ MigratorConfig, SourceSettings, TargetSettings }
 import com.scylladb.migrator.validation.RowComparisonFailure
-import com.scylladb.migrator.{ readers, DynamoUtils }
-import org.apache.hadoop.dynamodb.DynamoDBConstants
+import com.scylladb.migrator.readers
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 
@@ -41,7 +39,7 @@ object AlternatorValidator {
     val (target, _) = readers.DynamoDB.readRDD(
       spark,
       targetSettings.endpoint,
-      targetSettings.credentials,
+      targetSettings.finalCredentials,
       targetSettings.region,
       targetSettings.table,
       targetSettings.scanSegments,

--- a/migrator/src/main/scala/com/scylladb/migrator/config/AWSCredentials.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/AWSCredentials.scala
@@ -11,9 +11,14 @@ object AWSCredentials {
   implicit val encoder: Encoder[AWSCredentials] = deriveEncoder
 }
 
-case class AWSAssumeRole(arn: String, sessionName: String)
+case class AWSAssumeRole(arn: String, sessionName: Option[String]) {
+  def getSessionName: String =
+    sessionName.getOrElse(AWSAssumeRole.defaultSessionName)
+}
 
 object AWSAssumeRole {
   implicit val decoder: Decoder[AWSAssumeRole] = deriveDecoder
   implicit val encoder: Encoder[AWSAssumeRole] = deriveEncoder
+
+  val defaultSessionName: String = "scylla-migrator"
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/AWSCredentials.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/AWSCredentials.scala
@@ -1,19 +1,19 @@
 package com.scylladb.migrator.config
 
-import com.amazonaws.auth.{
-  AWSCredentialsProvider,
-  AWSStaticCredentialsProvider,
-  BasicAWSCredentials
-}
 import io.circe.{ Decoder, Encoder }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 
-case class AWSCredentials(accessKey: String, secretKey: String) {
-  def toAWSCredentialsProvider: AWSCredentialsProvider =
-    new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey))
+case class AWSCredentials(accessKey: String, secretKey: String, assumeRole: Option[AWSAssumeRole]) {
   override def toString: String = s"AWSCredentials(${accessKey.take(3)}..., <redacted>)"
 }
 object AWSCredentials {
   implicit val decoder: Decoder[AWSCredentials] = deriveDecoder
   implicit val encoder: Encoder[AWSCredentials] = deriveEncoder
+}
+
+case class AWSAssumeRole(arn: String, sessionName: String)
+
+object AWSAssumeRole {
+  implicit val decoder: Decoder[AWSAssumeRole] = deriveDecoder
+  implicit val encoder: Encoder[AWSAssumeRole] = deriveEncoder
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
@@ -47,10 +47,7 @@ object SourceSettings {
                      credentials: Option[AWSCredentials],
                      endpoint: Option[DynamoDBEndpoint],
                      region: Option[String])
-      extends SourceSettings {
-    lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
-      AwsUtils.computeFinalCredentials(credentials, endpoint, region)
-  }
+      extends SourceSettings
 
   case class DynamoDBS3Export(bucket: String,
                               manifestKey: String,

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
@@ -43,11 +43,7 @@ object SourceSettings {
     lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
       AwsUtils.computeFinalCredentials(credentials, endpoint, region)
   }
-  case class Parquet(path: String,
-                     credentials: Option[AWSCredentials],
-                     endpoint: Option[DynamoDBEndpoint],
-                     region: Option[String])
-      extends SourceSettings
+  case class Parquet(path: String, credentials: Option[AWSCredentials]) extends SourceSettings
 
   case class DynamoDBS3Export(bucket: String,
                               manifestKey: String,

--- a/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
@@ -1,6 +1,7 @@
 package com.scylladb.migrator.config
 
 import cats.implicits._
+import com.scylladb.migrator.AwsUtils
 import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import io.circe.syntax._
@@ -31,7 +32,10 @@ object TargetSettings {
                       maxMapTasks: Option[Int],
                       streamChanges: Boolean,
                       skipInitialSnapshotTransfer: Option[Boolean])
-      extends TargetSettings
+      extends TargetSettings {
+    lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
+      AwsUtils.computeFinalCredentials(credentials, endpoint, region)
+  }
 
   implicit val decoder: Decoder[TargetSettings] =
     Decoder.instance { cursor =>

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDBS3Export.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDBS3Export.scala
@@ -28,7 +28,7 @@ object DynamoDBS3Export {
           AmazonS3ClientBuilder.standard(),
           source.endpoint,
           source.region,
-          source.credentials.map(_.toAWSCredentialsProvider)
+          source.finalCredentials.map(_.toProvider)
         )
     for (usePathStyleAccess <- source.usePathStyleAccess) {
       s3ClientBuilder.withPathStyleAccessEnabled(usePathStyleAccess)

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
@@ -9,10 +9,17 @@ object Parquet {
   val log = LogManager.getLogger("com.scylladb.migrator.readers.Parquet")
 
   def readDataFrame(spark: SparkSession, source: SourceSettings.Parquet): SourceDataFrame = {
-    source.credentials.foreach { credentials =>
+    source.finalCredentials.foreach { credentials =>
       log.info("Loaded AWS credentials from config file")
       spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", credentials.accessKey)
       spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", credentials.secretKey)
+      credentials.maybeSessionToken.foreach { sessionToken =>
+        // See https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#Using_Session_Credentials_with_TemporaryAWSCredentialsProvider
+        spark.sparkContext.hadoopConfiguration.set(
+          "fs.s3a.aws.credentials.provider",
+          "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider")
+        spark.sparkContext.hadoopConfiguration.set("fs.s3a.session.token", sessionToken)
+      }
     }
 
     SourceDataFrame(spark.read.parquet(source.path), None, false)

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
@@ -11,22 +11,8 @@ object Parquet {
   def readDataFrame(spark: SparkSession, source: SourceSettings.Parquet): SourceDataFrame = {
     source.credentials.foreach { credentials =>
       log.info("Loaded AWS credentials from config file")
-      source.region.foreach { region =>
-        spark.sparkContext.hadoopConfiguration.set("fs.s3a.endpoint.region", region)
-      }
       spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", credentials.accessKey)
       spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", credentials.secretKey)
-      // See https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/assumed_roles.html
-      credentials.assumeRole.foreach { role =>
-        spark.sparkContext.hadoopConfiguration.set(
-          "fs.s3a.aws.credentials.provider",
-          "org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider")
-        spark.sparkContext.hadoopConfiguration.set("fs.s3a.assumed.role.arn", role.arn)
-        role.sessionName.foreach { sessionName =>
-          spark.sparkContext.hadoopConfiguration
-            .set("fs.s3a.assumed.role.session.name", sessionName)
-        }
-      }
     }
 
     SourceDataFrame(spark.read.parquet(source.path), None, false)

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
@@ -25,7 +25,7 @@ object DynamoDB {
       target.endpoint,
       target.scanSegments,
       target.maxMapTasks,
-      target.credentials)
+      target.finalCredentials)
     jobConf.set(DynamoDBConstants.OUTPUT_TABLE_NAME, target.table)
     val writeThroughput =
       target.writeThroughput.getOrElse(DynamoUtils.tableWriteThroughput(targetTableDesc))

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
@@ -62,7 +62,7 @@ object DynamoStreamReplication {
             SparkAWSCredentials.builder
               .basicCredentials(accessKey, secretKey)
           for (assumeRole <- maybeAssumeRole) {
-            builder.stsCredentials(assumeRole.arn, assumeRole.sessionName)
+            builder.stsCredentials(assumeRole.arn, assumeRole.getSessionName)
           }
           builder.build()
       }.orNull

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
@@ -57,10 +57,14 @@ object DynamoStreamReplication {
         case _ => None
       },
       kinesisCreds = src.credentials.map {
-        case AWSCredentials(accessKey, secretKey) =>
-          SparkAWSCredentials.builder
-            .basicCredentials(accessKey, secretKey)
-            .build()
+        case AWSCredentials(accessKey, secretKey, maybeAssumeRole) =>
+          val builder =
+            SparkAWSCredentials.builder
+              .basicCredentials(accessKey, secretKey)
+          for (assumeRole <- maybeAssumeRole) {
+            builder.stsCredentials(assumeRole.arn, assumeRole.sessionName)
+          }
+          builder.build()
       }.orNull
     ).foreachRDD { msgs =>
       val rdd = msgs

--- a/tests/src/test/scala/com/scylladb/migrator/config/AWSCredentialsParserTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/AWSCredentialsParserTest.scala
@@ -1,0 +1,37 @@
+package com.scylladb.migrator.config
+
+import io.circe.yaml
+
+class AWSCredentialsParserTest extends munit.FunSuite {
+
+  test("Basic authentication") {
+    val config =
+      """accessKey: foo
+        |secretKey: bar""".stripMargin
+    val expectedCredentials =
+      AWSCredentials("foo", "bar", None)
+    val parsedCredentials = parseCredentials(config)
+    assertEquals(parsedCredentials, expectedCredentials)
+  }
+
+  test("Optional assume role") {
+    val config =
+      """accessKey: foo
+        |secretKey: bar
+        |assumeRole:
+        |  arn: baz
+        |  sessionName: bah""".stripMargin
+    val expectedCredentials =
+      AWSCredentials("foo", "bar", Some(AWSAssumeRole("baz", "bah")))
+    val parsedCredentials = parseCredentials(config)
+    assertEquals(parsedCredentials, expectedCredentials)
+  }
+
+  private def parseCredentials(yamlContent: String): AWSCredentials =
+    yaml.parser
+      .parse(yamlContent)
+      .right
+      .flatMap(_.as[AWSCredentials])
+      .right.getOrElse(fail("Failed to parse AWS credentials."))
+
+}

--- a/tests/src/test/scala/com/scylladb/migrator/config/AWSCredentialsParserTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/AWSCredentialsParserTest.scala
@@ -22,7 +22,7 @@ class AWSCredentialsParserTest extends munit.FunSuite {
         |  arn: baz
         |  sessionName: bah""".stripMargin
     val expectedCredentials =
-      AWSCredentials("foo", "bar", Some(AWSAssumeRole("baz", "bah")))
+      AWSCredentials("foo", "bar", Some(AWSAssumeRole("baz", Some("bah"))))
     val parsedCredentials = parseCredentials(config)
     assertEquals(parsedCredentials, expectedCredentials)
   }


### PR DESCRIPTION
- Add `assumeRole` optional property to the credentials configuration objects
- Compute the “final” AWS credentials to use at the level of the `SourceSettings` or `TargetSettings`
- Support AssumeRole with DynamoDB source and target databases, with DynamoDB S3 exports
- Reading Parquet files from S3 (using paths like `s3a://…`) is still not supported because our version of hadoop is too old (see my comment below)

Relates to #149