### PR TITLE
Increase the capacity of `itemCount`

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDBS3Export.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDBS3Export.scala
@@ -171,7 +171,7 @@ object DynamoDBS3Export {
   }
 
   case class ManifestSummary(manifestFilesS3Key: String,
-                             itemCount: Int,
+                             itemCount: Long,
                              exportType: Option[String],
                              outputFormat: String)
   object ManifestSummary {


### PR DESCRIPTION
Use `Long` instead of `Int` to match the AWS SDK.

Fixes #186 