### PR TITLE
Build the fat-jar when a new release is published

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: temurin
+          cache: sbt
+      - name: Build
+        run: ./build.sh
+      - name: Publish
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: migrator/target/scala-2.13/scylla-migrator-assembly.jar
+          asset_name: scylla-migrator-assembly.jar
+          asset_content_type: application/octet-stream

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,3 +76,7 @@ Follow the procedure documented [here](https://stackoverflow.com/a/15505308/5617
    but you can see it in the worker web UI: http://localhost:8081/.
 5. Start the remote debugger from your IDE.
 6. The test execution resumes, and you can interact with it from your debugger.
+
+## Publishing
+
+Create a new [GitHub release](https://github.com/scylladb/scylla-migrator/releases), give it a tag name, a title, and a description, and then click Publish. A workflow will be triggered and will build the application fat-jar and upload it as a release asset.

--- a/README.md
+++ b/README.md
@@ -26,14 +26,6 @@ An ansible playbook is provided in ansible folder.  The ansible playbook will in
 12. You can monitor progress by observing the spark web console you opened in step 7.  Additionally, after the job has started, you can track progress via http://<spark-master-hostname>:4040.  
   FYI: When no spark jobs are actively running, the spark progress page at port 4040 displays unavailable.  It is only useful and renders when a spark job is in progress.
 
-
-# Building
-
-1. Make sure the Java 8+ JDK and `sbt` are installed on your machine.
-2. Export the `JAVA_HOME` environment variable with the path to the
-JDK installation.
-3. Run `build.sh`.
-
 # Configuring the Migrator
 
 Create a `config.yaml` for your migration using the template `config.yaml.example` in the repository root. Read the comments throughout carefully.
@@ -42,8 +34,15 @@ Create a `config.yaml` for your migration using the template `config.yaml.exampl
 
 The Scylla Migrator is built against Spark 3.5.1, so you'll need to run that version on your cluster.
 
-If you didn't build Scylla Migrator on the master node:
-After running `build.sh`, copy the jar from `./migrator/target/scala-2.13/scylla-migrator-assembly-0.0.1.jar` and the `config.yaml` you've created to the Spark master server.
+Download the latest [release](https://github.com/scylladb/scylla-migrator/releases) of the migrator:
+
+~~~ sh
+wget https://github.com/scylladb/scylla-migrator/releases/latest/download/scylla-migrator-assembly.jar
+~~~
+
+Alternatively, you can [build](#building) a custom version of the migrator.
+
+Copy the jar `scylla-migrator-assembly.jar` and the `config.yaml` you've created to the Spark master server.
 
 Start the spark master and slaves.
 `cd scylla-migrator`
@@ -63,7 +62,7 @@ Then, run this command on the Spark master server:
 spark-submit --class com.scylladb.migrator.Migrator \
   --master spark://<spark-master-hostname>:7077 \
   --conf spark.scylla.config=<path to config.yaml> \
-  <path to scylla-migrator-assembly-0.0.1.jar>
+  <path to scylla-migrator-assembly.jar>
 ```
 
 If you pass on the truststore file or ssl related files use `--files` option:
@@ -72,7 +71,7 @@ spark-submit --class com.scylladb.migrator.Migrator \
   --master spark://<spark-master-hostname>:7077 \
   --conf spark.scylla.config=<path to config.yaml> \
   --files truststorefilename \
-  <path to scylla-migrator-assembly-0.0.1.jar>
+  <path to scylla-migrator-assembly.jar>
 ```
 
 # Running the validator
@@ -85,7 +84,7 @@ the previous steps):
 spark-submit --class com.scylladb.migrator.Validator \
   --master spark://<spark-master-hostname>:7077 \
   --conf spark.scylla.config=<path to config.yaml> \
-  <path to scylla-migrator-assembly-0.0.1.jar>
+  <path to scylla-migrator-assembly.jar>
 ```
 
 # Running locally
@@ -119,7 +118,17 @@ docker compose exec spark-master /spark/bin/spark-submit --class com.scylladb.mi
   --master spark://spark-master:7077 \
   --conf spark.driver.host=spark-master \
   --conf spark.scylla.config=/app/config.yaml \
-  /jars/scylla-migrator-assembly-0.0.1.jar
+  /jars/scylla-migrator-assembly.jar
 ```
 
 The `spark-master` container mounts the `./migrator/target/scala-2.13` dir on `/jars` and the repository root on `/app`. To update the jar with new code, just run `build.sh` and then run `spark-submit` again.
+
+# Building
+
+To test a custom version of the migrator that has not been [released](https://github.com/scylladb/scylla-migrator/releases), you can build it yourself by cloning this Git repository and following the steps below:
+
+1. Make sure the Java 8+ JDK and `sbt` are installed on your machine.
+2. Export the `JAVA_HOME` environment variable with the path to the
+   JDK installation.
+3. Run `build.sh`.
+4. This will produce the .jar file to use in the `spark-submit` command at path `migrator/target/scala-2.13/scylla-migrator-assembly.jar`.

--- a/ansible/templates/submit-alternator-job.sh
+++ b/ansible/templates/submit-alternator-job.sh
@@ -14,4 +14,4 @@ time spark-submit --class com.scylladb.migrator.Migrator \
 --conf spark.scylla.config=/home/ubuntu/scylla-migrator/config.dynamodb.yml \
 --conf spark.executor.memory=$MEMORY \
 --conf spark.driver.memory=64G \
-/home/ubuntu/scylla-migrator/migrator/target/scala-2.13/scylla-migrator-assembly-0.0.1.jar
+/home/ubuntu/scylla-migrator/migrator/target/scala-2.13/scylla-migrator-assembly.jar

--- a/ansible/templates/submit-cql-job-validator.sh
+++ b/ansible/templates/submit-cql-job-validator.sh
@@ -15,4 +15,4 @@ time spark-submit --class com.scylladb.migrator.Validator \
   --num-executors $SPARK_WORKER_INSTANCES \
   --executor-memory $MEMORY \
   --conf spark.cassandra.connection.localConnectionsPerExecutor=4 \
-  scylla-migrator/target/scala-2.13/scylla-migrator-assembly-0.0.1.jar
+  migrator/target/scala-2.13/scylla-migrator-assembly.jar

--- a/ansible/templates/submit-cql-job.sh
+++ b/ansible/templates/submit-cql-job.sh
@@ -15,7 +15,7 @@ time spark-submit --class com.scylladb.migrator.Migrator \
   --num-executors $SPARK_WORKER_INSTANCES \
   --executor-memory $MEMORY \
   --conf spark.cassandra.connection.localConnectionsPerExecutor=4 \
-  scylla-migrator/target/scala-2.13/scylla-migrator-assembly-0.0.1.jar
+  migrator/target/scala-2.13/scylla-migrator-assembly.jar
 
 #sometimes you will need a tuning for driver memory size
 #add this config to above to tune it:
@@ -32,6 +32,6 @@ time spark-submit --class com.scylladb.migrator.Migrator \
 #  --executor-memory $MEMORY \
 #  --conf "spark.executor.extraJavaOptions=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=64000 -XX:+HeapDumpOnOutOfMemoryError" \
 #  --conf spark.cassandra.connection.localConnectionsPerExecutor=4 \
-#  scylla-migrator/target/scala-2.13/scylla-migrator-assembly-0.0.1.jar
+#  migrator/target/scala-2.13/scylla-migrator-assembly.jar
 
 #-XX:+HeapDumpOnOutOfMemoryError -XX:+PrintGCDetails

--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ lazy val migrator = (project in file("migrator")).settings(
       val oldStrategy = (assembly / assemblyMergeStrategy).value
       oldStrategy(x)
   },
+  assembly / assemblyJarName := s"${name.value}-assembly.jar",
   // uses compile classpath for the run task, including "provided" jar (cf http://stackoverflow.com/a/21803413/3827)
   Compile / run := Defaults
     .runTask(Compile / fullClasspath, Compile / run / mainClass, Compile / run / runner)

--- a/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
@@ -47,7 +47,7 @@ object SparkUtils {
         // Uncomment one of the following lines to plug a remote debugger on the Spark master or worker.
         // "--conf", "spark.driver.extraJavaOptions=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005",
         // "--conf", "spark.executor.extraJavaOptions=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5006",
-        "/jars/scylla-migrator-assembly-0.0.1.jar"
+        "/jars/scylla-migrator-assembly.jar"
       )
     ).run()
 


### PR DESCRIPTION
- Add a GitHub workflow that builds the jat-jar and uploads it as a release asset each time a new release is published.
- Change the assembled jar name to `scylla-migrator-assembly.jar` (remove the “constant version number” `0.0.1`). Users can download a specific release from the GitHub releases page, if they want to.
- Update the instructions in the README to download the pre-built fat-jar instead of building it manually (I kept the instructions to build it manually, but I moved them to the bottom of the README).
- Update the Ansible recipe and the testing infrastructure accordingly
- Fix path to the assembly in the Ansible scripts along the way

Fixes #154