### PR TITLE
Update trivy-action to 0.35.0

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -19,9 +19,9 @@ jobs:
     name: Trivy filesystem scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: fs
           scan-ref: .


### PR DESCRIPTION
## Summary
- Update `aquasecurity/trivy-action` from 0.28.0 to 0.35.0 to fix security scan failures (Trivy binary install was failing)
- Update `actions/checkout` from v4 to v6

## Test plan
- [x] Verify the Security Scan workflow passes on this PR