### PR TITLE
Add Scalafmt formatting check to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,8 @@ jobs:
           java-version: 8
           cache: sbt
       - uses: sbt/setup-sbt@v1
+      - name: Check formatting
+        run: sbt scalafmtCheckAll
       - name: Build migrator
         run: ./build.sh
       - name: Set up services


### PR DESCRIPTION
## Summary
- Add `sbt scalafmtCheckAll` step to the tests workflow to enforce consistent code formatting
- The project already has scalafmt configured but CI never verified formatting, allowing violations to be merged

## Test plan
- Verify the formatting check step runs on this PR
- Confirm it fails if code is intentionally misformatted