### PR TITLE
Drop rows with null primary keys before writing to Scylla

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
@@ -22,7 +22,8 @@ object TargetSettings {
     stripTrailingZerosForDecimals: Boolean,
     writeTTLInS: Option[Int],
     writeWritetimestampInuS: Option[Long],
-    consistencyLevel: String
+    consistencyLevel: String,
+    dropNullPrimaryKeys: Option[Boolean] = None
   ) extends TargetSettings
 
   case class DynamoDB(

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
@@ -89,7 +89,8 @@ trait ScyllaMigratorBase {
         migratorConfig.getRenamesOrNil,
         sourceDF.dataFrame,
         sourceDF.timestampColumns,
-        tokenRangeAccumulator
+        tokenRangeAccumulator,
+        migratorConfig.source
       )
     } catch {
       case NonFatal(e) => // Catching everything on purpose to try and dump the accumulator state

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -2,24 +2,110 @@ package com.scylladb.migrator.writers
 
 import com.datastax.spark.connector.writer._
 import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql.Schema
 import com.scylladb.migrator.Connectors
-import com.scylladb.migrator.config.{ Rename, TargetSettings }
+import com.scylladb.migrator.config.{ Rename, SourceSettings, TargetSettings }
 import com.scylladb.migrator.readers.TimestampColumns
 import org.apache.logging.log4j.{ LogManager, Logger }
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{ DataFrame, Row, SparkSession }
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.LongAccumulator
 import com.datastax.oss.driver.api.core.ConsistencyLevel
 
 import scala.collection.immutable.ArraySeq
+import java.util.Locale
 
 object Scylla {
   val log: Logger = LogManager.getLogger("com.scylladb.migrator.writer.Scylla")
+
+  private[writers] case class PrimaryKeyResolution(
+    sourcePkNames: Set[String],
+    resolvedSourcePkNames: Set[String],
+    unresolvedSourcePkNames: Set[String],
+    fieldIndices: Array[Int]
+  )
+
+  private[writers] def resolvePrimaryKeyColumns(
+    targetPkNames: Set[String],
+    renames: List[Rename],
+    dfSchema: StructType
+  ): PrimaryKeyResolution = {
+    val reverseRenames = renames.map(r => r.to -> r.from).toMap
+    val sourcePkNames =
+      targetPkNames.map(name => reverseRenames.getOrElse(name, name))
+    val dfFieldNamesLower =
+      dfSchema.fieldNames.map(name => name.toLowerCase(Locale.ROOT) -> name).toMap
+    val resolution = sourcePkNames.map { sourcePkName =>
+      sourcePkName -> dfFieldNamesLower.get(sourcePkName.toLowerCase(Locale.ROOT))
+    }
+
+    val resolvedSourcePkNames = resolution.collect { case (_, Some(dfFieldName)) =>
+      dfFieldName
+    }
+    val unresolvedSourcePkNames = resolution.collect { case (sourcePkName, None) =>
+      sourcePkName
+    }
+    val fieldIndices = resolvedSourcePkNames.map(dfSchema.fieldIndex).toArray
+
+    PrimaryKeyResolution(
+      sourcePkNames,
+      resolvedSourcePkNames,
+      unresolvedSourcePkNames,
+      fieldIndices
+    )
+  }
+
+  private[writers] def requireAllPrimaryKeysResolved(
+    targetPkNames: Set[String],
+    pkResolution: PrimaryKeyResolution
+  ): Unit =
+    if (pkResolution.resolvedSourcePkNames.size != targetPkNames.size) {
+      val resolved = pkResolution.resolvedSourcePkNames.mkString(", ")
+      val unresolved = pkResolution.unresolvedSourcePkNames.mkString(", ")
+      throw new IllegalArgumentException(
+        s"Cannot resolve all primary key columns from the source DataFrame. " +
+          s"Resolved: [${resolved}], unresolved: [${unresolved}]. " +
+          s"Check that column names in the source data match the target table, " +
+          s"or configure renames accordingly."
+      )
+    }
+
+  private[writers] def dropRowsWithNullPrimaryKeys(
+    rdd: RDD[Row],
+    pkFieldIndices: Array[Int],
+    nullPkRowsDropped: LongAccumulator
+  ): RDD[Row] =
+    rdd.filter { row =>
+      val hasNullPk = pkFieldIndices.exists(i => row.isNullAt(i))
+      if (hasNullPk) nullPkRowsDropped.add(1L)
+      !hasNullPk
+    }
+
+  /** Decide whether to drop rows with null primary keys. If explicitly configured on the target,
+    * use that value. Otherwise, auto-detect: CQL and DynamoDB sources guarantee non-null PKs, so
+    * filtering is skipped; other sources (Parquet, etc.) enable it.
+    */
+  private def shouldDropNullPrimaryKeys(
+    target: TargetSettings.Scylla,
+    source: SourceSettings
+  ): Boolean =
+    target.dropNullPrimaryKeys.getOrElse {
+      source match {
+        case _: SourceSettings.Cassandra | _: SourceSettings.DynamoDB |
+            _: SourceSettings.DynamoDBS3Export =>
+          false
+        case _ => true
+      }
+    }
 
   def writeDataframe(
     target: TargetSettings.Scylla,
     renames: List[Rename],
     df: DataFrame,
     timestampColumns: Option[TimestampColumns],
-    tokenRangeAccumulator: Option[TokenRangeAccumulator]
+    tokenRangeAccumulator: Option[TokenRangeAccumulator],
+    source: SourceSettings
   )(implicit spark: SparkSession): Unit = {
     val connector = Connectors.targetConnector(spark.sparkContext.getConf, target)
 
@@ -98,7 +184,38 @@ object Scylla {
           })
         }
 
-    rdd
+    // Optionally filter out rows where any primary key column is null to prevent
+    // infinite retries against the target database (see issue #262).
+    // Auto-detected from the source type, or overridden via target `dropNullPrimaryKeys`.
+    val dropNullPks = shouldDropNullPrimaryKeys(target, source)
+    log.info(s"Drop null primary key rows: ${dropNullPks}")
+    val (finalRdd, nullPkRowsDropped) =
+      if (dropNullPks) {
+        val tableDef =
+          connector.withSessionDo(Schema.tableFromCassandra(_, target.keyspace, target.table))
+        val targetPkNames = tableDef.primaryKey.map(_.columnName).toSet
+
+        val pkResolution = resolvePrimaryKeyColumns(targetPkNames, renames, df.schema)
+        pkResolution.unresolvedSourcePkNames.foreach { sourcePkName =>
+          log.warn(s"Primary key column '${sourcePkName}' not found in source DataFrame schema")
+        }
+        requireAllPrimaryKeysResolved(targetPkNames, pkResolution)
+
+        val pkColumnsInDf = pkResolution.resolvedSourcePkNames
+        val pkFieldIndices = pkResolution.fieldIndices
+        log.info(
+          s"Primary key columns in target table: ${targetPkNames.mkString(", ")}; " +
+            s"corresponding source columns: ${pkColumnsInDf.mkString(", ")}"
+        )
+
+        val accumulator =
+          spark.sparkContext.longAccumulator("Rows dropped due to null primary key")
+        (dropRowsWithNullPrimaryKeys(rdd, pkFieldIndices, accumulator), Some(accumulator))
+      } else {
+        (rdd, None)
+      }
+
+    finalRdd
       .saveToCassandra(
         target.keyspace,
         target.table,
@@ -106,6 +223,14 @@ object Scylla {
         writeConf,
         tokenRangeAccumulator = tokenRangeAccumulator
       )(connector, SqlRowWriter.Factory)
+
+    nullPkRowsDropped.foreach { acc =>
+      if (acc.value > 0) {
+        log.warn(
+          s"Dropped ${acc.value} rows with null primary key values"
+        )
+      }
+    }
   }
 
 }

--- a/tests/src/test/scala/com/scylladb/migrator/writers/ScyllaPrimaryKeyFilteringTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/writers/ScyllaPrimaryKeyFilteringTest.scala
@@ -1,0 +1,91 @@
+package com.scylladb.migrator.writers
+
+import com.scylladb.migrator.config.Rename
+import org.apache.spark.sql.{ Row, SparkSession }
+import org.apache.spark.sql.types.{ IntegerType, StringType, StructField, StructType }
+
+class ScyllaPrimaryKeyFilteringTest extends munit.FunSuite {
+
+  implicit val spark: SparkSession = SparkSession
+    .builder()
+    .appName("ScyllaPrimaryKeyFilteringTest")
+    .master("local[*]")
+    .config("spark.sql.shuffle.partitions", "1")
+    .getOrCreate()
+
+  override def afterAll(): Unit = {
+    spark.stop()
+    super.afterAll()
+  }
+
+  test("resolvePrimaryKeyColumns resolves renamed and case-insensitive primary key columns") {
+    val schema = StructType(
+      Seq(
+        StructField("ID", StringType, nullable             = true),
+        StructField("ClusteringKey", IntegerType, nullable = true),
+        StructField("value", StringType, nullable          = true)
+      )
+    )
+
+    val targetPkNames = Set("id_target", "clusteringkey")
+    val renames = List(Rename("ID", "id_target"))
+
+    val resolution = Scylla.resolvePrimaryKeyColumns(targetPkNames, renames, schema)
+
+    assertEquals(resolution.unresolvedSourcePkNames, Set.empty[String])
+    assertEquals(resolution.resolvedSourcePkNames, Set("ID", "ClusteringKey"))
+    assertEquals(
+      resolution.fieldIndices.toSet,
+      Set(schema.fieldIndex("ID"), schema.fieldIndex("ClusteringKey"))
+    )
+  }
+
+  test("requireAllPrimaryKeysResolved throws when not all primary key columns are found") {
+    val schema = StructType(
+      Seq(
+        StructField("id", StringType, nullable    = true),
+        StructField("value", StringType, nullable = true)
+      )
+    )
+
+    val targetPkNames = Set("id", "missing_pk")
+    val resolution = Scylla.resolvePrimaryKeyColumns(targetPkNames, Nil, schema)
+
+    val error = intercept[IllegalArgumentException] {
+      Scylla.requireAllPrimaryKeysResolved(targetPkNames, resolution)
+    }
+
+    assert(error.getMessage.contains("Cannot resolve all primary key columns"))
+    assert(error.getMessage.contains("missing_pk"))
+  }
+
+  test("dropRowsWithNullPrimaryKeys drops invalid rows and tracks dropped count") {
+    val schema = StructType(
+      Seq(
+        StructField("pk1", StringType, nullable   = true),
+        StructField("pk2", StringType, nullable   = true),
+        StructField("value", StringType, nullable = true)
+      )
+    )
+
+    val sourceRows = Seq(
+      Row("a", "1", "ok-1"),
+      Row(null, "2", "bad-1"),
+      Row("c", null, "bad-2"),
+      Row("d", "4", "ok-2")
+    )
+    val sourceRdd = spark.sparkContext.parallelize(sourceRows)
+    val droppedRows = spark.sparkContext.longAccumulator("dropped-null-pk-rows-test")
+
+    val filtered = Scylla.dropRowsWithNullPrimaryKeys(
+      sourceRdd,
+      Array(schema.fieldIndex("pk1"), schema.fieldIndex("pk2")),
+      droppedRows
+    )
+
+    val keptRows =
+      filtered.collect().map(row => (row.getString(0), row.getString(1), row.getString(2))).toSet
+    assertEquals(keptRows, Set(("a", "1", "ok-1"), ("d", "4", "ok-2")))
+    assert(droppedRows.value == 2L)
+  }
+}


### PR DESCRIPTION
## Summary

Rows with null primary key values cause infinite retries in the Spark-Cassandra connector (see #262). This PR detects PK columns from the target table schema and filters out rows with null PKs before writing.

### `dropNullPrimaryKeys` configuration

A new optional setting on the Scylla/Cassandra target controls this behavior:

```yaml
target:
  type: scylla
  # ... other settings ...
  dropNullPrimaryKeys: true  # optional, auto-detected when omitted
```

**When omitted** (default): auto-detected based on the source type:
| Source type | Default behavior |
|---|---|
| `cassandra` / `scylla` | Disabled — CQL enforces non-null PKs |
| `dynamodb` | Disabled — DynamoDB enforces non-null key attributes |
| `dynamodb-s3-export` | Disabled — same as DynamoDB |
| `parquet` | **Enabled** — Parquet files may contain null values in PK columns |

**When set to `true`**: always filters null-PK rows, regardless of source type.

**When set to `false`**: never filters, regardless of source type.

### How it works

1. Reads the target table schema to identify primary key columns
2. Resolves PK column names back to the source DataFrame, handling renames and case-insensitive matching
3. Validates that all target PK columns can be mapped — throws an error if any are missing
4. Filters out rows where any PK column is null
5. Logs a warning with the count of dropped rows after the write completes

Extracted from #283. Fixes #262.

## Test plan
- [x] Unit test for PK column resolution (with renames, case-insensitive matching)
- [x] Unit test for `requireAllPrimaryKeysResolved` error on missing columns
- [x] Unit test for `dropRowsWithNullPrimaryKeys` filtering and accumulator counting