### PR TITLE
Scylla 2025.1 introduced billing checks for Alternator

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -245,8 +245,8 @@ target:
 #   # from the source table or defaults to PAY_PER_REQUEST.
 #   billingMode: PAY_PER_REQUEST
 #
-#   # When billingMode is set to PAY_PER_REQUEST this should be true
-#   # For PROVISIONED it can stay false
+#   # When billingMode is set to PROVISIONED or unset this should be true
+#   # Table created with provisioned mode in Alternator should have the `--provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1` set
 #   # It configures the capacity accounting and removes the need for it (needed for Scylla version > 2024.2)
 #   # removeConsumedCapacity: true
 #

--- a/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
@@ -32,7 +32,7 @@ object TargetSettings {
                       throughputWritePercent: Option[Float],
                       streamChanges: Boolean,
                       skipInitialSnapshotTransfer: Option[Boolean],
-                      removeConsumedCapacity: Option[Boolean] = None,
+                      removeConsumedCapacity: Option[Boolean] = Some(true),
                       billingMode: Option[BillingMode] = None)
       extends TargetSettings {
     lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =


### PR DESCRIPTION
(see https://github.com/scylladb/scylladb/commit/c76347032d01ac37fbc587d0540ee6b0cf9b419d)

Scylla migrator now has options to set billingMode to provisioned or to set removeConsumedCapacity (which now defaults to true to avoid capacity limiting on Alternator)

Also workarounding automatic detection of provisioned units can be done using creation of alternator table like this:
```
aws dynamodb create-table    --table-name dev_source_data_reference_store    --attribute-definitions AttributeName=reference_id,AttributeType=S    --key-schema AttributeName=reference_id,KeyType=HASH    --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1    --endpoint-url "http://10.123.0.2:8000/
```

fixes #244