### PR TITLE
Add benchmark tests for ScyllaDB migrator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,11 @@ jobs:
         run: make test-integration-scylla
         env:
           COVERAGE: ${{ github.event_name == 'push' && 'true' || 'false' }}
+      - name: Run E2E sanity tests (Scylla only)
+        if: success()
+        run: make test-benchmark-e2e-sanity-scylla
       - name: Stop services
+        if: always()
         run: make stop-services
       - name: Save Spark image to cache
         if: steps.spark-cache.outputs.cache-hit != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ claude.log
 claude_history.json
 claude_config.json
 CLAUDE.md
+
+# Benchmark results
+benchmarks/results/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,50 +4,124 @@
 
 Tests are implemented in the `tests` sbt submodule. They simulate the submission of a Spark job as described in the README. Therefore, before running the tests you need to build the migrator fat-jar and to set up a stack with a Spark cluster and databases to read data from and to write to.
 
-1. Build the migrator fat-jar and its dependencies
+### Prerequisites
 
-   ~~~ sh
-   make build
-   ~~~
-
-2. Set up the testing stack with Docker
-
-   ~~~ sh
-   docker compose -f docker-compose-tests.yml up
-   ~~~
-
-3. Run the tests locally
-
-   ~~~ sh
-   sbt "testOnly -- --exclude-categories=com.scylladb.migrator.AWS"
-   ~~~
-
-   Or, to run a single test:
-
-   ~~~ sh
-   sbt testOnly com.scylladb.migrator.BasicMigrationTest
-   ~~~
-
-  Or, to run the tests that access AWS, first configure your AWS credentials with `aws configure`, and then:
-
-  ~~~ sh
-  AWS_REGION=us-east-1 \
-  sbt "testOnly -- --include-categories=com.scylladb.migrator.AWS"
-  ~~~
-
-4. Ultimately, stop the Docker containers
-
-   ~~~ sh
-   docker compose -f docker-compose-tests.yml down
-   ~~~
-
-Make sure to re-build the fat-jar everytime you change something in the implementation:
+Build the migrator fat-jar (re-build every time you change the implementation):
 
 ~~~ sh
-sbt migrator/assembly
+make build
 ~~~
 
-And then re-run the tests.
+### Quick start
+
+Run all local tests (unit + integration) with a single command:
+
+~~~ sh
+make test
+~~~
+
+This starts Docker services, waits for readiness, runs the tests, and cleans up.
+
+### Test categories
+
+Tests are organized into categories using JUnit `@Category` annotations. The Makefile exposes targets for each:
+
+| Target | Category | Services required | Description |
+|--------|----------|-------------------|-------------|
+| `make test-unit` | _(none)_ | No | Parsers, encoders, config validation |
+| `make test-integration` | `Integration` | Yes | End-to-end migrations with small datasets |
+| `make test-integration-aws` | `AWS` | Yes + AWS credentials | Tests that access real AWS services |
+| `make test-benchmark-e2e-sanity` | `E2E` | Yes | All migration paths with minimal rows (~2 min) |
+| `make test-benchmark-e2e` | `E2E` | Yes | Full throughput benchmarks (5M CQL / 500k DDB rows) |
+| `make test-benchmark-jmh` | _(JMH)_ | No | JMH microbenchmarks for hot-path code |
+
+### Running tests manually
+
+1. Start the testing stack:
+
+   ~~~ sh
+   make start-services
+   make wait-for-services
+   ~~~
+
+2. Run the desired tests:
+
+   ~~~ sh
+   # Unit tests (no services needed)
+   make test-unit
+
+   # Integration tests
+   make test-integration
+
+   # A single test class
+   sbt "testOnly com.scylladb.migrator.BasicMigrationTest"
+
+   # AWS tests (requires `aws configure` first)
+   AWS_REGION=us-east-1 make test-integration-aws
+   ~~~
+
+3. Stop the Docker containers:
+
+   ~~~ sh
+   make stop-services
+   ~~~
+
+### E2E benchmark tests
+
+E2E benchmarks exercise every supported migration path end-to-end: seed data into a source database, run the migrator via Spark, then verify row counts and spot-check data in the target.
+
+**Migration paths covered:**
+
+| Target | Source | Destination |
+|--------|--------|-------------|
+| `test-benchmark-e2e-cassandra-scylla` | Cassandra | ScyllaDB |
+| `test-benchmark-e2e-scylla-scylla` | ScyllaDB | ScyllaDB |
+| `test-benchmark-e2e-dynamodb-alternator` | DynamoDB | Alternator |
+| `test-benchmark-e2e-scylla-parquet` | ScyllaDB | Parquet files |
+| `test-benchmark-e2e-parquet-scylla` | Parquet files | ScyllaDB |
+| `test-benchmark-e2e-cassandra-parquet` | Cassandra | Parquet files |
+| `test-benchmark-e2e-dynamodb-s3export` | DynamoDB | S3 Export format |
+| `test-benchmark-e2e-s3export-alternator` | S3 Export | Alternator |
+
+**Dependencies:** `parquet-scylla` requires `scylla-parquet` to run first (produces the Parquet files), and `s3export-alternator` requires `dynamodb-s3export`. The Makefile encodes these as target dependencies.
+
+**Row counts** are configurable via environment variables:
+
+~~~ sh
+# Sanity check (~2 min) — used in CI
+make test-benchmark-e2e-sanity
+
+# Custom row counts
+make test-benchmark-e2e E2E_CQL_ROWS=100000 E2E_DDB_ROWS=10000
+
+# Full benchmarks (default: 5M CQL, 500k DDB)
+make test-benchmark-e2e
+~~~
+
+### JMH microbenchmarks
+
+JMH benchmarks measure throughput of critical code paths (serialization, row comparison, value conversion) without requiring external services.
+
+~~~ sh
+# Quick smoke run (1 iteration, no warmup)
+make test-benchmark-jmh-quick
+
+# Full benchmark run with JSON output
+make test-benchmark-jmh
+~~~
+
+Results are saved to `benchmarks/results/`.
+
+### CI pipeline
+
+The GitHub Actions workflow (`.github/workflows/tests.yml`) runs on every push to `master` and on pull requests:
+
+1. **Lint** — `make lint` (scalafmt check)
+2. **Build** — `make build` (assembly JAR, uploaded as artifact)
+3. **Unit tests** — `make test-unit`
+4. **Integration tests** — `make test-integration` + `make test-benchmark-e2e-sanity`
+
+The E2E sanity suite runs as part of the integration test job, reusing the same Docker services.
 
 ## Debugging
 

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,22 @@ SHELL := bash
         start-services-scylla wait-for-services-scylla \
         start-services-alternator wait-for-services-alternator \
         test test-unit test-integration test-integration-scylla test-integration-alternator \
-        test-integration-aws dump-logs
+        test-integration-aws \
+        test-benchmark test-benchmark-jmh test-benchmark-jmh-quick \
+        test-benchmark-e2e test-benchmark-e2e-sanity test-benchmark-e2e-sanity-scylla \
+        test-benchmark-e2e-cassandra-scylla test-benchmark-e2e-scylla-scylla test-benchmark-e2e-dynamodb-alternator \
+        test-benchmark-e2e-scylla-parquet test-benchmark-e2e-parquet-scylla \
+        test-benchmark-e2e-cassandra-parquet \
+        test-benchmark-e2e-dynamodb-s3export test-benchmark-e2e-s3export-alternator \
+        dump-logs
 
 COMPOSE_FILE := docker-compose-tests.yml
 CACHE_REPO ?= scylladb/migrator-cache
 MAX_ATTEMPTS ?= 480
 COVERAGE ?= false
 VERBOSE ?= false
+E2E_CQL_ROWS ?= 5000000
+E2E_DDB_ROWS ?= 500000
 
 ifeq ($(COVERAGE),true)
 SBT_COVERAGE_PREFIX := coverage
@@ -149,14 +158,14 @@ dump-logs: ## Dump Docker Compose container logs
 test-unit: ## Run unit tests (no services required)
 	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly -- --exclude-categories=com.scylladb.migrator.Integration" $(SBT_COVERAGE_SUFFIX)
 
-test-integration: ## Run integration tests (requires services, excludes AWS)
-	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.AWS" $(SBT_COVERAGE_SUFFIX)
+test-integration: ## Run integration tests (requires services, excludes AWS, benchmarks, and E2E)
+	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.AWS,com.scylladb.migrator.E2E" $(SBT_COVERAGE_SUFFIX)
 
-test-integration-scylla: ## Run Scylla integration tests only
-	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.scylla.* -- --include-categories=com.scylladb.migrator.Integration" $(SBT_COVERAGE_SUFFIX)
+test-integration-scylla: ## Run Scylla integration tests only (excludes E2E benchmarks)
+	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.scylla.* -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.E2E" $(SBT_COVERAGE_SUFFIX)
 
-test-integration-alternator: ## Run Alternator integration tests only (excludes AWS)
-	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.alternator.* com.scylladb.migrator.writers.* -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.AWS" $(SBT_COVERAGE_SUFFIX)
+test-integration-alternator: ## Run Alternator integration tests only (excludes AWS and E2E benchmarks)
+	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.alternator.* com.scylladb.migrator.writers.* -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.AWS,com.scylladb.migrator.E2E" $(SBT_COVERAGE_SUFFIX)
 
 test-integration-aws: ## Run AWS integration tests (requires services + AWS credentials)
 	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly -- --include-categories=com.scylladb.migrator.AWS" $(SBT_COVERAGE_SUFFIX)
@@ -166,3 +175,63 @@ test: start-services ## Run all local tests (unit + integration, excludes AWS)
 	$(MAKE) wait-for-services
 	$(MAKE) test-unit
 	$(MAKE) test-integration
+
+test-benchmark-jmh: ## Run all JMH microbenchmarks with JSON output
+	$(Q)mkdir -p benchmarks/results
+	$(Q)sbt "benchmarks/Jmh/run -rf json -rff benchmarks/results/jmh-results.json"
+
+test-benchmark-jmh-quick: ## Smoke run JMH benchmarks (1 iteration, no warmup)
+	$(Q)mkdir -p benchmarks/results
+	$(Q)sbt "benchmarks/Jmh/run -i 1 -wi 0 -f 1 -rf json -rff benchmarks/results/jmh-results-quick.json"
+
+test-benchmark: start-services ## Start services and run all benchmarks (JMH + E2E)
+	$(Q)trap '$(MAKE) dump-logs || true; $(MAKE) stop-services' EXIT
+	$(MAKE) wait-for-services
+	$(MAKE) test-benchmark-jmh
+	$(MAKE) test-benchmark-e2e
+
+test-benchmark-e2e-sanity: ## Run E2E sanity suite (small row counts, ~2min, for CI)
+	$(Q)$(MAKE) test-benchmark-e2e E2E_CQL_ROWS=1000 E2E_DDB_ROWS=100
+
+test-benchmark-e2e-sanity-scylla: ## Run Scylla-only E2E sanity (no DynamoDB services needed)
+	$(Q)$(MAKE) test-benchmark-e2e-cassandra-scylla E2E_CQL_ROWS=1000
+	$(Q)$(MAKE) test-benchmark-e2e-scylla-scylla E2E_CQL_ROWS=1000
+	$(Q)$(MAKE) test-benchmark-e2e-scylla-parquet E2E_CQL_ROWS=1000
+	$(Q)$(MAKE) test-benchmark-e2e-parquet-scylla E2E_CQL_ROWS=1000
+	$(Q)$(MAKE) test-benchmark-e2e-cassandra-parquet E2E_CQL_ROWS=1000
+
+test-benchmark-e2e: ## Run all E2E throughput benchmarks (requires services)
+	# Sequential execution is required: parquet-scylla depends on scylla-parquet output,
+	# and s3export-alternator depends on dynamodb-s3export output.
+	$(Q)$(MAKE) test-benchmark-e2e-cassandra-scylla
+	$(Q)$(MAKE) test-benchmark-e2e-scylla-scylla
+	$(Q)$(MAKE) test-benchmark-e2e-dynamodb-alternator
+	$(Q)$(MAKE) test-benchmark-e2e-scylla-parquet
+	$(Q)$(MAKE) test-benchmark-e2e-parquet-scylla
+	$(Q)$(MAKE) test-benchmark-e2e-cassandra-parquet
+	$(Q)$(MAKE) test-benchmark-e2e-dynamodb-s3export
+	$(Q)$(MAKE) test-benchmark-e2e-s3export-alternator
+
+test-benchmark-e2e-cassandra-scylla: ## Run Cassandra->Scylla E2E benchmarks
+	$(Q)sbt -De2e.cql.rows=$(E2E_CQL_ROWS) "testOnly com.scylladb.migrator.scylla.CassandraToScyllaE2EBenchmark"
+
+test-benchmark-e2e-scylla-scylla: ## Run Scylla->Scylla E2E benchmarks
+	$(Q)sbt -De2e.cql.rows=$(E2E_CQL_ROWS) "testOnly com.scylladb.migrator.scylla.ScyllaToScyllaE2EBenchmark"
+
+test-benchmark-e2e-dynamodb-alternator: ## Run DynamoDB->Alternator E2E benchmarks
+	$(Q)sbt -De2e.ddb.rows=$(E2E_DDB_ROWS) "testOnly com.scylladb.migrator.alternator.DynamoDBToAlternatorE2EBenchmark"
+
+test-benchmark-e2e-scylla-parquet: ## Run Scylla->Parquet E2E benchmark
+	$(Q)sbt -De2e.cql.rows=$(E2E_CQL_ROWS) "testOnly com.scylladb.migrator.scylla.ScyllaToParquetE2EBenchmark"
+
+test-benchmark-e2e-parquet-scylla: ## Run Parquet->Scylla E2E benchmark (requires scylla-parquet to have run first)
+	$(Q)sbt -De2e.cql.rows=$(E2E_CQL_ROWS) "testOnly com.scylladb.migrator.scylla.ParquetToScyllaE2EBenchmark"
+
+test-benchmark-e2e-cassandra-parquet: ## Run Cassandra->Parquet E2E benchmark
+	$(Q)sbt -De2e.cql.rows=$(E2E_CQL_ROWS) "testOnly com.scylladb.migrator.scylla.CassandraToParquetE2EBenchmark"
+
+test-benchmark-e2e-dynamodb-s3export: ## Run DynamoDB->S3Export E2E benchmark
+	$(Q)sbt -De2e.ddb.rows=$(E2E_DDB_ROWS) "testOnly com.scylladb.migrator.alternator.DynamoDBToS3ExportE2EBenchmark"
+
+test-benchmark-e2e-s3export-alternator: ## Run S3Export->Alternator E2E benchmark (requires dynamodb-s3export to have run first)
+	$(Q)sbt -De2e.ddb.rows=$(E2E_DDB_ROWS) "testOnly com.scylladb.migrator.alternator.S3ExportToAlternatorE2EBenchmark"

--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/AttributeValueV1ToV2Benchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/AttributeValueV1ToV2Benchmark.scala
@@ -1,0 +1,65 @@
+package com.scylladb.migrator.benchmarks
+
+import com.amazonaws.services.dynamodbv2.model.{ AttributeValue => AttributeValueV1 }
+import com.scylladb.migrator.AttributeValueUtils
+import org.openjdk.jmh.annotations._
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+
+import java.util.concurrent.TimeUnit
+import scala.jdk.CollectionConverters._
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 30, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class AttributeValueV1ToV2Benchmark {
+
+  private var flatItems: java.util.Map[String, AttributeValueV1] = _
+  private var nestedItems: java.util.Map[String, AttributeValueV1] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    flatItems = Map(
+      "pk"     -> new AttributeValueV1().withS("user-123"),
+      "sk"     -> new AttributeValueV1().withS("2024-01-15"),
+      "name"   -> new AttributeValueV1().withS("Alice"),
+      "age"    -> new AttributeValueV1().withN("30"),
+      "active" -> new AttributeValueV1().withBOOL(true),
+      "empty"  -> new AttributeValueV1().withNULL(true)
+    ).asJava
+
+    val innerMap = Map(
+      "street" -> new AttributeValueV1().withS("123 Main St"),
+      "city"   -> new AttributeValueV1().withS("Springfield"),
+      "zip"    -> new AttributeValueV1().withN("62701")
+    ).asJava
+
+    val innerList = java.util.Arrays.asList(
+      new AttributeValueV1().withS("urgent"),
+      new AttributeValueV1().withS("reviewed"),
+      new AttributeValueV1().withN("42")
+    )
+
+    nestedItems = Map(
+      "pk"      -> new AttributeValueV1().withS("order-456"),
+      "address" -> new AttributeValueV1().withM(innerMap),
+      "tags"    -> new AttributeValueV1().withL(innerList)
+    ).asJava
+  }
+
+  @Benchmark
+  def convertFlatItems(): java.util.Map[String, AttributeValue] = {
+    val result = new java.util.HashMap[String, AttributeValue](flatItems.size())
+    flatItems.forEach((k, v) => result.put(k, AttributeValueUtils.fromV1(v)))
+    result
+  }
+
+  @Benchmark
+  def convertNestedItems(): java.util.Map[String, AttributeValue] = {
+    val result = new java.util.HashMap[String, AttributeValue](nestedItems.size())
+    nestedItems.forEach((k, v) => result.put(k, AttributeValueUtils.fromV1(v)))
+    result
+  }
+}

--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/ConvertRowTypesBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/ConvertRowTypesBenchmark.scala
@@ -1,0 +1,37 @@
+package com.scylladb.migrator.benchmarks
+
+import com.scylladb.migrator.benchmarks.util.BenchmarkFixtures
+import com.scylladb.migrator.readers.Cassandra
+import org.apache.spark.sql.Row
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 30, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class ConvertRowTypesBenchmark {
+
+  @Param(Array("100", "1000"))
+  var batchSize: Int = _
+
+  private var utf8Rows: Array[Row] = _
+  private var plainRows: Array[Row] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    utf8Rows  = Array.tabulate(batchSize)(BenchmarkFixtures.makeUTF8Row)
+    plainRows = Array.tabulate(batchSize)(BenchmarkFixtures.makeSimpleRow)
+  }
+
+  @Benchmark
+  def convertBatch_utf8Rows(): Array[Row] =
+    utf8Rows.map(row => Row.fromSeq(row.toSeq.map(Cassandra.convertValue)))
+
+  @Benchmark
+  def convertBatch_plainRows(): Array[Row] =
+    plainRows.map(row => Row.fromSeq(row.toSeq.map(Cassandra.convertValue)))
+}

--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/ConvertValueBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/ConvertValueBenchmark.scala
@@ -1,0 +1,80 @@
+package com.scylladb.migrator.benchmarks
+
+import com.scylladb.migrator.readers.Cassandra
+import org.apache.spark.unsafe.types.UTF8String
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+import scala.collection.mutable.ArrayBuffer
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 30, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class ConvertValueBenchmark {
+
+  private var utf8Value: UTF8String = _
+  private var plainString: String = _
+  private var intValue: Integer = _
+  private var mapValue: Map[UTF8String, UTF8String] = _
+  private var listValue: List[UTF8String] = _
+  private var setValue: Set[UTF8String] = _
+  private var arrayBufValue: ArrayBuffer[UTF8String] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    utf8Value   = UTF8String.fromString("hello-world")
+    plainString = "hello-world"
+    intValue    = 42
+    mapValue = Map(
+      UTF8String.fromString("k1") -> UTF8String.fromString("v1"),
+      UTF8String.fromString("k2") -> UTF8String.fromString("v2"),
+      UTF8String.fromString("k3") -> UTF8String.fromString("v3")
+    )
+    listValue = List(
+      UTF8String.fromString("a"),
+      UTF8String.fromString("b"),
+      UTF8String.fromString("c")
+    )
+    setValue = Set(
+      UTF8String.fromString("x"),
+      UTF8String.fromString("y"),
+      UTF8String.fromString("z")
+    )
+    arrayBufValue = ArrayBuffer(
+      UTF8String.fromString("p"),
+      UTF8String.fromString("q"),
+      UTF8String.fromString("r")
+    )
+  }
+
+  @Benchmark
+  def convert_utf8String(): Any =
+    Cassandra.convertValue(utf8Value)
+
+  @Benchmark
+  def convert_plainString(): Any =
+    Cassandra.convertValue(plainString)
+
+  @Benchmark
+  def convert_int(): Any =
+    Cassandra.convertValue(intValue)
+
+  @Benchmark
+  def convert_map(): Any =
+    Cassandra.convertValue(mapValue)
+
+  @Benchmark
+  def convert_list(): Any =
+    Cassandra.convertValue(listValue)
+
+  @Benchmark
+  def convert_set(): Any =
+    Cassandra.convertValue(setValue)
+
+  @Benchmark
+  def convert_arrayBuffer(): Any =
+    Cassandra.convertValue(arrayBufValue)
+}

--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/CreateSelectionBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/CreateSelectionBenchmark.scala
@@ -1,0 +1,32 @@
+package com.scylladb.migrator.benchmarks
+
+import com.scylladb.migrator.benchmarks.util.BenchmarkFixtures
+import com.scylladb.migrator.readers.Cassandra
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 30, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class CreateSelectionBenchmark {
+
+  @Benchmark
+  def createSelection_withTimestamps(): Any =
+    Cassandra.createSelection(
+      BenchmarkFixtures.simpleTableDef,
+      BenchmarkFixtures.simpleSchema,
+      preserveTimes = true
+    )
+
+  @Benchmark
+  def createSelection_withoutTimestamps(): Any =
+    Cassandra.createSelection(
+      BenchmarkFixtures.simpleTableDef,
+      BenchmarkFixtures.simpleSchema,
+      preserveTimes = false
+    )
+}

--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/DdbValueBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/DdbValueBenchmark.scala
@@ -1,0 +1,81 @@
+package com.scylladb.migrator.benchmarks
+
+import com.scylladb.migrator.alternator.DdbValue
+import org.openjdk.jmh.annotations._
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+
+import java.util.concurrent.TimeUnit
+import scala.jdk.CollectionConverters._
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 30, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class DdbValueBenchmark {
+
+  private var flatItem: AttributeValue = _
+  private var nestedItem: AttributeValue = _
+  private var setItem: AttributeValue = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    // Flat item: a Map with simple scalar attributes
+    flatItem = AttributeValue
+      .fromM(
+        Map(
+          "pk"     -> AttributeValue.fromS("user-123"),
+          "sk"     -> AttributeValue.fromS("2024-01-15"),
+          "name"   -> AttributeValue.fromS("Alice"),
+          "age"    -> AttributeValue.fromN("30"),
+          "active" -> AttributeValue.fromBool(true),
+          "empty"  -> AttributeValue.fromNul(true)
+        ).asJava
+      )
+
+    // Nested item: Map containing a nested Map and a List
+    nestedItem = AttributeValue
+      .fromM(
+        Map(
+          "pk" -> AttributeValue.fromS("order-456"),
+          "address" -> AttributeValue.fromM(
+            Map(
+              "street" -> AttributeValue.fromS("123 Main St"),
+              "city"   -> AttributeValue.fromS("Springfield"),
+              "zip"    -> AttributeValue.fromN("62701")
+            ).asJava
+          ),
+          "tags" -> AttributeValue.fromL(
+            java.util.Arrays.asList(
+              AttributeValue.fromS("urgent"),
+              AttributeValue.fromS("reviewed"),
+              AttributeValue.fromN("42")
+            )
+          )
+        ).asJava
+      )
+
+    // Set item: contains SS, NS
+    setItem = AttributeValue
+      .fromM(
+        Map(
+          "pk"     -> AttributeValue.fromS("item-789"),
+          "colors" -> AttributeValue.fromSs(java.util.Arrays.asList("red", "green", "blue")),
+          "scores" -> AttributeValue.fromNs(java.util.Arrays.asList("100", "200", "300"))
+        ).asJava
+      )
+  }
+
+  @Benchmark
+  def convertFlatItem(): Map[String, DdbValue] =
+    flatItem.m().asScala.view.mapValues(DdbValue.from).toMap
+
+  @Benchmark
+  def convertNestedItem(): Map[String, DdbValue] =
+    nestedItem.m().asScala.view.mapValues(DdbValue.from).toMap
+
+  @Benchmark
+  def convertSetItem(): Map[String, DdbValue] =
+    setItem.m().asScala.view.mapValues(DdbValue.from).toMap
+}

--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/DdbValueSerializationBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/DdbValueSerializationBenchmark.scala
@@ -1,0 +1,92 @@
+package com.scylladb.migrator.benchmarks
+
+import com.scylladb.migrator.alternator.DdbValue
+import org.openjdk.jmh.annotations._
+
+import java.io.{
+  ByteArrayInputStream,
+  ByteArrayOutputStream,
+  ObjectInputStream,
+  ObjectOutputStream
+}
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 30, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class DdbValueSerializationBenchmark {
+
+  private var flatItem: Map[String, DdbValue] = _
+  private var nestedItem: Map[String, DdbValue] = _
+  private var flatItemBytes: Array[Byte] = _
+  private var nestedItemBytes: Array[Byte] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    flatItem = Map(
+      "pk"     -> DdbValue.S("user-123"),
+      "sk"     -> DdbValue.S("2024-01-15"),
+      "name"   -> DdbValue.S("Alice"),
+      "age"    -> DdbValue.N("30"),
+      "active" -> DdbValue.Bool(true),
+      "empty"  -> DdbValue.Null(true)
+    )
+
+    nestedItem = Map(
+      "pk" -> DdbValue.S("order-456"),
+      "address" -> DdbValue.M(
+        Map(
+          "street" -> DdbValue.S("123 Main St"),
+          "city"   -> DdbValue.S("Springfield"),
+          "zip"    -> DdbValue.N("62701")
+        )
+      ),
+      "tags"   -> DdbValue.L(Seq(DdbValue.S("urgent"), DdbValue.S("reviewed"), DdbValue.N("42"))),
+      "scores" -> DdbValue.Ns(Seq("100", "200", "300"))
+    )
+
+    flatItemBytes   = serialize(flatItem)
+    nestedItemBytes = serialize(nestedItem)
+  }
+
+  private def serialize(obj: AnyRef): Array[Byte] = {
+    val baos = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject(obj)
+    oos.close()
+    baos.toByteArray
+  }
+
+  private def deserialize[T](bytes: Array[Byte]): T = {
+    val bais = new ByteArrayInputStream(bytes)
+    val ois = new ObjectInputStream(bais)
+    ois.readObject().asInstanceOf[T]
+  }
+
+  @Benchmark
+  def serialize_flatItem(): Array[Byte] =
+    serialize(flatItem)
+
+  @Benchmark
+  def serialize_nestedItem(): Array[Byte] =
+    serialize(nestedItem)
+
+  @Benchmark
+  def deserialize_flatItem(): Map[String, DdbValue] =
+    deserialize(flatItemBytes)
+
+  @Benchmark
+  def deserialize_nestedItem(): Map[String, DdbValue] =
+    deserialize(nestedItemBytes)
+
+  @Benchmark
+  def roundtrip_flatItem(): Map[String, DdbValue] =
+    deserialize(serialize(flatItem))
+
+  @Benchmark
+  def roundtrip_nestedItem(): Map[String, DdbValue] =
+    deserialize(serialize(nestedItem))
+}

--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/ExplodeRowBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/ExplodeRowBenchmark.scala
@@ -1,0 +1,74 @@
+package com.scylladb.migrator.benchmarks
+
+import com.scylladb.migrator.benchmarks.util.BenchmarkFixtures
+import com.scylladb.migrator.readers.Cassandra
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 30, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class ExplodeRowBenchmark {
+
+  private var singleTimestampRow: org.apache.spark.sql.Row = _
+  private var multiTimestampRow: org.apache.spark.sql.Row = _
+  private var wideSingleTimestampRow: org.apache.spark.sql.Row = _
+  private var wideMultiTimestampRow: org.apache.spark.sql.Row = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    singleTimestampRow     = BenchmarkFixtures.makeSingleTimestampRow(1)
+    multiTimestampRow      = BenchmarkFixtures.makeMultiTimestampRow(1)
+    wideSingleTimestampRow = BenchmarkFixtures.makeWideSingleTimestampRow(1)
+    wideMultiTimestampRow  = BenchmarkFixtures.makeWideMultiTimestampRow(1)
+  }
+
+  @Benchmark
+  def explodeRow_singleTimestamp(): Any =
+    Cassandra.explodeRow(
+      singleTimestampRow,
+      BenchmarkFixtures.timestampSchema,
+      BenchmarkFixtures.primaryKeyOrdinals,
+      BenchmarkFixtures.regularKeyOrdinals
+    )
+
+  @Benchmark
+  def explodeRow_multiTimestamp(): Any =
+    Cassandra.explodeRow(
+      multiTimestampRow,
+      BenchmarkFixtures.timestampSchema,
+      BenchmarkFixtures.primaryKeyOrdinals,
+      BenchmarkFixtures.regularKeyOrdinals
+    )
+
+  @Benchmark
+  def explodeRow_noRegularKeys(): Any =
+    Cassandra.explodeRow(
+      BenchmarkFixtures.makeSimpleRow(1),
+      BenchmarkFixtures.simpleSchema,
+      BenchmarkFixtures.primaryKeyOrdinals,
+      regularKeyOrdinals = Map.empty
+    )
+
+  @Benchmark
+  def explodeRow_wide_singleTimestamp(): Any =
+    Cassandra.explodeRow(
+      wideSingleTimestampRow,
+      BenchmarkFixtures.wideTimestampSchema,
+      BenchmarkFixtures.widePrimaryKeyOrdinals,
+      BenchmarkFixtures.wideRegularKeyOrdinals
+    )
+
+  @Benchmark
+  def explodeRow_wide_multiTimestamp(): Any =
+    Cassandra.explodeRow(
+      wideMultiTimestampRow,
+      BenchmarkFixtures.wideTimestampSchema,
+      BenchmarkFixtures.widePrimaryKeyOrdinals,
+      BenchmarkFixtures.wideRegularKeyOrdinals
+    )
+}

--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/RowComparisonBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/RowComparisonBenchmark.scala
@@ -1,0 +1,147 @@
+package com.scylladb.migrator.benchmarks
+
+import com.datastax.spark.connector.CassandraRow
+import com.scylladb.migrator.alternator.DdbValue
+import com.scylladb.migrator.validation.RowComparisonFailure
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 30, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class RowComparisonBenchmark {
+
+  private var cassandraLeft: CassandraRow = _
+  private var cassandraRightSame: CassandraRow = _
+  private var cassandraRightDiff: CassandraRow = _
+
+  private var cassandraWithTsLeft: CassandraRow = _
+  private var cassandraWithTsSame: CassandraRow = _
+  private var cassandraWithTsDiff: CassandraRow = _
+
+  private var dynamoLeft: Map[String, DdbValue] = _
+  private var dynamoRightSame: Map[String, DdbValue] = _
+  private var dynamoRightDiff: Map[String, DdbValue] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    val cassandraData = Map[String, Any](
+      "id"   -> "row-1",
+      "col1" -> "value-1",
+      "col2" -> 42,
+      "col3" -> 1000L
+    )
+    cassandraLeft      = CassandraRow.fromMap(cassandraData)
+    cassandraRightSame = CassandraRow.fromMap(cassandraData)
+    cassandraRightDiff = CassandraRow.fromMap(
+      cassandraData.updated("col1", "different-value").updated("col2", 99)
+    )
+
+    // Rows with _ttl and _writetime columns for compareTimestamps=true
+    val tsData = Map[String, Any](
+      "id"             -> "row-1",
+      "col1"           -> "value-1",
+      "col1_ttl"       -> 3600L,
+      "col1_writetime" -> 1000000L,
+      "col2"           -> 42,
+      "col2_ttl"       -> 3600L,
+      "col2_writetime" -> 1000000L
+    )
+    cassandraWithTsLeft = CassandraRow.fromMap(tsData)
+    cassandraWithTsSame = CassandraRow.fromMap(tsData)
+    cassandraWithTsDiff = CassandraRow.fromMap(
+      tsData
+        .updated("col1_ttl", 7200L)
+        .updated("col2_writetime", 9999999L)
+    )
+
+    dynamoLeft = Map(
+      "pk"     -> DdbValue.S("user-123"),
+      "name"   -> DdbValue.S("Alice"),
+      "age"    -> DdbValue.N("30"),
+      "active" -> DdbValue.Bool(true)
+    )
+    dynamoRightSame = Map(
+      "pk"     -> DdbValue.S("user-123"),
+      "name"   -> DdbValue.S("Alice"),
+      "age"    -> DdbValue.N("30"),
+      "active" -> DdbValue.Bool(true)
+    )
+    dynamoRightDiff = Map(
+      "pk"     -> DdbValue.S("user-123"),
+      "name"   -> DdbValue.S("Bob"),
+      "age"    -> DdbValue.N("25"),
+      "active" -> DdbValue.Bool(false)
+    )
+  }
+
+  @Benchmark
+  def compareCassandraRows_identical(): Option[RowComparisonFailure] =
+    RowComparisonFailure.compareCassandraRows(
+      cassandraLeft,
+      Some(cassandraRightSame),
+      floatingPointTolerance   = 0.0,
+      timestampMsTolerance     = 0L,
+      ttlToleranceMillis       = 0L,
+      writetimeToleranceMillis = 0L,
+      compareTimestamps        = false
+    )
+
+  @Benchmark
+  def compareCassandraRows_differing(): Option[RowComparisonFailure] =
+    RowComparisonFailure.compareCassandraRows(
+      cassandraLeft,
+      Some(cassandraRightDiff),
+      floatingPointTolerance   = 0.0,
+      timestampMsTolerance     = 0L,
+      ttlToleranceMillis       = 0L,
+      writetimeToleranceMillis = 0L,
+      compareTimestamps        = false
+    )
+
+  @Benchmark
+  def compareDynamoDBRows_identical(): Option[RowComparisonFailure] =
+    RowComparisonFailure.compareDynamoDBRows(
+      dynamoLeft,
+      Some(dynamoRightSame),
+      renamedColumn          = identity,
+      floatingPointTolerance = 0.0
+    )
+
+  @Benchmark
+  def compareDynamoDBRows_differing(): Option[RowComparisonFailure] =
+    RowComparisonFailure.compareDynamoDBRows(
+      dynamoLeft,
+      Some(dynamoRightDiff),
+      renamedColumn          = identity,
+      floatingPointTolerance = 0.0
+    )
+
+  @Benchmark
+  def compareCassandraRows_withTimestamps_identical(): Option[RowComparisonFailure] =
+    RowComparisonFailure.compareCassandraRows(
+      cassandraWithTsLeft,
+      Some(cassandraWithTsSame),
+      floatingPointTolerance   = 0.0,
+      timestampMsTolerance     = 0L,
+      ttlToleranceMillis       = 0L,
+      writetimeToleranceMillis = 0L,
+      compareTimestamps        = true
+    )
+
+  @Benchmark
+  def compareCassandraRows_withTimestamps_differing(): Option[RowComparisonFailure] =
+    RowComparisonFailure.compareCassandraRows(
+      cassandraWithTsLeft,
+      Some(cassandraWithTsDiff),
+      floatingPointTolerance   = 0.0,
+      timestampMsTolerance     = 0L,
+      ttlToleranceMillis       = 0L,
+      writetimeToleranceMillis = 0L,
+      compareTimestamps        = true
+    )
+}

--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/S3ExportDecoderBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/S3ExportDecoderBenchmark.scala
@@ -1,0 +1,64 @@
+package com.scylladb.migrator.benchmarks
+
+import com.scylladb.migrator.readers.DynamoDBS3Export
+import io.circe.parser.decode
+import org.openjdk.jmh.annotations._
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 30, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class S3ExportDecoderBenchmark {
+
+  private var simpleJson: String = _
+  private var multiAttrJson: String = _
+  private var nestedJson: String = _
+  private var wideJson: String = _
+  private var deeplyNestedJson: String = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    simpleJson = """{"Item":{"name":{"S":"hello"}}}"""
+
+    multiAttrJson =
+      """{"Item":{"pk":{"S":"user-123"},"age":{"N":"30"},"active":{"BOOL":true},"empty":{"NULL":true}}}"""
+
+    nestedJson =
+      """{"Item":{"pk":{"S":"order-456"},"address":{"M":{"street":{"S":"123 Main St"},"city":{"S":"Springfield"},"zip":{"N":"62701"}}},"tags":{"L":[{"S":"urgent"},{"S":"reviewed"},{"N":"42"}]}}}"""
+
+    // Wide item: 50 attributes (typical production item)
+    val wideAttrs = (1 to 50)
+      .map(j => s""""col$j":{"S":"value-$j"}""")
+      .mkString(",")
+    wideJson = s"""{"Item":{"pk":{"S":"wide-1"},$wideAttrs}}"""
+
+    // Deeply nested item: 3 levels of Map nesting
+    deeplyNestedJson =
+      """{"Item":{"pk":{"S":"deep-1"},"l1":{"M":{"a":{"M":{"b":{"M":{"c":{"S":"deep"},"d":{"N":"42"}}},"e":{"L":[{"S":"x"},{"N":"1"}]}}},"f":{"S":"shallow"}}}}}"""
+  }
+
+  @Benchmark
+  def decodeSimpleItem(): Map[String, AttributeValue] =
+    decode(simpleJson)(DynamoDBS3Export.itemDecoder).fold(throw _, identity)
+
+  @Benchmark
+  def decodeMultiAttrItem(): Map[String, AttributeValue] =
+    decode(multiAttrJson)(DynamoDBS3Export.itemDecoder).fold(throw _, identity)
+
+  @Benchmark
+  def decodeNestedItem(): Map[String, AttributeValue] =
+    decode(nestedJson)(DynamoDBS3Export.itemDecoder).fold(throw _, identity)
+
+  @Benchmark
+  def decodeWideItem(): Map[String, AttributeValue] =
+    decode(wideJson)(DynamoDBS3Export.itemDecoder).fold(throw _, identity)
+
+  @Benchmark
+  def decodeDeeplyNestedItem(): Map[String, AttributeValue] =
+    decode(deeplyNestedJson)(DynamoDBS3Export.itemDecoder).fold(throw _, identity)
+}

--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/StripTrailingZerosBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/StripTrailingZerosBenchmark.scala
@@ -1,0 +1,63 @@
+package com.scylladb.migrator.benchmarks
+
+import org.apache.spark.sql.Row
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 30, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class StripTrailingZerosBenchmark {
+
+  @Param(Array("100", "1000"))
+  var batchSize: Int = _
+
+  private var decimalRows: Array[Row] = _
+  private var mixedRows: Array[Row] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    // Rows where all values are BigDecimals (worst case for the mapping)
+    decimalRows = Array.tabulate(batchSize) { i =>
+      Row.fromSeq(
+        Seq(
+          new java.math.BigDecimal(s"$i.12300"),
+          new java.math.BigDecimal(s"${i * 10}.45600"),
+          new java.math.BigDecimal(s"${i * 100}.78900")
+        )
+      )
+    }
+
+    // Rows with mixed types (typical case: some BigDecimals, some strings/ints)
+    mixedRows = Array.tabulate(batchSize) { i =>
+      Row.fromSeq(
+        Seq(
+          s"id-$i",
+          new java.math.BigDecimal(s"$i.12300"),
+          i,
+          i.toLong * 1000L,
+          new java.math.BigDecimal(s"${i * 10}.45600")
+        )
+      )
+    }
+  }
+
+  /** The stripTrailingZeros mapping as used in Scylla.writeDataframe */
+  private def stripTrailingZerosRow(row: Row): Row =
+    Row.fromSeq(row.toSeq.map {
+      case x: java.math.BigDecimal => x.stripTrailingZeros()
+      case x                       => x
+    })
+
+  @Benchmark
+  def stripBatch_decimalRows(): Array[Row] =
+    decimalRows.map(stripTrailingZerosRow)
+
+  @Benchmark
+  def stripBatch_mixedRows(): Array[Row] =
+    mixedRows.map(stripTrailingZerosRow)
+}

--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/util/BenchmarkFixtures.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/util/BenchmarkFixtures.scala
@@ -1,0 +1,165 @@
+package com.scylladb.migrator.benchmarks.util
+
+import com.datastax.spark.connector.cql.{ ColumnDef, PartitionKeyColumn, RegularColumn, TableDef }
+import com.datastax.spark.connector.types.{ BigIntType, CassandraOption, IntType, VarCharType }
+import org.apache.spark.sql.types.{ IntegerType, LongType, StringType, StructField, StructType }
+import org.apache.spark.sql.Row
+import org.apache.spark.unsafe.types.UTF8String
+
+import scala.collection.immutable.ArraySeq
+
+object BenchmarkFixtures {
+
+  /** Simple flat schema: (id TEXT PK, col1 TEXT, col2 INT, col3 BIGINT) */
+  val simpleSchema: StructType = StructType(
+    Seq(
+      StructField("id", StringType, nullable    = false),
+      StructField("col1", StringType, nullable  = true),
+      StructField("col2", IntegerType, nullable = true),
+      StructField("col3", LongType, nullable    = true)
+    )
+  )
+
+  /** Schema with TTL/writetime columns appended for each regular column */
+  val timestampSchema: StructType = StructType(
+    Seq(
+      StructField("id", StringType, nullable           = false),
+      StructField("col1", StringType, nullable         = true),
+      StructField("col1_ttl", IntegerType, nullable    = true),
+      StructField("col1_writetime", LongType, nullable = true),
+      StructField("col2", IntegerType, nullable        = true),
+      StructField("col2_ttl", IntegerType, nullable    = true),
+      StructField("col2_writetime", LongType, nullable = true),
+      StructField("col3", LongType, nullable           = true),
+      StructField("col3_ttl", IntegerType, nullable    = true),
+      StructField("col3_writetime", LongType, nullable = true)
+    )
+  )
+
+  val simpleTableDef: TableDef = TableDef(
+    keyspaceName      = "bench",
+    tableName         = "simple",
+    partitionKey      = Seq(ColumnDef("id", PartitionKeyColumn, VarCharType)),
+    clusteringColumns = Seq.empty,
+    regularColumns = Seq(
+      ColumnDef("col1", RegularColumn, VarCharType),
+      ColumnDef("col2", RegularColumn, IntType),
+      ColumnDef("col3", RegularColumn, BigIntType)
+    )
+  )
+
+  val primaryKeyOrdinals: Map[String, Int] = Map("id" -> 0)
+
+  val regularKeyOrdinals: Map[String, (Int, Int, Int)] = Map(
+    "col1" -> (1, 2, 3),
+    "col2" -> (4, 5, 6),
+    "col3" -> (7, 8, 9)
+  )
+
+  /** Generate a simple Row with String values (post-conversion) */
+  def makeSimpleRow(i: Int): Row =
+    Row(s"id-$i", s"value-$i", i, i.toLong * 1000L)
+
+  /** Generate a Row with UTF8String values (pre-conversion, as from Cassandra connector RDD) */
+  def makeUTF8Row(i: Int): Row =
+    Row(UTF8String.fromString(s"id-$i"), UTF8String.fromString(s"value-$i"), i, i.toLong * 1000L)
+
+  /** Generate a Row with TTL/writetime columns (for explodeRow benchmarks) */
+  def makeTimestampRow(i: Int): Row = {
+    val writetime = System.currentTimeMillis() * 1000L
+    Row(
+      s"id-$i",
+      s"value-$i",
+      3600,
+      writetime,
+      i,
+      3600,
+      writetime,
+      i.toLong * 1000L,
+      3600,
+      writetime
+    )
+  }
+
+  /** Generate a Row where all regular columns share the same timestamp (single-group path) */
+  def makeSingleTimestampRow(i: Int): Row = {
+    val writetime = 1000000L
+    val ttl = 3600
+    Row(
+      s"id-$i",
+      s"value-$i",
+      ttl,
+      writetime,
+      i,
+      ttl,
+      writetime,
+      i.toLong * 1000L,
+      ttl,
+      writetime
+    )
+  }
+
+  /** Generate a Row where regular columns have different timestamps (multi-group path) */
+  def makeMultiTimestampRow(i: Int): Row =
+    Row(
+      s"id-$i",
+      s"value-$i",
+      3600,
+      1000000L,
+      i,
+      7200,
+      2000000L,
+      i.toLong * 1000L,
+      null,
+      null
+    )
+
+  // --- Wide row fixtures (50 regular columns) ---
+
+  private val wideColumnCount = 50
+
+  val wideTimestampSchema: StructType = StructType(
+    StructField("id", StringType, nullable = false) +:
+      (1 to wideColumnCount).flatMap { j =>
+        Seq(
+          StructField(s"col$j", StringType, nullable           = true),
+          StructField(s"col${j}_ttl", IntegerType, nullable    = true),
+          StructField(s"col${j}_writetime", LongType, nullable = true)
+        )
+      }
+  )
+
+  val wideTableDef: TableDef = TableDef(
+    keyspaceName      = "bench",
+    tableName         = "wide",
+    partitionKey      = Seq(ColumnDef("id", PartitionKeyColumn, VarCharType)),
+    clusteringColumns = Seq.empty,
+    regularColumns =
+      (1 to wideColumnCount).map(j => ColumnDef(s"col$j", RegularColumn, VarCharType))
+  )
+
+  val widePrimaryKeyOrdinals: Map[String, Int] = Map("id" -> 0)
+
+  val wideRegularKeyOrdinals: Map[String, (Int, Int, Int)] =
+    (1 to wideColumnCount).map { j =>
+      val base = 1 + (j - 1) * 3
+      s"col$j" -> (base, base + 1, base + 2)
+    }.toMap
+
+  /** Generate a wide Row (50 columns) where all share the same timestamp (single-group path) */
+  def makeWideSingleTimestampRow(i: Int): Row = {
+    val writetime = 1000000L
+    val ttl = 3600
+    Row.fromSeq(
+      s"id-$i" +: (1 to wideColumnCount).flatMap(j => Seq(s"val-$j-$i", ttl, writetime))
+    )
+  }
+
+  /** Generate a wide Row (50 columns) where columns have varying timestamps (multi-group path) */
+  def makeWideMultiTimestampRow(i: Int): Row =
+    Row.fromSeq(
+      s"id-$i" +: (1 to wideColumnCount).flatMap { j =>
+        Seq(s"val-$j-$i", j * 100, j.toLong * 1000000L)
+      }
+    )
+}

--- a/build.sbt
+++ b/build.sbt
@@ -105,19 +105,47 @@ lazy val tests = project
     Test / parallelExecution := false,
     // Needed to build a Spark session on Java 17+, see https://stackoverflow.com/questions/73465937/apache-spark-3-3-0-breaks-on-java-17-with-cannot-access-class-sun-nio-ch-direct
     Test / javaOptions ++= {
-      val maybeJavaMajorVersion =
-        sys.props
-          .get("java.version")
-          .map(version => version.takeWhile(_ != '.').toInt)
-      if (maybeJavaMajorVersion.exists(_ > 11))
-        Seq("--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED")
-      else
-        Nil
+      val javaCompat = {
+        val maybeJavaMajorVersion =
+          sys.props
+            .get("java.version")
+            .map(version => version.takeWhile(_ != '.').toInt)
+        if (maybeJavaMajorVersion.exists(_ > 11))
+          Seq("--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED")
+        else
+          Nil
+      }
+      val e2eProps = Seq("e2e.cql.rows", "e2e.ddb.rows").flatMap { key =>
+        sys.props.get(key).map(v => s"-D${key}=${v}")
+      }
+      javaCompat ++ e2eProps
     },
     Test / fork := true
   )
   .dependsOn(migrator)
 
+lazy val benchmarks = project
+  .in(file("benchmarks"))
+  .enablePlugins(pl.project13.scala.sbt.JmhPlugin)
+  .settings(
+    name := "scylla-migrator-benchmarks",
+    libraryDependencies ++= Seq(
+      "org.apache.spark"        %% "spark-streaming"             % sparkVersion,
+      "org.apache.spark"        %% "spark-sql"                   % sparkVersion,
+      "software.amazon.awssdk"   % "dynamodb"                    % awsSdkVersion,
+      "com.amazonaws"            % "dynamodb-streams-kinesis-adapter" % dynamodbStreamsKinesisAdapterVersion,
+      "io.circe"                %% "circe-parser"                % circeVersion,
+      "com.scylladb"            %% "spark-scylladb-connector"    % connectorVersion
+    ),
+    Jmh / javaOptions ++= Seq(
+      "--add-exports",
+      "java.base/sun.nio.ch=ALL-UNNAMED"
+    ),
+    // Run JMH forks from the project root so relative output paths resolve correctly
+    Jmh / baseDirectory := (ThisBuild / baseDirectory).value
+  )
+  .dependsOn(migrator)
+
 lazy val root = project
   .in(file("."))
-  .aggregate(migrator, `spark-kinesis-dynamodb`, tests)
+  .aggregate(migrator, `spark-kinesis-dynamodb`, tests, benchmarks)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ addSbtPlugin("com.github.sbt" % "sbt-dynver"    % "5.0.1")
 addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo" % "0.12.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
+
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")

--- a/tests/src/test/configurations/bench-e2e-cassandra-to-parquet.yaml
+++ b/tests/src/test/configurations/bench-e2e-cassandra-to-parquet.yaml
@@ -1,0 +1,25 @@
+source:
+  type: cassandra
+  host: cassandra
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: bench_e2e_cass_parquet
+  consistencyLevel: LOCAL_QUORUM
+  preserveTimestamps: false
+  splitCount: 8
+  connections: 8
+  fetchSize: 5000
+
+target:
+  type: parquet
+  path: /app/parquet/bench_e2e_cass
+  compression: gzip
+  mode: overwrite
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/bench-e2e-cassandra-to-scylla-nots.yaml
+++ b/tests/src/test/configurations/bench-e2e-cassandra-to-scylla-nots.yaml
@@ -1,0 +1,33 @@
+source:
+  type: cassandra
+  host: cassandra
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: bench_e2e_nots
+  consistencyLevel: LOCAL_QUORUM
+  preserveTimestamps: false
+  splitCount: 8
+  connections: 8
+  fetchSize: 5000
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: bench_e2e_nots
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/bench-e2e-cassandra-to-scylla-ts.yaml
+++ b/tests/src/test/configurations/bench-e2e-cassandra-to-scylla-ts.yaml
@@ -1,0 +1,33 @@
+source:
+  type: cassandra
+  host: cassandra
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: bench_e2e_ts
+  consistencyLevel: LOCAL_QUORUM
+  preserveTimestamps: true
+  splitCount: 8
+  connections: 8
+  fetchSize: 5000
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: bench_e2e_ts
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/bench-e2e-dynamodb-to-alternator.yaml
+++ b/tests/src/test/configurations/bench-e2e-dynamodb-to-alternator.yaml
@@ -1,0 +1,30 @@
+source:
+  type: dynamodb
+  table: bench_e2e_ddb
+  region: dummy
+  endpoint:
+    host: http://dynamodb
+    port: 8000
+  credentials:
+    accessKey: dummy
+    secretKey: dummy
+  scanSegments: 8
+  readThroughput: 25
+
+target:
+  type: dynamodb
+  table: bench_e2e_ddb
+  region: dummy
+  endpoint:
+    host: http://scylla
+    port: 8000
+  credentials:
+    accessKey: dummy
+    secretKey: dummy
+  streamChanges: false
+  removeConsumedCapacity: true
+  billingMode: PAY_PER_REQUEST
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/bench-e2e-dynamodb-to-s3export.yaml
+++ b/tests/src/test/configurations/bench-e2e-dynamodb-to-s3export.yaml
@@ -1,0 +1,21 @@
+source:
+  type: dynamodb
+  table: bench_e2e_ddb_s3
+  region: dummy
+  endpoint:
+    host: http://dynamodb
+    port: 8000
+  credentials:
+    accessKey: dummy
+    secretKey: dummy
+  scanSegments: 8
+  # Low value is fine for local DynamoDB which does not enforce throughput limits
+  readThroughput: 25
+
+target:
+  type: dynamodb-s3-export
+  path: /app/parquet/bench_s3export
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/bench-e2e-parquet-to-scylla.yaml
+++ b/tests/src/test/configurations/bench-e2e-parquet-to-scylla.yaml
@@ -1,0 +1,21 @@
+source:
+  type: parquet
+  path: /app/parquet/bench_e2e
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: bench_e2e_parquet_restore
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/bench-e2e-s3export-to-alternator.yaml
+++ b/tests/src/test/configurations/bench-e2e-s3export-to-alternator.yaml
@@ -1,0 +1,38 @@
+source:
+  type: dynamodb-s3-export
+  bucket: bench-bucket
+  manifestKey: bench_s3export/manifest-summary.json
+  region: eu-central-1
+  endpoint:
+    host: http://s3
+    port: 4566
+  credentials:
+    accessKey: dummy
+    secretKey: dummy
+  usePathStyleAccess: true
+  tableDescription:
+    attributeDefinitions:
+      - name: id
+        type: S
+    keySchema:
+      - name: id
+        type: HASH
+    billingMode: PAY_PER_REQUEST
+
+target:
+  type: dynamodb
+  table: bench_e2e_ddb_s3_restore
+  region: dummy
+  endpoint:
+    host: http://scylla
+    port: 8000
+  credentials:
+    accessKey: dummy
+    secretKey: dummy
+  streamChanges: false
+  removeConsumedCapacity: true
+  billingMode: PAY_PER_REQUEST
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/bench-e2e-scylla-to-parquet.yaml
+++ b/tests/src/test/configurations/bench-e2e-scylla-to-parquet.yaml
@@ -1,0 +1,25 @@
+source:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: bench_e2e_parquet
+  consistencyLevel: LOCAL_QUORUM
+  preserveTimestamps: false
+  splitCount: 8
+  connections: 8
+  fetchSize: 5000
+
+target:
+  type: parquet
+  path: /app/parquet/bench_e2e
+  compression: gzip
+  mode: overwrite
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/bench-e2e-scylla-to-scylla.yaml
+++ b/tests/src/test/configurations/bench-e2e-scylla-to-scylla.yaml
@@ -1,0 +1,33 @@
+source:
+  type: scylla
+  host: scylla-source
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: bench_e2e_s2s
+  consistencyLevel: LOCAL_QUORUM
+  preserveTimestamps: false
+  splitCount: 8
+  connections: 8
+  fetchSize: 5000
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: bench_e2e_s2s
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/scala/com/scylladb/migrator/BenchmarkDataGenerator.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/BenchmarkDataGenerator.scala
@@ -1,0 +1,103 @@
+package com.scylladb.migrator
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.`type`.DataTypes
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder
+
+import java.util.concurrent.{ CompletionException, CompletionStage }
+import scala.collection.mutable
+
+object BenchmarkDataGenerator {
+
+  /** Sample indices for spot-checking benchmark rows: first, 25%, 50%, last. Deduplicates indices
+    * when rowCount is small (< 4).
+    */
+  def sampleIndices(rowCount: Int): Seq[Int] =
+    if (rowCount <= 0) Seq.empty
+    else Seq(0, rowCount / 4, rowCount / 2, rowCount - 1).distinct.filter(_ >= 0)
+
+  /** Create a simple flat table: (id TEXT PK, col1 TEXT, col2 INT, col3 BIGINT) */
+  def createSimpleTable(session: CqlSession, keyspace: String, table: String): Unit = {
+    val dropStmt = SchemaBuilder.dropTable(keyspace, table).ifExists().build()
+    session.execute(dropStmt)
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, table)
+      .withPartitionKey("id", DataTypes.TEXT)
+      .withColumn("col1", DataTypes.TEXT)
+      .withColumn("col2", DataTypes.INT)
+      .withColumn("col3", DataTypes.BIGINT)
+      .build()
+    session.execute(createStmt)
+  }
+
+  /** Insert rows using batched prepared statements with async execution for throughput.
+    *
+    * @param session
+    *   CQL session
+    * @param keyspace
+    *   target keyspace
+    * @param table
+    *   target table name
+    * @param rowCount
+    *   number of rows to insert
+    * @param batchSize
+    *   number of rows per unlogged batch
+    * @param maxConcurrent
+    *   maximum number of in-flight async batch requests
+    */
+  def insertSimpleRows(
+    session: CqlSession,
+    keyspace: String,
+    table: String,
+    rowCount: Int,
+    batchSize: Int = 100,
+    maxConcurrent: Int = 64
+  ): Unit = {
+    val prepared = session.prepare(
+      s"INSERT INTO $keyspace.$table (id, col1, col2, col3) VALUES (?, ?, ?, ?)"
+    )
+
+    val inflight = mutable.Queue.empty[CompletionStage[_]]
+
+    def drainOne(): Unit = {
+      val future = inflight.dequeue().toCompletableFuture
+      try future.join()
+      catch {
+        case e: CompletionException =>
+          // Drain remaining futures to avoid leaking resources, then rethrow
+          inflight.foreach { f =>
+            try f.toCompletableFuture.join()
+            catch { case _: Exception => () }
+          }
+          inflight.clear()
+          throw e
+      }
+    }
+
+    for (batch <- (0 until rowCount).grouped(batchSize)) {
+      val batchStmt =
+        com.datastax.oss.driver.api.core.cql.BatchStatement
+          .newInstance(com.datastax.oss.driver.api.core.cql.BatchType.UNLOGGED)
+
+      val stmts = batch.map { i =>
+        prepared
+          .bind()
+          .setString(0, s"id-$i")
+          .setString(1, s"value-$i")
+          .setInt(2, i)
+          .setLong(3, i.toLong * 1000L)
+      }
+
+      val finalBatch = stmts.foldLeft(batchStmt)((b, s) => b.add(s))
+      inflight.enqueue(session.executeAsync(finalBatch))
+
+      // Drain oldest futures when we reach the concurrency limit
+      while (inflight.size >= maxConcurrent)
+        drainOne()
+    }
+
+    // Wait for remaining in-flight requests
+    while (inflight.nonEmpty)
+      drainOne()
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/DynamoDBBenchmarkDataGenerator.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/DynamoDBBenchmarkDataGenerator.scala
@@ -1,0 +1,222 @@
+package com.scylladb.migrator
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.{
+  AttributeDefinition,
+  AttributeValue,
+  BatchWriteItemRequest,
+  BillingMode,
+  CreateTableRequest,
+  DeleteTableRequest,
+  DescribeTableRequest,
+  KeySchemaElement,
+  KeyType,
+  PutRequest,
+  ResourceNotFoundException,
+  ScalarAttributeType,
+  WriteRequest
+}
+
+import java.util.concurrent.{ Executors, Semaphore, ThreadFactory, TimeUnit }
+import java.util.concurrent.atomic.{ AtomicInteger, AtomicReference }
+import scala.annotation.tailrec
+import scala.jdk.CollectionConverters._
+
+object DynamoDBBenchmarkDataGenerator extends munit.Assertions {
+
+  /** Create a simple DynamoDB table with on-demand billing for maximum throughput. */
+  def createSimpleTable(client: DynamoDbClient, tableName: String): Unit = {
+    // Drop if exists
+    val deleted =
+      try {
+        client.deleteTable(DeleteTableRequest.builder().tableName(tableName).build())
+        true
+      } catch {
+        case _: ResourceNotFoundException => false
+      }
+    if (deleted)
+      client
+        .waiter()
+        .waitUntilTableNotExists(
+          DescribeTableRequest.builder().tableName(tableName).build()
+        )
+
+    client.createTable(
+      CreateTableRequest
+        .builder()
+        .tableName(tableName)
+        .keySchema(
+          KeySchemaElement.builder().attributeName("id").keyType(KeyType.HASH).build()
+        )
+        .attributeDefinitions(
+          AttributeDefinition
+            .builder()
+            .attributeName("id")
+            .attributeType(ScalarAttributeType.S)
+            .build()
+        )
+        .billingMode(BillingMode.PAY_PER_REQUEST)
+        .build()
+    )
+
+    client
+      .waiter()
+      .waitUntilTableExists(
+        DescribeTableRequest.builder().tableName(tableName).build()
+      )
+  }
+
+  /** Insert rows using BatchWriteItem (25 items per batch, DynamoDB maximum).
+    *
+    * Uses a thread pool with a semaphore to run multiple batches concurrently while limiting the
+    * number of in-flight requests.
+    */
+  def insertSimpleRows(
+    client: DynamoDbClient,
+    tableName: String,
+    rowCount: Int,
+    batchSize: Int = 25,
+    maxConcurrent: Int = 32
+  ): Unit = {
+    val daemonThreadFactory: ThreadFactory = new ThreadFactory {
+      private val counter = new AtomicInteger(0)
+      override def newThread(r: Runnable): Thread = {
+        val t = new Thread(r, s"ddb-batch-writer-${counter.getAndIncrement()}")
+        t.setDaemon(true)
+        t
+      }
+    }
+    val executor = Executors.newFixedThreadPool(maxConcurrent, daemonThreadFactory)
+    val semaphore = new Semaphore(maxConcurrent)
+    val firstError = new AtomicReference[Throwable](null)
+
+    try {
+      for (batch <- (0 until rowCount).grouped(batchSize) if firstError.get() == null) {
+        val writeRequests = batch.map { i =>
+          WriteRequest
+            .builder()
+            .putRequest(
+              PutRequest
+                .builder()
+                .item(
+                  Map(
+                    "id"   -> AttributeValue.fromS(s"id-$i"),
+                    "col1" -> AttributeValue.fromS(s"value-$i"),
+                    "col2" -> AttributeValue.fromN(i.toString),
+                    "col3" -> AttributeValue.fromN((i.toLong * 1000L).toString)
+                  ).asJava
+                )
+                .build()
+            )
+            .build()
+        }
+
+        val request = BatchWriteItemRequest
+          .builder()
+          .requestItems(Map(tableName -> writeRequests.asJava).asJava)
+          .build()
+
+        semaphore.acquire()
+        executor.submit(new Runnable {
+          def run(): Unit =
+            try writeBatchWithRetry(client, request)
+            catch {
+              case e: Throwable =>
+                firstError.compareAndSet(null, e)
+            } finally semaphore.release()
+        })
+      }
+
+      // Wait for all remaining tasks to complete
+      semaphore.acquire(maxConcurrent)
+      semaphore.release(maxConcurrent)
+    } finally {
+      if (firstError.get() != null)
+        executor.shutdownNow()
+      else
+        executor.shutdown()
+      if (!executor.awaitTermination(10, TimeUnit.MINUTES))
+        throw new RuntimeException(
+          "DynamoDB batch insert threads did not terminate within 10 minutes"
+        )
+    }
+
+    val error = firstError.get()
+    if (error != null)
+      throw new RuntimeException(s"Batch write failed for table $tableName", error)
+  }
+
+  /** Retry batch writes until all items are processed, up to maxRetries attempts. Uses exponential
+    * backoff with jitter to avoid thundering herd.
+    */
+  @tailrec
+  private def writeBatchWithRetry(
+    client: DynamoDbClient,
+    request: BatchWriteItemRequest,
+    retriesLeft: Int = 50,
+    baseDelayMs: Long = 50
+  ): Unit = {
+    val response = client.batchWriteItem(request)
+    val unprocessed = response.unprocessedItems()
+    if (unprocessed != null && !unprocessed.isEmpty) {
+      require(
+        retriesLeft > 0,
+        s"Exceeded max retries for batch write with ${unprocessed.size()} unprocessed items"
+      )
+      val delay =
+        baseDelayMs + java.util.concurrent.ThreadLocalRandom.current().nextLong(baseDelayMs)
+      Thread.sleep(delay)
+      writeBatchWithRetry(
+        client,
+        BatchWriteItemRequest.builder().requestItems(unprocessed).build(),
+        retriesLeft - 1,
+        Math.min(baseDelayMs * 2, 5000)
+      )
+    }
+  }
+
+  /** Verify a sample of rows in the target to detect data corruption. */
+  def spotCheckRows(client: DynamoDbClient, tableName: String, rowCount: Int): Unit = {
+    import software.amazon.awssdk.services.dynamodb.model.GetItemRequest
+    val sampleIndices = BenchmarkDataGenerator.sampleIndices(rowCount)
+    for (i <- sampleIndices) {
+      val resp = client.getItem(
+        GetItemRequest
+          .builder()
+          .tableName(tableName)
+          .key(Map("id" -> AttributeValue.fromS(s"id-$i")).asJava)
+          .build()
+      )
+      val item = resp.item()
+      assert(
+        item != null && !item.isEmpty,
+        s"Spot-check: row id-$i not found in target"
+      )
+      val col1 = item.get("col1")
+      assert(col1 != null, s"Spot-check: col1 attribute missing for id-$i")
+      assertEquals(col1.s(), s"value-$i", s"Spot-check: col1 mismatch for id-$i")
+      val col2 = item.get("col2")
+      assert(col2 != null, s"Spot-check: col2 attribute missing for id-$i")
+      assertEquals(col2.n(), i.toString, s"Spot-check: col2 mismatch for id-$i")
+      val col3 = item.get("col3")
+      assert(col3 != null, s"Spot-check: col3 attribute missing for id-$i")
+      assertEquals(
+        col3.n(),
+        (i.toLong * 1000L).toString,
+        s"Spot-check: col3 mismatch for id-$i"
+      )
+    }
+  }
+
+  /** Count all items in a DynamoDB table using paginated scan. */
+  def countItems(client: DynamoDbClient, tableName: String): Long = {
+    import software.amazon.awssdk.services.dynamodb.model.ScanRequest
+    client
+      .scanPaginator(
+        ScanRequest.builder().tableName(tableName).select("COUNT").build()
+      )
+      .stream()
+      .mapToLong(_.count().toLong)
+      .sum()
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/E2E.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/E2E.scala
@@ -1,0 +1,7 @@
+package com.scylladb.migrator
+
+/** munit tag for end-to-end throughput benchmarks (1M+ rows).
+  *
+  * Separated from [[Benchmark]] so that shorter benchmarks can run independently.
+  */
+class E2E extends munit.Tag("E2E")

--- a/tests/src/test/scala/com/scylladb/migrator/ThroughputReporter.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/ThroughputReporter.scala
@@ -1,0 +1,16 @@
+package com.scylladb.migrator
+
+/** Structured stdout reporter for integration throughput benchmarks.
+  *
+  * Output format is grep-friendly: {{{ BENCHMARK_RESULT | scenario=X rows=N durationMs=T
+  * rowsPerSec=R }}}
+  */
+object ThroughputReporter {
+
+  def report(scenario: String, rows: Long, durationMs: Long): Unit = {
+    val rowsPerSec = if (durationMs > 0) rows * 1000.0 / durationMs else 0.0
+    println(
+      f"BENCHMARK_RESULT | scenario=$scenario rows=$rows durationMs=$durationMs rowsPerSec=$rowsPerSec%.1f"
+    )
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBE2EBenchmarkSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBE2EBenchmarkSuite.scala
@@ -1,0 +1,21 @@
+package com.scylladb.migrator.alternator
+
+import com.scylladb.migrator.{ E2E, Integration }
+import org.junit.experimental.categories.Category
+
+import scala.concurrent.duration._
+
+/** Abstract base class for DynamoDB end-to-end throughput benchmarks.
+  *
+  * Centralizes munitTimeout and rowCount parsing for all DynamoDB E2E benchmarks.
+  */
+@Category(Array(classOf[Integration], classOf[E2E]))
+abstract class DynamoDBE2EBenchmarkSuite extends MigratorSuiteWithDynamoDBLocal {
+
+  override val munitTimeout: Duration = 60.minutes
+
+  protected val rowCount: Int = sys.props
+    .getOrElse("e2e.ddb.rows", "500000")
+    .toIntOption
+    .getOrElse(throw new IllegalArgumentException("e2e.ddb.rows must be a valid integer"))
+}

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBToAlternatorE2EBenchmark.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBToAlternatorE2EBenchmark.scala
@@ -1,0 +1,42 @@
+package com.scylladb.migrator.alternator
+
+import com.scylladb.migrator.{ DynamoDBBenchmarkDataGenerator, SparkUtils, ThroughputReporter }
+
+/** End-to-end throughput benchmarks for DynamoDB-to-Alternator migration.
+  *
+  * Source: DynamoDB Local (port 8001) Target: ScyllaDB Alternator (port 8000)
+  *
+  * Row count is configurable via `-De2e.ddb.rows=N` (default: 500000).
+  *
+  * Note: DynamoDB Local is significantly slower than real DynamoDB for batch writes (25
+  * items/batch), so the row count is lower than CQL-based benchmarks. The seeding time is excluded
+  * from the migration measurement.
+  */
+class DynamoDBToAlternatorE2EBenchmark extends DynamoDBE2EBenchmarkSuite {
+
+  test(s"DynamoDB->Alternator ${rowCount} rows") {
+    val tableName = "bench_e2e_ddb"
+
+    // Clean up both source and target from any previous runs
+    deleteTableIfExists(targetAlternator(), tableName)
+    DynamoDBBenchmarkDataGenerator.createSimpleTable(sourceDDb(), tableName)
+    DynamoDBBenchmarkDataGenerator.insertSimpleRows(sourceDDb(), tableName, rowCount)
+
+    try {
+      val startTime = System.currentTimeMillis()
+      SparkUtils.successfullyPerformMigration("bench-e2e-dynamodb-to-alternator.yaml")
+      val durationMs = System.currentTimeMillis() - startTime
+
+      val targetCount = DynamoDBBenchmarkDataGenerator.countItems(targetAlternator(), tableName)
+      assertEquals(targetCount, rowCount.toLong, "Row count mismatch for DynamoDB->Alternator")
+
+      // Spot-check a few rows to catch data corruption
+      DynamoDBBenchmarkDataGenerator.spotCheckRows(targetAlternator(), tableName, rowCount)
+
+      ThroughputReporter.report(s"dynamodb-to-alternator-${rowCount}", rowCount.toLong, durationMs)
+    } finally {
+      deleteTableIfExists(sourceDDb(), tableName)
+      deleteTableIfExists(targetAlternator(), tableName)
+    }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBToS3ExportE2EBenchmark.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBToS3ExportE2EBenchmark.scala
@@ -1,0 +1,51 @@
+package com.scylladb.migrator.alternator
+
+import com.scylladb.migrator.{ DynamoDBBenchmarkDataGenerator, SparkUtils, ThroughputReporter }
+import io.circe.parser.{ decode => jsonDecode }
+
+import java.io.File
+import scala.io.Source
+import scala.util.Using
+
+/** End-to-end throughput benchmark for DynamoDB -> S3 Export.
+  *
+  * Source: DynamoDB Local (port 8001) Target: S3 Export files at /app/parquet/bench_s3export
+  *
+  * Row count is configurable via `-De2e.ddb.rows=N` (default: 500000).
+  */
+class DynamoDBToS3ExportE2EBenchmark extends DynamoDBE2EBenchmarkSuite {
+
+  test(s"DynamoDB->S3Export ${rowCount} rows") {
+    val tableName = "bench_e2e_ddb_s3"
+
+    DynamoDBS3ExportE2EBenchmarkUtils.deleteS3ExportDir()
+    DynamoDBBenchmarkDataGenerator.createSimpleTable(sourceDDb(), tableName)
+    DynamoDBBenchmarkDataGenerator.insertSimpleRows(sourceDDb(), tableName, rowCount)
+
+    try {
+      val startTime = System.currentTimeMillis()
+      SparkUtils.successfullyPerformMigration("bench-e2e-dynamodb-to-s3export.yaml")
+      val durationMs = System.currentTimeMillis() - startTime
+
+      assert(
+        DynamoDBS3ExportE2EBenchmarkUtils.hasExportFiles,
+        s"Expected S3 export files in ${DynamoDBS3ExportE2EBenchmarkUtils.s3ExportHostDir}, found none"
+      )
+
+      // Verify item count from manifest
+      val summaryFile =
+        new File(DynamoDBS3ExportE2EBenchmarkUtils.s3ExportHostDir, "manifest-summary.json")
+      val summaryJson = Using.resource(Source.fromFile(summaryFile))(_.mkString)
+      val summary = jsonDecode[DynamoDBS3ExportE2EBenchmarkUtils.ManifestSummary](summaryJson)
+        .fold(throw _, identity)
+      assertEquals(summary.itemCount, rowCount.toLong, "Manifest item count mismatch")
+
+      ThroughputReporter.report(s"dynamodb-to-s3export-${rowCount}", rowCount.toLong, durationMs)
+    } finally {
+      deleteTableIfExists(sourceDDb(), tableName)
+      // S3 export files are intentionally NOT deleted here because
+      // S3ExportToAlternatorE2EBenchmark depends on them. Cleanup happens there.
+    }
+  }
+
+}

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/S3ExportToAlternatorE2EBenchmark.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/S3ExportToAlternatorE2EBenchmark.scala
@@ -1,0 +1,66 @@
+package com.scylladb.migrator.alternator
+
+import com.scylladb.migrator.{ DynamoDBBenchmarkDataGenerator, SparkUtils, ThroughputReporter }
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+
+/** End-to-end throughput benchmark for S3 Export -> Alternator.
+  *
+  * Source: S3 Export files uploaded to LocalStack S3 Target: ScyllaDB Alternator (port 8000)
+  *
+  * Requires running `test-benchmark-e2e-dynamodb-s3export` first to generate S3 Export files.
+  *
+  * Row count is configurable via `-De2e.ddb.rows=N` (default: 500000).
+  */
+class S3ExportToAlternatorE2EBenchmark extends DynamoDBE2EBenchmarkSuite {
+
+  private val bucketName = "bench-bucket"
+  private val s3Prefix = "bench_s3export"
+
+  private val s3Client: S3Client = S3TestUtils.localStackS3Client()
+
+  override def afterAll(): Unit = {
+    s3Client.close()
+    super.afterAll()
+  }
+
+  test(s"S3Export->Alternator ${rowCount} rows") {
+    val targetTable = "bench_e2e_ddb_s3_restore"
+
+    assert(
+      DynamoDBS3ExportE2EBenchmarkUtils.hasExportFiles,
+      "No S3 export files found. Run test-benchmark-e2e-dynamodb-s3export first."
+    )
+
+    // Clean up target and S3 bucket
+    deleteTableIfExists(targetAlternator(), targetTable)
+    S3TestUtils.deleteBucket(s3Client, bucketName)
+    s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketName).build())
+
+    // Upload export files to LocalStack S3
+    S3TestUtils.uploadDirToS3(
+      s3Client,
+      bucketName,
+      DynamoDBS3ExportE2EBenchmarkUtils.s3ExportHostDir,
+      s3Prefix
+    )
+
+    try {
+      val startTime = System.currentTimeMillis()
+      SparkUtils.successfullyPerformMigration("bench-e2e-s3export-to-alternator.yaml")
+      val durationMs = System.currentTimeMillis() - startTime
+
+      val targetCount = DynamoDBBenchmarkDataGenerator.countItems(targetAlternator(), targetTable)
+      assertEquals(targetCount, rowCount.toLong, "Row count mismatch for S3Export->Alternator")
+
+      // Spot-check a few rows to catch data corruption
+      DynamoDBBenchmarkDataGenerator.spotCheckRows(targetAlternator(), targetTable, rowCount)
+
+      ThroughputReporter.report(s"s3export-to-alternator-${rowCount}", rowCount.toLong, durationMs)
+    } finally {
+      deleteTableIfExists(targetAlternator(), targetTable)
+      S3TestUtils.deleteBucket(s3Client, bucketName)
+      DynamoDBS3ExportE2EBenchmarkUtils.deleteS3ExportDir()
+    }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/CassandraToParquetE2EBenchmark.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/CassandraToParquetE2EBenchmark.scala
@@ -1,0 +1,67 @@
+package com.scylladb.migrator.scylla
+
+import com.scylladb.migrator.{
+  BenchmarkDataGenerator,
+  SparkUtils,
+  TestFileUtils,
+  ThroughputReporter
+}
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder
+
+import java.io.File
+
+/** End-to-end throughput benchmark for Cassandra -> Parquet export.
+  *
+  * Source: Cassandra (port 9043) Target: Parquet at /app/parquet/bench_e2e_cass
+  *
+  * Row count is configurable via `-De2e.cql.rows=N` (default: 5000000).
+  */
+class CassandraToParquetE2EBenchmark extends E2EBenchmarkSuite(sourcePort = 9043) {
+
+  // Host path maps to /app/parquet/bench_e2e_cass inside the Spark container
+  private val parquetHostDir = new File("docker/parquet/bench_e2e_cass")
+
+  test(s"Cassandra->Parquet ${rowCount} rows") {
+    val sourceTable = "bench_e2e_cass_parquet"
+
+    if (parquetHostDir.exists()) TestFileUtils.deleteRecursive(parquetHostDir)
+    BenchmarkDataGenerator.createSimpleTable(sourceCassandra(), keyspace, sourceTable)
+    BenchmarkDataGenerator.insertSimpleRows(sourceCassandra(), keyspace, sourceTable, rowCount)
+
+    try {
+      val startTime = System.currentTimeMillis()
+      SparkUtils.successfullyPerformMigration("bench-e2e-cassandra-to-parquet.yaml")
+      val durationMs = System.currentTimeMillis() - startTime
+
+      val parquetFiles = ParquetE2EBenchmarkUtils.countParquetFilesIn(parquetHostDir)
+      assert(
+        parquetFiles > 0,
+        s"Expected parquet files in ${parquetHostDir}, found none"
+      )
+
+      val parquetRows = ParquetE2EBenchmarkUtils.countParquetRowsIn(parquetHostDir)
+      assertEquals(parquetRows, rowCount.toLong, "Parquet row count mismatch")
+
+      // Spot-check a few rows to catch data corruption
+      val rows = ParquetE2EBenchmarkUtils.readFirstRows(parquetHostDir, 3)
+      assert(rows.nonEmpty, "Spot-check: should be able to read at least one row")
+      for (row <- rows) {
+        assert(row.contains("id"), s"Spot-check: row missing 'id' column: $row")
+        assert(row.contains("col1"), s"Spot-check: row missing 'col1' column: $row")
+        assert(row("id").nonEmpty, s"Spot-check: 'id' should not be empty: $row")
+      }
+
+      ThroughputReporter.report(s"cassandra-to-parquet-${rowCount}", rowCount.toLong, durationMs)
+    } finally {
+      if (parquetHostDir.exists()) TestFileUtils.deleteRecursive(parquetHostDir)
+      try
+        sourceCassandra().execute(
+          SchemaBuilder.dropTable(keyspace, sourceTable).ifExists().build()
+        )
+      catch {
+        case e: Exception =>
+          System.err.println(s"Cleanup: failed to drop source table: ${e.getMessage}")
+      }
+    }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/CassandraToScyllaE2EBenchmark.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/CassandraToScyllaE2EBenchmark.scala
@@ -1,0 +1,28 @@
+package com.scylladb.migrator.scylla
+
+/** End-to-end throughput benchmarks for Cassandra-to-Scylla migration.
+  *
+  * Source: Cassandra (port 9043) Target: ScyllaDB (port 9042)
+  *
+  * Row count is configurable via `-De2e.cql.rows=N` (default: 5000000).
+  */
+class CassandraToScyllaE2EBenchmark extends E2EBenchmarkSuite(sourcePort = 9043) {
+
+  test(s"Cassandra->Scylla ${rowCount} rows without timestamps") {
+    runThroughputBenchmark(
+      scenario   = s"cassandra-to-scylla-nots-${rowCount}",
+      tableName  = "bench_e2e_nots",
+      configFile = "bench-e2e-cassandra-to-scylla-nots.yaml",
+      rowCount   = rowCount
+    )
+  }
+
+  test(s"Cassandra->Scylla ${rowCount} rows with timestamps") {
+    runThroughputBenchmark(
+      scenario   = s"cassandra-to-scylla-ts-${rowCount}",
+      tableName  = "bench_e2e_ts",
+      configFile = "bench-e2e-cassandra-to-scylla-ts.yaml",
+      rowCount   = rowCount
+    )
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/E2EBenchmarkSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/E2EBenchmarkSuite.scala
@@ -1,0 +1,26 @@
+package com.scylladb.migrator.scylla
+
+import com.scylladb.migrator.{ E2E, Integration }
+import org.junit.experimental.categories.Category
+
+import scala.concurrent.duration._
+
+/** Abstract base class for end-to-end throughput benchmarks (1M+ rows).
+  *
+  * Same structure as [[BenchmarkSuite]] but tagged with E2E for separate invocation via Makefile
+  * targets.
+  *
+  * Row counts are configurable via system properties (set in Makefile):
+  *   - `e2e.cql.rows` — row count for CQL-based benchmarks (default: 5000000)
+  */
+@Category(Array(classOf[Integration], classOf[E2E]))
+abstract class E2EBenchmarkSuite(sourcePort: Int)
+    extends MigratorSuite(sourcePort) with ThroughputBenchmarkSupport {
+
+  override val munitTimeout: Duration = 60.minutes
+
+  protected val rowCount: Int = sys.props
+    .getOrElse("e2e.cql.rows", "5000000")
+    .toIntOption
+    .getOrElse(throw new IllegalArgumentException("e2e.cql.rows must be a valid integer"))
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetE2EBenchmarkUtils.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetE2EBenchmarkUtils.scala
@@ -1,0 +1,92 @@
+package com.scylladb.migrator.scylla
+
+import com.scylladb.migrator.TestFileUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.hadoop.util.HadoopInputFile
+
+import org.apache.parquet.example.data.simple.convert.GroupRecordConverter
+import org.apache.parquet.io.ColumnIOFactory
+
+import java.io.File
+import scala.jdk.CollectionConverters._
+
+object ParquetE2EBenchmarkUtils {
+  // Host path maps to /app/parquet/bench_e2e inside the Spark container.
+  // Relative to the sbt working directory (tests/).
+  val parquetHostDir = new File("docker/parquet/bench_e2e")
+
+  def deleteParquetDir(): Unit =
+    if (parquetHostDir.exists())
+      TestFileUtils.deleteRecursive(parquetHostDir)
+
+  def countParquetFiles(): Int = countParquetFilesIn(parquetHostDir)
+
+  def countParquetFilesIn(dir: File): Int =
+    if (dir.exists()) {
+      val files = dir.listFiles()
+      if (files != null) files.count(_.getName.endsWith(".parquet"))
+      else 0
+    } else 0
+
+  /** Count total rows across all Parquet files by reading file footers. */
+  def countParquetRows(): Long = countParquetRowsIn(parquetHostDir)
+
+  /** Count total rows across all Parquet files in a given directory. */
+  def countParquetRowsIn(dir: File): Long =
+    if (dir.exists()) {
+      val conf = new Configuration()
+      val files = dir.listFiles()
+      if (files == null) 0L
+      else
+        files
+          .filter(_.getName.endsWith(".parquet"))
+          .map { f =>
+            val reader = ParquetFileReader.open(
+              HadoopInputFile.fromPath(new Path(f.getAbsolutePath), conf)
+            )
+            try reader.getFooter.getBlocks.stream().mapToLong(_.getRowCount).sum()
+            finally reader.close()
+          }
+          .sum
+    } else 0L
+
+  /** Read the first N rows from Parquet files in the given directory. Returns a list of maps
+    * (column name -> string value).
+    */
+  def readFirstRows(dir: File, n: Int): List[Map[String, String]] = {
+    val conf = new Configuration()
+    val files = dir.listFiles()
+    if (files == null) return Nil
+
+    val parquetFiles = files.filter(_.getName.endsWith(".parquet")).sorted
+    val result = scala.collection.mutable.ListBuffer.empty[Map[String, String]]
+
+    for (f <- parquetFiles if result.size < n) {
+      val reader = ParquetFileReader.open(
+        HadoopInputFile.fromPath(new Path(f.getAbsolutePath), conf)
+      )
+      try {
+        val schema = reader.getFooter.getFileMetaData.getSchema
+        var pages = reader.readNextRowGroup()
+        while (pages != null && result.size < n) {
+          val columnIO = new ColumnIOFactory().getColumnIO(schema)
+          val recordReader = columnIO.getRecordReader(pages, new GroupRecordConverter(schema))
+          val rowCount = pages.getRowCount
+          var i = 0L
+          while (i < rowCount && result.size < n) {
+            val group = recordReader.read()
+            val row = schema.getFields.asScala.map { field =>
+              field.getName -> group.getValueToString(schema.getFieldIndex(field.getName), 0)
+            }.toMap
+            result += row
+            i += 1
+          }
+          pages = reader.readNextRowGroup()
+        }
+      } finally reader.close()
+    }
+    result.toList
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetToScyllaE2EBenchmark.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetToScyllaE2EBenchmark.scala
@@ -1,0 +1,68 @@
+package com.scylladb.migrator.scylla
+
+import com.scylladb.migrator.{ BenchmarkDataGenerator, SparkUtils, ThroughputReporter }
+import com.datastax.oss.driver.api.querybuilder.{ QueryBuilder, SchemaBuilder }
+
+import java.time.Duration
+
+/** End-to-end throughput benchmark for Parquet -> Scylla import.
+  *
+  * Source: Parquet at /app/parquet/bench_e2e Target: ScyllaDB (port 9042)
+  *
+  * Requires running `test-benchmark-e2e-scylla-parquet` first to generate Parquet files.
+  *
+  * Row count is configurable via `-De2e.cql.rows=N` (default: 5000000).
+  */
+class ParquetToScyllaE2EBenchmark extends E2EBenchmarkSuite(sourcePort = 9042) {
+
+  test(s"Parquet->Scylla ${rowCount} rows") {
+    val targetTable = "bench_e2e_parquet_restore"
+
+    assert(
+      ParquetE2EBenchmarkUtils.countParquetFiles() > 0,
+      "No parquet files found. Run test-benchmark-e2e-scylla-parquet first."
+    )
+
+    val parquetRows = ParquetE2EBenchmarkUtils.countParquetRows()
+    assertEquals(
+      parquetRows,
+      rowCount.toLong,
+      s"Parquet files contain $parquetRows rows but expected $rowCount. " +
+        "Stale files from a previous run with different -De2e.cql.rows? " +
+        "Re-run test-benchmark-e2e-scylla-parquet first."
+    )
+
+    BenchmarkDataGenerator.createSimpleTable(targetScylla(), keyspace, targetTable)
+
+    try {
+      val startTime = System.currentTimeMillis()
+      SparkUtils.successfullyPerformMigration("bench-e2e-parquet-to-scylla.yaml")
+      val durationMs = System.currentTimeMillis() - startTime
+
+      val countStmt = QueryBuilder
+        .selectFrom(keyspace, targetTable)
+        .countAll()
+        .build()
+        .setTimeout(Duration.ofMinutes(5))
+      val countResult = targetScylla().execute(countStmt)
+      val targetRowCount = countResult.one().getLong(0)
+      assertEquals(targetRowCount, rowCount.toLong, "Row count mismatch for Parquet->Scylla")
+
+      // Spot-check a few rows to catch data corruption
+      spotCheckRows(targetTable, rowCount)
+
+      ThroughputReporter.report(s"parquet-to-scylla-${rowCount}", rowCount.toLong, durationMs)
+
+      // Only delete Parquet files on success; keep them on failure for diagnosis
+      ParquetE2EBenchmarkUtils.deleteParquetDir()
+    } finally
+      try
+        targetScylla().execute(
+          SchemaBuilder.dropTable(keyspace, targetTable).ifExists().build()
+        )
+      catch {
+        case e: Exception =>
+          System.err.println(s"Cleanup: failed to drop target table: ${e.getMessage}")
+      }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaToParquetE2EBenchmark.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaToParquetE2EBenchmark.scala
@@ -1,0 +1,57 @@
+package com.scylladb.migrator.scylla
+
+import com.scylladb.migrator.{ BenchmarkDataGenerator, SparkUtils, ThroughputReporter }
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder
+
+/** End-to-end throughput benchmark for Scylla -> Parquet export.
+  *
+  * Source: ScyllaDB (port 9042) Target: Parquet at /app/parquet/bench_e2e
+  *
+  * Row count is configurable via `-De2e.cql.rows=N` (default: 5000000).
+  */
+class ScyllaToParquetE2EBenchmark extends E2EBenchmarkSuite(sourcePort = 9042) {
+
+  test(s"Scylla->Parquet ${rowCount} rows") {
+    val sourceTable = "bench_e2e_parquet"
+
+    ParquetE2EBenchmarkUtils.deleteParquetDir()
+    BenchmarkDataGenerator.createSimpleTable(sourceCassandra(), keyspace, sourceTable)
+    BenchmarkDataGenerator.insertSimpleRows(sourceCassandra(), keyspace, sourceTable, rowCount)
+
+    try {
+      val startTime = System.currentTimeMillis()
+      SparkUtils.successfullyPerformMigration("bench-e2e-scylla-to-parquet.yaml")
+      val durationMs = System.currentTimeMillis() - startTime
+
+      val parquetFiles = ParquetE2EBenchmarkUtils.countParquetFiles()
+      assert(
+        parquetFiles > 0,
+        s"Expected parquet files in ${ParquetE2EBenchmarkUtils.parquetHostDir}, found none"
+      )
+
+      val parquetRows = ParquetE2EBenchmarkUtils.countParquetRows()
+      assertEquals(parquetRows, rowCount.toLong, "Parquet row count mismatch")
+
+      // Spot-check a few rows to catch data corruption
+      val rows = ParquetE2EBenchmarkUtils.readFirstRows(ParquetE2EBenchmarkUtils.parquetHostDir, 3)
+      assert(rows.nonEmpty, "Spot-check: should be able to read at least one row")
+      for (row <- rows) {
+        assert(row.contains("id"), s"Spot-check: row missing 'id' column: $row")
+        assert(row.contains("col1"), s"Spot-check: row missing 'col1' column: $row")
+        assert(row("id").nonEmpty, s"Spot-check: 'id' should not be empty: $row")
+      }
+
+      ThroughputReporter.report(s"scylla-to-parquet-${rowCount}", rowCount.toLong, durationMs)
+    } finally
+      // Parquet files are intentionally NOT deleted here because
+      // ParquetToScyllaE2EBenchmark depends on them. Cleanup happens there.
+      try
+        sourceCassandra().execute(
+          SchemaBuilder.dropTable(keyspace, sourceTable).ifExists().build()
+        )
+      catch {
+        case e: Exception =>
+          System.err.println(s"Cleanup: failed to drop source table: ${e.getMessage}")
+      }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaToScyllaE2EBenchmark.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaToScyllaE2EBenchmark.scala
@@ -1,0 +1,19 @@
+package com.scylladb.migrator.scylla
+
+/** End-to-end throughput benchmarks for Scylla-to-Scylla migration.
+  *
+  * Source: ScyllaDB (port 9044, scylla-source) Target: ScyllaDB (port 9042, scylla)
+  *
+  * Row count is configurable via `-De2e.cql.rows=N` (default: 5000000).
+  */
+class ScyllaToScyllaE2EBenchmark extends E2EBenchmarkSuite(sourcePort = 9044) {
+
+  test(s"Scylla->Scylla ${rowCount} rows") {
+    runThroughputBenchmark(
+      scenario   = s"scylla-to-scylla-${rowCount}",
+      tableName  = "bench_e2e_s2s",
+      configFile = "bench-e2e-scylla-to-scylla.yaml",
+      rowCount   = rowCount
+    )
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ThroughputBenchmarkSupport.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ThroughputBenchmarkSupport.scala
@@ -1,0 +1,69 @@
+package com.scylladb.migrator.scylla
+
+import com.scylladb.migrator.{ BenchmarkDataGenerator, SparkUtils, ThroughputReporter }
+import com.datastax.oss.driver.api.querybuilder.{ QueryBuilder, SchemaBuilder }
+
+import java.time.Duration
+
+/** Shared throughput benchmark logic for CQL-based benchmark suites. */
+trait ThroughputBenchmarkSupport { self: MigratorSuite =>
+
+  def runThroughputBenchmark(
+    scenario: String,
+    tableName: String,
+    configFile: String,
+    rowCount: Int
+  ): Unit = {
+    BenchmarkDataGenerator.createSimpleTable(sourceCassandra(), keyspace, tableName)
+    BenchmarkDataGenerator.insertSimpleRows(sourceCassandra(), keyspace, tableName, rowCount)
+
+    BenchmarkDataGenerator.createSimpleTable(targetScylla(), keyspace, tableName)
+
+    try {
+      val startTime = System.currentTimeMillis()
+      SparkUtils.successfullyPerformMigration(configFile)
+      val durationMs = System.currentTimeMillis() - startTime
+
+      val countStmt = QueryBuilder
+        .selectFrom(keyspace, tableName)
+        .countAll()
+        .build()
+        .setTimeout(Duration.ofMinutes(5))
+      val countResult = targetScylla().execute(countStmt)
+      val targetRowCount = countResult.one().getLong(0)
+      assertEquals(targetRowCount, rowCount.toLong, s"Row count mismatch for $scenario")
+
+      // Spot-check a few rows to catch data corruption
+      spotCheckRows(tableName, rowCount)
+
+      ThroughputReporter.report(scenario, rowCount.toLong, durationMs)
+    } finally {
+      val dropStmt = SchemaBuilder.dropTable(keyspace, tableName).ifExists().build()
+      try sourceCassandra().execute(dropStmt)
+      catch {
+        case e: Exception =>
+          System.err.println(s"Cleanup: failed to drop source table: ${e.getMessage}")
+      }
+      try targetScylla().execute(dropStmt)
+      catch {
+        case e: Exception =>
+          System.err.println(s"Cleanup: failed to drop target table: ${e.getMessage}")
+      }
+    }
+  }
+
+  /** Verify a sample of rows in the target to detect data corruption. */
+  protected def spotCheckRows(tableName: String, rowCount: Int): Unit = {
+    val sampleIndices = BenchmarkDataGenerator.sampleIndices(rowCount)
+    val prepared = targetScylla().prepare(
+      s"SELECT id, col1, col2, col3 FROM $keyspace.$tableName WHERE id = ?"
+    )
+    for (i <- sampleIndices) {
+      val row = targetScylla().execute(prepared.bind(s"id-$i")).one()
+      assert(row != null, s"Spot-check: row id-$i not found in target")
+      assertEquals(row.getString("col1"), s"value-$i", s"Spot-check: col1 mismatch for id-$i")
+      assertEquals(row.getInt("col2"), i, s"Spot-check: col2 mismatch for id-$i")
+      assertEquals(row.getLong("col3"), i.toLong * 1000L, s"Spot-check: col3 mismatch for id-$i")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add JMH microbenchmarks for CPU-bound hot paths (`explodeRow`, `convertValue`, `createSelection`, DDB value conversions, row comparison, S3 export decoding) in a new `benchmarks` sbt module with shared fixtures
- Add end-to-end integration throughput benchmarks for all migration paths: Cassandra→Scylla, Scylla→Scylla, Scylla→Parquet, Cassandra→Parquet, Parquet→Scylla, DynamoDB→Alternator, DynamoDB→S3Export, S3Export→Alternator
- Refactor `convertRowTypes` closure into public `Cassandra.convertValue` so JMH can call it directly
- Add `Benchmark` munit tag excluded from regular `test-integration` runs
- Add Makefile targets: `test-benchmark-jmh`, `test-benchmark-e2e`, `test-benchmark-e2e-sanity`, and convenience aliases
- Add E2E sanity test step to CI workflow (runs after integration tests)
- Rewrite CONTRIBUTING.md with test category table and updated instructions
- Update docs theme to 1.9 (pip→uv, Python 3.10→3.12)

## Test plan

- [x] `sbt migrator/compile` — migrator compiles after refactor
- [x] `sbt benchmarks/compile` — JMH benchmarks compile
- [x] `sbt scalafmtCheckAll` — formatting passes
- [x] JMH smoke test runs successfully (ExplodeRowBenchmark)
- [x] All 91 unit tests pass (no regression)
- [x] `make test-integration` — existing integration tests still pass, benchmarks excluded
- [x] `make test-benchmark-e2e-sanity` — all migration paths verified with minimal rows
- [x] `make test-benchmark-e2e` — full throughput benchmarks run against Docker services