### PR TITLE
Fix AWS integration test

### DIFF
--- a/.github/workflows/tests-aws.yml
+++ b/.github/workflows/tests-aws.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Download assembly JAR


### PR DESCRIPTION
## Summary
- Upgrade Java version from 8 to 17 in the AWS integration test workflow to match the Spark 4.0 requirements

## Test plan
- [x] Verify AWS integration tests pass with Java 17