### PR TITLE
Add Dependabot scanning for Scala/Java dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     allow:
       - dependency-name: "sphinx-scylladb-theme"
       - dependency-name: "sphinx-multiversion-scylla"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Add maven ecosystem to Dependabot config to track Spark, AWS SDK, Hadoop, and other JVM dependency updates
- Currently only Python docs dependencies are monitored; this closes the gap for the main application

## Test plan
- Verify Dependabot starts creating PRs for outdated maven dependencies after merge