### PR TITLE
Extend CI trigger paths to include workflows, Dockerfiles, and scripts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,21 @@ on:
     paths:
       - '**.scala'
       - '**.sbt'
+      - 'Dockerfile'
+      - 'dockerfiles/**'
+      - 'docker-compose-tests.yml'
+      - '.github/workflows/**'
+      - '.github/*.sh'
+
   pull_request:
     paths:
       - '**.scala'
       - '**.sbt'
+      - 'Dockerfile'
+      - 'dockerfiles/**'
+      - 'docker-compose-tests.yml'
+      - '.github/workflows/**'
+      - '.github/*.sh'
 
 jobs:
   test:

--- a/.github/workflows/tutorial-dynamodb.yaml
+++ b/.github/workflows/tutorial-dynamodb.yaml
@@ -6,10 +6,19 @@ on:
     paths:
       - '**.scala'
       - '**.sbt'
+      - 'Dockerfile'
+      - 'dockerfiles/**'
+      - '.github/workflows/**'
+      - '.github/*.sh'
+
   pull_request:
     paths:
       - '**.scala'
       - '**.sbt'
+      - 'Dockerfile'
+      - 'dockerfiles/**'
+      - '.github/workflows/**'
+      - '.github/*.sh'
 
 env:
   TUTORIAL_DIR: docs/source/tutorials/dynamodb-to-scylladb-alternator


### PR DESCRIPTION
## Summary
- Add paths to CI triggers so changes to workflow files, Dockerfiles, docker-compose test config, and helper scripts also trigger the test and tutorial workflows
- Previously only `.scala` and `.sbt` changes triggered CI, meaning infrastructure changes could be merged without any validation

## Test plan
- This PR itself should trigger the tests workflow, confirming the fix works