### PR TITLE
Update urllib3 to 2.6.3 to fix Trivy CVEs

### DIFF
--- a/docs/poetry.lock
+++ b/docs/poetry.lock
@@ -1202,21 +1202,21 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
-    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
+    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "uvicorn"


### PR DESCRIPTION
## Summary
- Update `urllib3` from 2.5.0 to 2.6.3 in `docs/poetry.lock` to resolve 3 HIGH severity CVEs flagged by Trivy:
  - CVE-2025-66418: Unbounded decompression chain leads to resource exhaustion
  - CVE-2025-66471: Streaming API improperly handles highly compressed data
  - CVE-2026-21441: Decompression-bomb safeguard bypass when following HTTP redirects

## Test plan
- [x] Trivy scan should pass with updated urllib3 version
- [x] Docs build should still work (`poetry install` in `docs/`)