### PR TITLE
Build spark-cassandra-connector as a usual dependency instead of a fat-jar

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,13 +12,7 @@ TMPDIR="$PWD"/tmpexec
 mkdir -p "$TMPDIR"
 trap "rm -rf $TMPDIR" EXIT
 pushd spark-cassandra-connector
-sbt -Djava.io.tmpdir="$TMPDIR" ++2.11.12 assembly
+sbt -Djava.io.tmpdir="$TMPDIR" ++2.11.12 publishLocal
 popd
 
-if [ ! -d "./migrator/lib" ]; then
-    mkdir migrator/lib
-fi
-
-cp ./spark-cassandra-connector/connector/target/scala-2.11/spark-cassandra-connector-assembly-*.jar ./migrator/lib
-
-sbt -Djava.io.tmpdir="$TMPDIR" -mem 8192 migrator/assembly
+sbt -Djava.io.tmpdir="$TMPDIR" migrator/assembly


### PR DESCRIPTION
The assembly of the migrator project requires a huge amount of resources because it has to process [thousands of files](https://github.com/scylladb/scylla-migrator/actions/runs/9483786283/job/26131722478#step:5:125) that are duplicated between the fat-jar of the spark-cassandra-connector and scylla-migrator’s dependencies.

On my machine, the OS often crashes when I try to build the assembly…

Instead, we should build the spark-cassandra-connector as a usual Maven/Ivy package, publish it locally, and depend on it in the scylla-migrator project.
