### PR TITLE
Apply the AlternatorEndpointProvider only on custom endpoints

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
@@ -293,10 +293,14 @@ object DynamoUtils {
   class AlternatorLoadBalancingEnabler extends DynamoDbClientBuilderTransformer with Configurable {
     private var conf: Configuration = null
 
-    override def apply(builder: DynamoDbClientBuilder): DynamoDbClientBuilder =
-      builder.endpointProvider(
-        new AlternatorEndpointProvider(URI.create(conf.get(DynamoDBConstants.ENDPOINT)))
-      )
+    override def apply(builder: DynamoDbClientBuilder): DynamoDbClientBuilder = {
+      for (customEndpoint <- Option(conf.get(DynamoDBConstants.ENDPOINT))) {
+        builder.endpointProvider(
+          new AlternatorEndpointProvider(URI.create(customEndpoint))
+        )
+      }
+      builder
+    }
 
     override def setConf(configuration: Configuration): Unit =
       conf = configuration


### PR DESCRIPTION
The previous implementation was failing when used on AWS DynamoDB because `conf.get(DynamoDBConstants.ENDPOINT)` was `null`.

This was not caught by our tests because our tests always use a custom endpoint (see #113)