### PR TITLE
Update spark-scylladb-connector to 4.1.0

### DIFF
--- a/.github/workflows/tests-aws.yml
+++ b/.github/workflows/tests-aws.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Download assembly JAR


### PR DESCRIPTION
## Summary
- Bump `spark-scylladb-connector` from 4.0.0 to 4.1.0
- Update Java from 8/11 to 17 across CI workflows, Spark Docker image, and build Dockerfile
- Update Spark version in Docker image from 3.5.1 to 3.5.8

## Test plan
- [x] Verify the project compiles with the updated dependency
- [x] Run existing integration tests