### PR TITLE
Add code coverage reporting with sbt-scoverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,15 @@ jobs:
           .github/wait-for-port.sh 8080 # Spark master
           .github/wait-for-port.sh 8081 # Spark worker
       - name: Run tests locally
-        run: sbt "testOnly -- --exclude-categories=com.scylladb.migrator.AWS"
+        run: sbt coverage "testOnly -- --exclude-categories=com.scylladb.migrator.AWS"
       - name: Stop services
         run: docker compose -f docker-compose-tests.yml down
+      - name: Generate coverage report
+        run: sbt coverageReport
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            tests/target/scala-2.13/scoverage-report/
+            migrator/target/scala-2.13/scoverage-report/

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,3 +4,5 @@ addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")


### PR DESCRIPTION
## Summary
- Add sbt-scoverage plugin for Scala code coverage instrumentation
- Enable coverage during test runs in CI and upload HTML coverage reports as artifacts
- Coverage reports are available as downloadable artifacts after each CI run

## Test plan
- Verify the tests workflow completes with coverage enabled
- Download the coverage report artifact and inspect the HTML report