### PR TITLE
Fix ScyllaDB permission error in AWS integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,8 @@ start-services: spark-image ## Start all Docker Compose test services
 	docker compose -f $(COMPOSE_FILE) up -d
 
 start-services-aws: spark-image ## Start only services needed for AWS tests
-	$(Q)docker compose -f $(COMPOSE_FILE) up -d scylla spark-master spark-worker
+	$(Q)sudo chmod -R 777 ./tests/docker/scylla
+	docker compose -f $(COMPOSE_FILE) up -d scylla spark-master spark-worker
 
 wait-for-services: ## Wait for all test services to become ready
 	$(Q)$(call wait-for-port,8000)


### PR DESCRIPTION
## Summary
- The `start-services-aws` Makefile target was missing the `sudo chmod -R 777 ./tests/docker/scylla` command that `start-services` already has
- This caused the ScyllaDB container to crash with `PermissionError: [Errno 13] Permission denied: '/var/lib/scylla/data'` because the mounted host directory lacked write permissions
- Fixes https://github.com/scylladb/scylla-migrator/actions/runs/22464078234/job/65065831623

## Test plan
- [x] Re-run AWS integration tests CI and confirm ScyllaDB starts successfully