### PR TITLE
Fix CI flakiness due to DynamoDB segments partitioning

### DIFF
--- a/tests/src/test/scala/com/scylladb/migrator/alternator/SkippedSegmentsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/SkippedSegmentsTest.scala
@@ -34,7 +34,7 @@ class SkippedSegmentsTest extends MigratorSuiteWithDynamoDBLocal {
 
     // Verify that some items have been copied to the target database …
     val itemCount = targetAlternatorItemCount(tableName)
-    assert(itemCount > 90L && itemCount < 110L)
+    assert(itemCount > 75L && itemCount < 125L, s"Unexpected item count: ${itemCount}")
     // … but not all of them, hence the validator fails
     submitSparkJob(configPart2, "com.scylladb.migrator.Validator").exitValue().tap { statusCode =>
       assertEquals(statusCode, 1)


### PR DESCRIPTION
The CI failure was caused when we performed partial migration on a subset of the Scan segments. The number of items that belong to the migrated segment can vary across releases of DynamoDB / ScyllaDB.