### PR TITLE
Update alternator load-balancing from 1.0.0 to 2.0.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val migrator = (project in file("migrator"))
       "com.scylladb"          %% "spark-scylladb-connector" % connectorVersion,
       "com.github.jnr" % "jnr-posix" % "3.1.19", // Needed by the Spark ScyllaDB connector
       "com.scylladb.alternator" % "emr-dynamodb-hadoop"  % "5.8.0",
-      "com.scylladb.alternator" % "load-balancing"       % "1.0.0",
+      "com.scylladb.alternator" % "load-balancing"       % "2.0.3",
       "io.circe"               %% "circe-generic"        % circeVersion,
       "io.circe"               %% "circe-parser"         % circeVersion,
       "io.circe"               %% "circe-yaml"           % "0.15.1",

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -253,6 +253,31 @@ target:
 #   # Optional - when streamChanges is true, skip the initial snapshot transfer and only stream changes.
 #   # This setting is ignored if streamChanges is false.
 #   #skipInitialSnapshotTransfer: false
+#
+#   # Optional - Alternator-specific settings (only used when endpoint is set):
+#   #alternator:
+#   #  # Preferred datacenter for DC-aware routing (falls back to all nodes if unavailable)
+#   #  datacenter: dc1
+#   #  # Preferred rack for rack-aware routing (requires datacenter, falls back to DC then all nodes)
+#   #  rack: rack1
+#   #  # Interval (ms) for refreshing the node list while the client is active (default: 1000)
+#   #  activeRefreshIntervalMs: 1000
+#   #  # Interval (ms) for refreshing the node list while the client is idle (default: 60000)
+#   #  idleRefreshIntervalMs: 60000
+#   #  # Enable GZIP compression of request bodies (default: false)
+#   #  compression: false
+#   #  # Optimize HTTP headers to reduce traffic overhead (default: false)
+#   #  optimizeHeaders: false
+#   #  # Maximum connections in the HTTP connection pool (default: 400)
+#   #  maxConnections: 400
+#   #  # Maximum idle time for pooled connections in ms (default: 600000)
+#   #  connectionMaxIdleTimeMs: 600000
+#   #  # Maximum lifetime for pooled connections in ms, 0 = unlimited (default: 0)
+#   #  connectionTimeToLiveMs: 0
+#   #  # Maximum time to wait when the pool is exhausted in ms (default: 10000)
+#   #  connectionAcquisitionTimeoutMs: 10000
+#   #  # Maximum time to wait for TCP handshake in ms (default: 15000)
+#   #  connectionTimeoutMs: 15000
 
 # Savepoints are configuration files (like this one), saved by the migrator as it
 # runs. Their purpose is to skip token ranges that have already been copied. This

--- a/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
@@ -1,14 +1,28 @@
 package com.scylladb.migrator
 
-import com.scylladb.alternator.AlternatorEndpointProvider
-import com.scylladb.migrator.config.{ DynamoDBEndpoint, SourceSettings, TargetSettings }
+import com.scylladb.alternator.AlternatorDynamoDbClient
+import com.scylladb.alternator.routing.{ ClusterScope, DatacenterScope, RackScope }
+import com.scylladb.alternator.RequestCompressionAlgorithm
+import com.scylladb.migrator.config.{
+  AlternatorSettings,
+  DynamoDBEndpoint,
+  SourceSettings,
+  TargetSettings
+}
 import org.apache.hadoop.conf.{ Configurable, Configuration }
 import org.apache.hadoop.dynamodb.read.DynamoDBInputFormat
 import org.apache.hadoop.dynamodb.write.DynamoDBOutputFormat
 import org.apache.hadoop.dynamodb.{ DynamoDBConstants, DynamoDbClientBuilderTransformer }
 import org.apache.hadoop.mapred.JobConf
 import org.apache.logging.log4j.LogManager
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.auth.credentials.{
+  AwsBasicCredentials,
+  AwsCredentialsProvider,
+  AwsSessionCredentials,
+  DefaultCredentialsProvider,
+  StaticCredentialsProvider
+}
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.{ DynamoDbClient, DynamoDbClientBuilder }
 import software.amazon.awssdk.core.SdkRequest
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
@@ -50,6 +64,22 @@ import scala.jdk.OptionConverters._
 object DynamoUtils {
   val log = LogManager.getLogger("com.scylladb.migrator.DynamoUtils")
   private val RemoveConsumedCapacityConfig = "scylla.migrator.remove_consumed_capacity"
+  private val AlternatorDatacenterConfig = "scylla.migrator.alternator.datacenter"
+  private val AlternatorRackConfig = "scylla.migrator.alternator.rack"
+  private val AlternatorActiveRefreshConfig =
+    "scylla.migrator.alternator.active_refresh_interval_ms"
+  private val AlternatorIdleRefreshConfig = "scylla.migrator.alternator.idle_refresh_interval_ms"
+  private val AlternatorCompressionConfig = "scylla.migrator.alternator.compression"
+  private val AlternatorOptimizeHeadersConfig = "scylla.migrator.alternator.optimize_headers"
+  private val AlternatorMaxConnectionsConfig = "scylla.migrator.alternator.max_connections"
+  private val AlternatorConnectionMaxIdleTimeMsConfig =
+    "scylla.migrator.alternator.connection_max_idle_time_ms"
+  private val AlternatorConnectionTimeToLiveMsConfig =
+    "scylla.migrator.alternator.connection_time_to_live_ms"
+  private val AlternatorConnectionAcquisitionTimeoutMsConfig =
+    "scylla.migrator.alternator.connection_acquisition_timeout_ms"
+  private val AlternatorConnectionTimeoutMsConfig =
+    "scylla.migrator.alternator.connection_timeout_ms"
 
   class RemoveConsumedCapacityInterceptor extends ExecutionInterceptor {
     override def modifyRequest(ctx: Context.ModifyRequest, attrs: ExecutionAttributes): SdkRequest =
@@ -82,7 +112,8 @@ object DynamoUtils {
         target.region,
         if (target.removeConsumedCapacity.getOrElse(false))
           Seq(new RemoveConsumedCapacityInterceptor)
-        else Nil
+        else Nil,
+        target.alternator
       )
 
     log.info("Checking for table existence at destination")
@@ -196,7 +227,8 @@ object DynamoUtils {
         source.region,
         if (source.removeConsumedCapacity.getOrElse(false))
           Seq(new RemoveConsumedCapacityInterceptor)
-        else Nil
+        else Nil,
+        source.alternator
       )
     val sourceStreamsClient =
       buildDynamoStreamsClient(
@@ -247,14 +279,55 @@ object DynamoUtils {
     endpoint: Option[DynamoDBEndpoint],
     creds: Option[AwsCredentialsProvider],
     region: Option[String],
-    interceptors: Seq[ExecutionInterceptor]
+    interceptors: Seq[ExecutionInterceptor],
+    alternatorSettings: Option[AlternatorSettings] = None
   ): DynamoDbClient = {
+    val baseBuilder: DynamoDbClientBuilder =
+      if (endpoint.isDefined) {
+        val altBuilder = AlternatorDynamoDbClient.builder()
+        applyAlternatorSettings(altBuilder, alternatorSettings)
+        altBuilder
+      } else DynamoDbClient.builder()
     val builder =
-      AwsUtils.configureClientBuilder(DynamoDbClient.builder(), endpoint, region, creds)
+      AwsUtils.configureClientBuilder(baseBuilder, endpoint, region, creds)
     val conf = ClientOverrideConfiguration.builder()
     interceptors.foreach(conf.addExecutionInterceptor)
     builder.overrideConfiguration(conf.build()).build()
   }
+
+  private def applyAlternatorSettings(
+    altBuilder: AlternatorDynamoDbClient.AlternatorDynamoDbClientBuilder,
+    alternatorSettings: Option[AlternatorSettings]
+  ): Unit =
+    for (settings <- alternatorSettings) {
+      val routingScope = (settings.datacenter, settings.rack) match {
+        case (Some(dc), Some(rack)) =>
+          RackScope.of(dc, rack, DatacenterScope.of(dc, ClusterScope.create()))
+        case (Some(dc), None) =>
+          DatacenterScope.of(dc, ClusterScope.create())
+        case _ => null
+      }
+      if (routingScope != null)
+        altBuilder.withRoutingScope(routingScope)
+      for (interval <- settings.activeRefreshIntervalMs)
+        altBuilder.withActiveRefreshIntervalMs(interval)
+      for (interval <- settings.idleRefreshIntervalMs)
+        altBuilder.withIdleRefreshIntervalMs(interval)
+      if (settings.compression.getOrElse(false))
+        altBuilder.withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+      if (settings.optimizeHeaders.getOrElse(false))
+        altBuilder.withOptimizeHeaders(true)
+      for (maxConns <- settings.maxConnections)
+        altBuilder.withMaxConnections(maxConns)
+      for (idleTime <- settings.connectionMaxIdleTimeMs)
+        altBuilder.withConnectionMaxIdleTimeMs(idleTime)
+      for (ttl <- settings.connectionTimeToLiveMs)
+        altBuilder.withConnectionTimeToLiveMs(ttl)
+      for (timeout <- settings.connectionAcquisitionTimeoutMs)
+        altBuilder.withConnectionAcquisitionTimeoutMs(timeout)
+      for (timeout <- settings.connectionTimeoutMs)
+        altBuilder.withConnectionTimeoutMs(timeout)
+    }
 
   def buildDynamoStreamsClient(
     endpoint: Option[DynamoDBEndpoint],
@@ -300,7 +373,8 @@ object DynamoUtils {
     maybeScanSegments: Option[Int],
     maybeMaxMapTasks: Option[Int],
     maybeAwsCredentials: Option[AWSCredentials],
-    removeConsumedCapacity: Boolean = false
+    removeConsumedCapacity: Boolean = false,
+    alternatorSettings: Option[AlternatorSettings] = None
   ): Unit = {
     for (region <- maybeRegion) {
       log.info(s"Using AWS region: ${region}")
@@ -332,6 +406,52 @@ object DynamoUtils {
 
     jobConf.set("mapred.output.format.class", classOf[DynamoDBOutputFormat].getName)
     jobConf.set("mapred.input.format.class", classOf[DynamoDBInputFormat].getName)
+
+    for (settings <- alternatorSettings) {
+      setOptionalConf(jobConf, AlternatorDatacenterConfig, settings.datacenter)
+      setOptionalConf(jobConf, AlternatorRackConfig, settings.rack)
+      setOptionalConf(
+        jobConf,
+        AlternatorActiveRefreshConfig,
+        settings.activeRefreshIntervalMs.map(_.toString)
+      )
+      setOptionalConf(
+        jobConf,
+        AlternatorIdleRefreshConfig,
+        settings.idleRefreshIntervalMs.map(_.toString)
+      )
+      setOptionalConf(jobConf, AlternatorCompressionConfig, settings.compression.map(_.toString))
+      setOptionalConf(
+        jobConf,
+        AlternatorOptimizeHeadersConfig,
+        settings.optimizeHeaders.map(_.toString)
+      )
+      setOptionalConf(
+        jobConf,
+        AlternatorMaxConnectionsConfig,
+        settings.maxConnections.map(_.toString)
+      )
+      setOptionalConf(
+        jobConf,
+        AlternatorConnectionMaxIdleTimeMsConfig,
+        settings.connectionMaxIdleTimeMs.map(_.toString)
+      )
+      setOptionalConf(
+        jobConf,
+        AlternatorConnectionTimeToLiveMsConfig,
+        settings.connectionTimeToLiveMs.map(_.toString)
+      )
+      setOptionalConf(
+        jobConf,
+        AlternatorConnectionAcquisitionTimeoutMsConfig,
+        settings.connectionAcquisitionTimeoutMs.map(_.toString)
+      )
+      setOptionalConf(
+        jobConf,
+        AlternatorConnectionTimeoutMsConfig,
+        settings.connectionTimeoutMs.map(_.toString)
+      )
+    }
   }
 
   /** @return
@@ -366,14 +486,60 @@ object DynamoUtils {
     private var conf: Configuration = null
 
     override def apply(builder: DynamoDbClientBuilder): DynamoDbClientBuilder = {
-      for (customEndpoint <- Option(conf.get(DynamoDBConstants.ENDPOINT)))
-        builder.endpointProvider(
-          new AlternatorEndpointProvider(URI.create(customEndpoint))
-        )
+      val effectiveBuilder: DynamoDbClientBuilder =
+        Option(conf.get(DynamoDBConstants.ENDPOINT)) match {
+          case Some(customEndpoint) =>
+            val altBuilder = AlternatorDynamoDbClient.builder()
+            altBuilder.endpointOverride(URI.create(customEndpoint))
+            for (region <- Option(conf.get(DynamoDBConstants.REGION)))
+              altBuilder.region(Region.of(region))
+            (
+              Option(conf.get(DynamoDBConstants.DYNAMODB_ACCESS_KEY_CONF)),
+              Option(conf.get(DynamoDBConstants.DYNAMODB_SECRET_KEY_CONF))
+            ) match {
+              case (Some(accessKey), Some(secretKey)) =>
+                val awsCreds =
+                  Option(conf.get(DynamoDBConstants.DYNAMODB_SESSION_TOKEN_CONF)) match {
+                    case Some(token) =>
+                      AwsSessionCredentials.create(accessKey, secretKey, token)
+                    case None =>
+                      AwsBasicCredentials.create(accessKey, secretKey)
+                  }
+                altBuilder.credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+              case _ => // No credentials configured - use anonymous (Alternator default)
+            }
+            applyAlternatorSettings(
+              altBuilder,
+              Some(
+                AlternatorSettings(
+                  datacenter = Option(conf.get(AlternatorDatacenterConfig)),
+                  rack       = Option(conf.get(AlternatorRackConfig)),
+                  activeRefreshIntervalMs =
+                    Option(conf.get(AlternatorActiveRefreshConfig)).map(_.toLong),
+                  idleRefreshIntervalMs =
+                    Option(conf.get(AlternatorIdleRefreshConfig)).map(_.toLong),
+                  compression = Option(conf.get(AlternatorCompressionConfig)).map(_.toBoolean),
+                  optimizeHeaders =
+                    Option(conf.get(AlternatorOptimizeHeadersConfig)).map(_.toBoolean),
+                  maxConnections = Option(conf.get(AlternatorMaxConnectionsConfig)).map(_.toInt),
+                  connectionMaxIdleTimeMs =
+                    Option(conf.get(AlternatorConnectionMaxIdleTimeMsConfig)).map(_.toLong),
+                  connectionTimeToLiveMs =
+                    Option(conf.get(AlternatorConnectionTimeToLiveMsConfig)).map(_.toLong),
+                  connectionAcquisitionTimeoutMs =
+                    Option(conf.get(AlternatorConnectionAcquisitionTimeoutMsConfig)).map(_.toLong),
+                  connectionTimeoutMs =
+                    Option(conf.get(AlternatorConnectionTimeoutMsConfig)).map(_.toLong)
+                )
+              )
+            )
+            altBuilder
+          case None => builder
+        }
       val overrideConf = ClientOverrideConfiguration.builder()
       if (conf.get(RemoveConsumedCapacityConfig, "false").toBoolean)
         overrideConf.addExecutionInterceptor(new RemoveConsumedCapacityInterceptor)
-      builder.overrideConfiguration(overrideConf.build())
+      effectiveBuilder.overrideConfiguration(overrideConf.build())
     }
 
     override def setConf(configuration: Configuration): Unit =

--- a/migrator/src/main/scala/com/scylladb/migrator/config/AlternatorSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/AlternatorSettings.scala
@@ -1,0 +1,23 @@
+package com.scylladb.migrator.config
+
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
+
+case class AlternatorSettings(
+  datacenter: Option[String] = None,
+  rack: Option[String] = None,
+  activeRefreshIntervalMs: Option[Long] = None,
+  idleRefreshIntervalMs: Option[Long] = None,
+  compression: Option[Boolean] = None,
+  optimizeHeaders: Option[Boolean] = None,
+  maxConnections: Option[Int] = None,
+  connectionMaxIdleTimeMs: Option[Long] = None,
+  connectionTimeToLiveMs: Option[Long] = None,
+  connectionAcquisitionTimeoutMs: Option[Long] = None,
+  connectionTimeoutMs: Option[Long] = None
+)
+
+object AlternatorSettings {
+  implicit val decoder: Decoder[AlternatorSettings] = deriveDecoder
+  implicit val encoder: Encoder[AlternatorSettings] = deriveEncoder
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
@@ -42,7 +42,8 @@ object SourceSettings {
     readThroughput: Option[Int],
     throughputReadPercent: Option[Float],
     maxMapTasks: Option[Int],
-    removeConsumedCapacity: Option[Boolean] = None
+    removeConsumedCapacity: Option[Boolean] = None,
+    alternator: Option[AlternatorSettings] = None
   ) extends SourceSettings {
     lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
       AwsUtils.computeFinalCredentials(credentials, endpoint, region)

--- a/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
@@ -35,7 +35,8 @@ object TargetSettings {
     streamChanges: Boolean,
     skipInitialSnapshotTransfer: Option[Boolean],
     removeConsumedCapacity: Option[Boolean] = Some(true),
-    billingMode: Option[BillingMode] = None
+    billingMode: Option[BillingMode] = None,
+    alternator: Option[AlternatorSettings] = None
   ) extends TargetSettings {
     lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
       AwsUtils.computeFinalCredentials(credentials, endpoint, region)

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
@@ -36,7 +36,8 @@ object DynamoDB {
           target.endpoint,
           target.finalCredentials.map(_.toProvider),
           target.region,
-          Seq.empty
+          Seq.empty,
+          target.alternator
         )
 
         try
@@ -91,7 +92,8 @@ object DynamoDB {
       maybeScanSegments = None,
       maybeMaxMapTasks  = None,
       target.finalCredentials,
-      target.removeConsumedCapacity.getOrElse(false)
+      target.removeConsumedCapacity.getOrElse(false),
+      target.alternator
     )
     jobConf.set(DynamoDBConstants.OUTPUT_TABLE_NAME, target.table)
     val writeThroughput =

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
@@ -57,7 +57,8 @@ object DynamoStreamReplication {
             target.endpoint,
             target.finalCredentials.map(_.toProvider),
             target.region,
-            Seq.empty
+            Seq.empty,
+            target.alternator
           )
         try
           partition.foreach { item =>


### PR DESCRIPTION
## Summary
- Bump `com.scylladb.alternator:load-balancing` from 1.0.0 to 2.0.3
- Use the public `AlternatorDynamoDbClient.builder()` API instead of internal `AlternatorLiveNodes` + `BasicQueryPlanInterceptor`
- Use `AlternatorDynamoDbClient.builder()` in `buildDynamoClient` to add load balancing to table management, delete, and stream replication operations (not just Hadoop bulk I/O)
- Support anonymous credentials (no credentials configured) for Alternator
- Add Alternator-specific client configuration via optional `alternator` YAML section:
  - `datacenter` / `rack`: DC and rack-aware routing with automatic fallback
  - `activeRefreshIntervalMs` / `idleRefreshIntervalMs`: node list refresh tuning
  - `compression`: GZIP compression of request bodies
  - `optimizeHeaders`: reduce HTTP header overhead
  - `maxConnections`: HTTP connection pool size (default 400)
  - `connectionMaxIdleTimeMs`: max idle time for pooled connections (default 600s)
  - `connectionTimeToLiveMs`: connection TTL (default unlimited)
  - `connectionAcquisitionTimeoutMs`: pool exhaustion wait (default 10s)
  - `connectionTimeoutMs`: TCP connect timeout (default 15s)
- Settings apply to all data paths: direct SDK (deletes, stream replication, DDL) and Hadoop-based (bulk scan/write)

## Test plan
- [x] Verify the project compiles with the updated dependency
- [x] Run existing integration tests (Scylla + Alternator)
- [x] Run DynamoDB tutorial test
- [x] Test with alternator section omitted (backward compatibility)
- [x] Test with alternator section present including new connection pool settings