### PR TITLE
fix-failed-tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 on:
   push:
     branches:
-      - master      
+      - master
     paths:
       - '**.scala'
       - '**.sbt'
@@ -31,6 +31,7 @@ jobs:
         run: ./build.sh
       - name: Set up services
         run: |
+          sudo chmod -R 777 ./tests/docker/scylla ./tests/docker/scylla-source
           docker compose -f docker-compose-tests.yml up -d
           .github/wait-for-port.sh 8000 # ScyllaDB Alternator
           .github/wait-for-port.sh 8001 # DynamoDB

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,16 @@ docs/_build/
 # PyCharm files
 *.idea
 
+# Vscode
+.vscode
+
+# Metals
+.metals
+metals.sbt
+
+# Bloop
+.bloop
+
 # emacs stuff
 
 # Autoenv

--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,7 @@ lazy val tests = project.in(file("tests")).settings(
   libraryDependencies ++= Seq(
     "software.amazon.awssdk"    % "dynamodb"                 % awsSdkVersion,
     "org.apache.spark"         %% "spark-sql"                % sparkVersion,
+    "org.apache.spark"         %% "spark-streaming"          % sparkVersion,
     "org.apache.cassandra"     % "java-driver-query-builder" % "4.18.0",
     "com.github.mjakubowski84" %% "parquet4s-core"           % "1.9.4",
     "org.apache.hadoop"        % "hadoop-client"             % hadoopVersion,

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -240,6 +240,11 @@ target:
 #   # migrator run.
 #   streamChanges: false
 #
+#   # Optional - explicitly set the billing mode when creating the target table.
+#   # Set to PROVISIONED or PAY_PER_REQUEST. If omitted, the mode is derived
+#   # from the source table or defaults to PAY_PER_REQUEST.
+#   billingMode: PAY_PER_REQUEST
+#
 #   # Optional - when streamChanges is true, skip the initial snapshot transfer and only stream changes.
 #   # This setting is ignored if streamChanges is false.
 #   #skipInitialSnapshotTransfer: false

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
@@ -45,7 +45,8 @@ object AlternatorValidator {
       sourceSettings.maxMapTasks,
       sourceSettings.readThroughput,
       sourceSettings.throughputReadPercent,
-      skipSegments = None
+      skipSegments           = None,
+      removeConsumedCapacity = targetSettings.removeConsumedCapacity.getOrElse(false)
     )
 
     // Define some aliases to prevent the Spark engine to try to serialize the whole object graph

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
@@ -5,6 +5,7 @@ import com.scylladb.migrator.AwsUtils
 import io.circe.syntax._
 import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
+import software.amazon.awssdk.services.dynamodb.model.BillingMode
 
 case class DynamoDBEndpoint(host: String, port: Int) {
   def renderEndpoint = s"${host}:${port}"
@@ -38,7 +39,8 @@ object SourceSettings {
                       scanSegments: Option[Int],
                       readThroughput: Option[Int],
                       throughputReadPercent: Option[Float],
-                      maxMapTasks: Option[Int])
+                      maxMapTasks: Option[Int],
+                      removeConsumedCapacity: Option[Boolean] = None)
       extends SourceSettings {
     lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
       AwsUtils.computeFinalCredentials(credentials, endpoint, region)
@@ -71,10 +73,12 @@ object SourceSettings {
       */
     case class TableDescription(
       attributeDefinitions: Seq[AttributeDefinition],
-      keySchema: Seq[KeySchema]
+      keySchema: Seq[KeySchema],
+      billingMode: Option[BillingMode] = None
     )
 
     object TableDescription {
+      import com.scylladb.migrator.config.BillingModeCodec._
       implicit val decoder: Decoder[TableDescription] = deriveDecoder[TableDescription]
       implicit val encoder: Encoder[TableDescription] = deriveEncoder[TableDescription]
     }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
@@ -5,6 +5,8 @@ import com.scylladb.migrator.AwsUtils
 import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import io.circe.syntax._
+import software.amazon.awssdk.services.dynamodb.model.BillingMode
+import com.scylladb.migrator.config.BillingModeCodec._
 
 sealed trait TargetSettings
 object TargetSettings {
@@ -29,7 +31,9 @@ object TargetSettings {
                       writeThroughput: Option[Int],
                       throughputWritePercent: Option[Float],
                       streamChanges: Boolean,
-                      skipInitialSnapshotTransfer: Option[Boolean])
+                      skipInitialSnapshotTransfer: Option[Boolean],
+                      removeConsumedCapacity: Option[Boolean] = None,
+                      billingMode: Option[BillingMode] = None)
       extends TargetSettings {
     lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
       AwsUtils.computeFinalCredentials(credentials, endpoint, region)

--- a/migrator/src/main/scala/com/scylladb/migrator/config/package.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/package.scala
@@ -1,0 +1,17 @@
+package com.scylladb.migrator
+
+import io.circe.Decoder
+import software.amazon.awssdk.services.dynamodb.model.BillingMode
+import io.circe.Encoder
+
+package object config {
+  object BillingModeCodec {
+    implicit val billingModeDecoder: Decoder[BillingMode] =
+      Decoder.decodeString.emap { billingModeStr =>
+        Option(BillingMode.fromValue(billingModeStr))
+          .toRight(s"Invalid billing mode: ${billingModeStr}")
+      }
+    implicit val billingModeEncoder: Encoder[BillingMode] =
+      Encoder.encodeString.contramap(_.toString)
+  }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
@@ -36,26 +36,35 @@ object DynamoDB {
       source.maxMapTasks,
       source.readThroughput,
       source.throughputReadPercent,
-      skipSegments
+      skipSegments,
+      source.removeConsumedCapacity.getOrElse(false)
     )
 
   /**
     * Overload of `readRDD` that does not depend on `SourceSettings.DynamoDB`
     */
-  def readRDD(
-    spark: SparkSession,
-    endpoint: Option[DynamoDBEndpoint],
-    credentials: Option[AWSCredentials],
-    region: Option[String],
-    table: String,
-    scanSegments: Option[Int],
-    maxMapTasks: Option[Int],
-    readThroughput: Option[Int],
-    throughputReadPercent: Option[Float],
-    skipSegments: Option[Set[Int]]): (RDD[(Text, DynamoDBItemWritable)], TableDescription) = {
+  def readRDD(spark: SparkSession,
+              endpoint: Option[DynamoDBEndpoint],
+              credentials: Option[AWSCredentials],
+              region: Option[String],
+              table: String,
+              scanSegments: Option[Int],
+              maxMapTasks: Option[Int],
+              readThroughput: Option[Int],
+              throughputReadPercent: Option[Float],
+              skipSegments: Option[Set[Int]],
+              removeConsumedCapacity: Boolean = false)
+    : (RDD[(Text, DynamoDBItemWritable)], TableDescription) = {
 
     val dynamoDbClient =
-      DynamoUtils.buildDynamoClient(endpoint, credentials.map(_.toProvider), region)
+      DynamoUtils.buildDynamoClient(
+        endpoint,
+        credentials.map(_.toProvider),
+        region,
+        if (removeConsumedCapacity)
+          Seq(new DynamoUtils.RemoveConsumedCapacityInterceptor)
+        else Nil
+      )
 
     val tableDescription =
       dynamoDbClient
@@ -82,7 +91,8 @@ object DynamoDB {
         throughputReadPercent,
         tableDescription,
         maybeTtlDescription,
-        skipSegments
+        skipSegments,
+        removeConsumedCapacity
       )
 
     val rdd =
@@ -106,7 +116,8 @@ object DynamoDB {
     throughputReadPercent: Option[Float],
     description: TableDescription,
     maybeTtlDescription: Option[TimeToLiveDescription],
-    skipSegments: Option[Set[Int]]
+    skipSegments: Option[Set[Int]],
+    removeConsumedCapacity: Boolean
   ): JobConf = {
     val maybeItemCount = Option(description.itemCount).map(_.toLong)
     val maybeAvgItemSize =
@@ -124,7 +135,8 @@ object DynamoDB {
       endpoint,
       scanSegments,
       maxMapTasks,
-      credentials
+      credentials,
+      removeConsumedCapacity
     )
     jobConf.set(DynamoDBConstants.INPUT_TABLE_NAME, table)
     setOptionalConf(jobConf, DynamoDBConstants.ITEM_COUNT, maybeItemCount.map(_.toString))

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDBS3Export.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDBS3Export.scala
@@ -13,6 +13,8 @@ import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.dynamodb.model.{
   AttributeDefinition,
   AttributeValue,
+  BillingMode,
+  BillingModeSummary,
   KeySchemaElement,
   ProvisionedThroughputDescription,
   ScalarAttributeType,
@@ -165,6 +167,10 @@ object DynamoDBS3Export {
           ): _*
         )
         .provisionedThroughput(ProvisionedThroughputDescription.builder().build())
+        .billingModeSummary(BillingModeSummary
+          .builder()
+          .billingMode(source.tableDescription.billingMode.getOrElse(BillingMode.PAY_PER_REQUEST))
+          .build())
         .build()
 
     (rdd, tableDescription)

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
@@ -30,7 +30,9 @@ object DynamoDB {
       target.endpoint,
       maybeScanSegments = None,
       maybeMaxMapTasks  = None,
-      target.finalCredentials)
+      target.finalCredentials,
+      target.removeConsumedCapacity.getOrElse(false)
+    )
     jobConf.set(DynamoDBConstants.OUTPUT_TABLE_NAME, target.table)
     val writeThroughput =
       target.writeThroughput match {

--- a/tests/docker/.gitignore
+++ b/tests/docker/.gitignore
@@ -1,5 +1,3 @@
 cassandra/
 s3/
-scylla/
-scylla-source/
 spark-master/

--- a/tests/docker/scylla-source/.gitignore
+++ b/tests/docker/scylla-source/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tests/docker/scylla/.gitignore
+++ b/tests/docker/scylla/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tests/src/test/configurations/dynamodb-s3-export-to-alternator-basic.yaml
+++ b/tests/src/test/configurations/dynamodb-s3-export-to-alternator-basic.yaml
@@ -17,6 +17,7 @@ source:
     keySchema:
       - name: id
         type: HASH
+    billingMode: PAY_PER_REQUEST
 
 target:
   type: dynamodb
@@ -29,6 +30,8 @@ target:
     accessKey: dummy
     secretKey: dummy
   streamChanges: false
+  removeConsumedCapacity: true
+  billingMode: PAY_PER_REQUEST
 
 # Below are unused but mandatory settings
 savepoints:

--- a/tests/src/test/configurations/dynamodb-to-alternator-basic.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-basic.yaml
@@ -20,6 +20,8 @@ target:
     accessKey: dummy
     secretKey: dummy
   streamChanges: false
+  removeConsumedCapacity: true
+  billingMode: PAY_PER_REQUEST
 
 # Below are unused but mandatory settings
 savepoints:

--- a/tests/src/test/configurations/dynamodb-to-alternator-issue-103.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-issue-103.yaml
@@ -23,6 +23,8 @@ target:
     secretKey: dummy
   maxMapTasks: 1
   streamChanges: false
+  removeConsumedCapacity: true
+  billingMode: PAY_PER_REQUEST
 
 # Below are unused but mandatory settings
 savepoints:

--- a/tests/src/test/configurations/dynamodb-to-alternator-part1.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-part1.yaml
@@ -21,6 +21,8 @@ target:
     accessKey: dummy
     secretKey: dummy
   streamChanges: false
+  removeConsumedCapacity: true
+  billingMode: PAY_PER_REQUEST
 
 savepoints:
   path: /app/savepoints

--- a/tests/src/test/configurations/dynamodb-to-alternator-part2.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-part2.yaml
@@ -21,6 +21,8 @@ target:
     accessKey: dummy
     secretKey: dummy
   streamChanges: false
+  removeConsumedCapacity: true
+  billingMode: PAY_PER_REQUEST
 
 savepoints:
   path: /app/savepoints

--- a/tests/src/test/configurations/dynamodb-to-alternator-renames.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-renames.yaml
@@ -22,6 +22,8 @@ target:
     secretKey: dummy
   maxMapTasks: 1
   streamChanges: false
+  removeConsumedCapacity: true
+  billingMode: PAY_PER_REQUEST
 
 renames:
   - from: foo

--- a/tests/src/test/configurations/dynamodb-to-alternator-secondary-indexes.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-secondary-indexes.yaml
@@ -20,6 +20,8 @@ target:
     accessKey: dummy
     secretKey: dummy
   streamChanges: false
+  removeConsumedCapacity: true
+  billingMode: PAY_PER_REQUEST
 
 renames: []
 

--- a/tests/src/test/configurations/dynamodb-to-alternator-streaming-skip-snapshot.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-streaming-skip-snapshot.yaml
@@ -15,6 +15,8 @@ target:
     secretKey: dummy
   streamChanges: true
   skipInitialSnapshotTransfer: true
+  removeConsumedCapacity: true
+  billingMode: PAY_PER_REQUEST
 
 savepoints:
   path: /app/savepoints

--- a/tests/src/test/configurations/dynamodb-to-alternator-streaming.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-streaming.yaml
@@ -14,6 +14,8 @@ target:
     accessKey: dummy
     secretKey: dummy
   streamChanges: true
+  removeConsumedCapacity: true
+  billingMode: PAY_PER_REQUEST
 
 savepoints:
   path: /app/savepoints

--- a/tests/src/test/configurations/dynamodb-to-alternator-ttl.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-ttl.yaml
@@ -20,6 +20,8 @@ target:
     accessKey: dummy
     secretKey: dummy
   streamChanges: false
+  removeConsumedCapacity: true
+  billingMode: PAY_PER_REQUEST
 
 savepoints:
   path: /app/savepoints

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBInputFormatTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBInputFormatTest.scala
@@ -76,7 +76,8 @@ class DynamoDBInputFormatTest extends munit.FunSuite {
       throughputReadPercent = configuredThroughputReadPercent,
       description = tableDescriptionBuilder.build(),
       maybeTtlDescription = None,
-      skipSegments = None
+      skipSegments = None,
+      removeConsumedCapacity = false
     )
     val splits = new DynamoDBInputFormat().getSplits(jobConf, 1)
 

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
@@ -21,6 +21,8 @@ import scala.sys.process.stringToProcess
   *
   */
 trait MigratorSuite extends munit.FunSuite {
+  import com.scylladb.migrator.DynamoUtils
+  import com.scylladb.migrator.config.DynamoDBEndpoint
 
   /** Client of a source DynamoDB instance */
   def sourceDDb: Fixture[DynamoDbClient]
@@ -31,12 +33,12 @@ trait MigratorSuite extends munit.FunSuite {
     def apply(): DynamoDbClient = client
     override def beforeAll(): Unit = {
       client =
-        DynamoDbClient
-          .builder()
-          .region(Region.of("dummy"))
-          .endpointOverride(new URI("http://localhost:8000"))
-          .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", "dummy")))
-          .build()
+        DynamoUtils.buildDynamoClient(
+          endpoint = Some(DynamoDBEndpoint("http://localhost", 8000)),
+          creds = Some(StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", "dummy"))),
+          region = Some("dummy"),
+          interceptors = Seq(new DynamoUtils.RemoveConsumedCapacityInterceptor)
+        )
     }
     override def afterAll(): Unit = client.close()
   }


### PR DESCRIPTION
There were several problems that ruined tests:

- containers were not able to access `scylla` and `scylla-source` folders
Folders is created + chmod is applied

- `INDEXES consumed capacity is not supported` issue on the Alternator side
new config was added remove_consumed_capacity ( default false )
if true => set ConsumedCapacity to null

- `provisionedThroughput.readCapacityUnits is missing, when BillingMode=PROVISIONED`
Proposed solution is to add config for billing mode and check if readCapacityUnits / writeCapacityUnits are set for it