### PR TITLE
Embed the version number in the application

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,4 +79,10 @@ Follow the procedure documented [here](https://stackoverflow.com/a/15505308/5617
 
 ## Publishing
 
-Create a new [GitHub release](https://github.com/scylladb/scylla-migrator/releases), give it a tag name, a title, and a description, and then click Publish. A workflow will be triggered and will build the application fat-jar and upload it as a release asset.
+Create a new [GitHub release](https://github.com/scylladb/scylla-migrator/releases), give it a tag name (please see below), a title, and a description, and then click Publish. A workflow will be triggered and will build the application fat-jar and upload it as a release asset.
+
+Rules for the release tag name:
+- Make sure to use tag names like `v1.2.3`, starting with `v` and followed by a [semantic version number](https://semver.org/).
+- Bump the major version number if the new release breaks the backward compatibility (e.g., an existing configuration or setup will not work anymore with the new release).
+- Bump the minor version number if the new release introduces new features in a backward compatible manner.
+- Bump the patch version number if the new release only introduces bugfixes in a backward compatible manner.

--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,8 @@ lazy val `spark-kinesis-dynamodb` = project.in(file("spark-kinesis-dynamodb")).s
   )
 )
 
-lazy val migrator = (project in file("migrator")).settings(
+lazy val migrator = (project in file("migrator")).enablePlugins(BuildInfoPlugin).settings(
   name      := "scylla-migrator",
-  version   := "0.0.1",
   mainClass := Some("com.scylladb.migrator.Migrator"),
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   javaOptions ++= Seq(
@@ -71,24 +70,12 @@ lazy val migrator = (project in file("migrator")).settings(
       oldStrategy(x)
   },
   assembly / assemblyJarName := s"${name.value}-assembly.jar",
+  buildInfoKeys := Seq[BuildInfoKey](version),
+  buildInfoPackage := "com.scylladb.migrator",
   // uses compile classpath for the run task, including "provided" jar (cf http://stackoverflow.com/a/21803413/3827)
   Compile / run := Defaults
     .runTask(Compile / fullClasspath, Compile / run / mainClass, Compile / run / runner)
-    .evaluated,
-  pomIncludeRepository := { x =>
-    false
-  },
-  pomIncludeRepository := { x =>
-    false
-  },
-  // publish settings
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot.value)
-      Some("snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  }
+    .evaluated
 ).dependsOn(`spark-kinesis-dynamodb`)
 
 lazy val tests = project.in(file("tests")).settings(

--- a/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
@@ -22,6 +22,8 @@ object Migrator {
     Logger.getLogger("org.apache.spark.scheduler.TaskSetManager").setLevel(Level.WARN)
     Logger.getLogger("com.datastax.spark.connector.cql.CassandraConnector").setLevel(Level.WARN)
 
+    log.info(s"ScyllaDB Migrator ${BuildInfo.version}")
+
     val migratorConfig =
       MigratorConfig.loadFrom(spark.conf.get("spark.scylla.config"))
 

--- a/migrator/src/main/scala/com/scylladb/migrator/Validator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Validator.scala
@@ -35,6 +35,8 @@ object Validator {
     Logger.getLogger("org.apache.spark.scheduler.TaskSetManager").setLevel(Level.INFO)
     Logger.getLogger("com.datastax.spark.connector.cql.CassandraConnector").setLevel(Level.INFO)
 
+    log.info(s"ScyllaDB Migrator Validator ${BuildInfo.version}")
+
     val migratorConfig =
       MigratorConfig.loadFrom(spark.conf.get("spark.scylla.config"))
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,6 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
 
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
+
+addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")


### PR DESCRIPTION
- Show a message like “ScyllaDB Migrator 1.0.0” at start up
- Use sbt-dynver to compute the version from “git describe”
- Use sbt-buildinfo to include the version number computed at “build-time” into the program

Fixes #159