### PR TITLE
Support AssumedRole authentication when reading Parquet files in S3

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -50,10 +50,22 @@ source:
 #   path: s3a://bucket-name/path/to/parquet-directory
 #   # Optional AWS access/secret key for loading from S3.
 #   # This section can be left out if running on EC2 instances that have instance profiles with the
-#   # appropriate permissions. Assuming roles is not supported currently.
+#   # appropriate permissions.
 #   credentials:
 #     accessKey: <user>
 #     secretKey: <pass>
+#     # Optional - assume role, see https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
+#     assumeRole:
+#       arn: <roleArn>
+#       # Optional - the session name to use. If not set, we use 'scylla-migrator'
+#       sessionName: <roleSessionName>
+#   # Optional - specify the region:
+#   region: <region>
+#   # Optional - specify the endpoint
+#   endpoint:
+#     # Specify the hostname without a protocol
+#     host: <host>
+#     port: <port>
 
 # Example for loading from DynamoDB:
 # source:

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
@@ -43,7 +43,14 @@ object SourceSettings {
     lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
       AwsUtils.computeFinalCredentials(credentials, endpoint, region)
   }
-  case class Parquet(path: String, credentials: Option[AWSCredentials]) extends SourceSettings
+  case class Parquet(path: String,
+                     credentials: Option[AWSCredentials],
+                     endpoint: Option[DynamoDBEndpoint],
+                     region: Option[String])
+      extends SourceSettings {
+    lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
+      AwsUtils.computeFinalCredentials(credentials, endpoint, region)
+  }
 
   case class DynamoDBS3Export(bucket: String,
                               manifestKey: String,

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
@@ -9,10 +9,23 @@ object Parquet {
   val log = LogManager.getLogger("com.scylladb.migrator.readers.Parquet")
 
   def readDataFrame(spark: SparkSession, source: SourceSettings.Parquet): SourceDataFrame = {
-    source.credentials.foreach { credentials =>
+    source.finalCredentials.foreach { credentials =>
       log.info("Loaded AWS credentials from config file")
+      source.region.foreach { region =>
+        spark.sparkContext.hadoopConfiguration.set("fs.s3a.endpoint.region", region)
+      }
       spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", credentials.accessKey)
       spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", credentials.secretKey)
+      // See https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#Using_Session_Credentials_with_TemporaryAWSCredentialsProvider
+      credentials.maybeSessionToken.foreach { sessionToken =>
+        spark.sparkContext.hadoopConfiguration.set(
+          "fs.s3a.aws.credentials.provider",
+          "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider")
+        spark.sparkContext.hadoopConfiguration.set(
+          "fs.s3a.session.token",
+          sessionToken
+        )
+      }
     }
 
     SourceDataFrame(spark.read.parquet(source.path), None, false)


### PR DESCRIPTION
I tested manually that I could read Parquet files using the `s3a://` protocol with direct credentials and with temporary credentials obtained via “assumed role”.

Fixes #149.