### PR TITLE
Fix order-sensitive DynamoDB set comparison in validator

### DIFF
--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/DdbValueSerializationBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/DdbValueSerializationBenchmark.scala
@@ -45,7 +45,7 @@ class DdbValueSerializationBenchmark {
         )
       ),
       "tags"   -> DdbValue.L(Seq(DdbValue.S("urgent"), DdbValue.S("reviewed"), DdbValue.N("42"))),
-      "scores" -> DdbValue.Ns(Seq("100", "200", "300"))
+      "scores" -> DdbValue.Ns(Set("100", "200", "300"))
     )
 
     flatItemBytes   = serialize(flatItem)

--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/RowComparisonBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/RowComparisonBenchmark.scala
@@ -4,6 +4,7 @@ import com.datastax.spark.connector.CassandraRow
 import com.scylladb.migrator.alternator.DdbValue
 import com.scylladb.migrator.validation.RowComparisonFailure
 import org.openjdk.jmh.annotations._
+import software.amazon.awssdk.core.SdkBytes
 
 import java.util.concurrent.TimeUnit
 
@@ -26,6 +27,10 @@ class RowComparisonBenchmark {
   private var dynamoLeft: Map[String, DdbValue] = _
   private var dynamoRightSame: Map[String, DdbValue] = _
   private var dynamoRightDiff: Map[String, DdbValue] = _
+
+  private var dynamoSetLeft: Map[String, DdbValue] = _
+  private var dynamoSetRightSame: Map[String, DdbValue] = _
+  private var dynamoSetRightDiff: Map[String, DdbValue] = _
 
   @Setup(Level.Trial)
   def setup(): Unit = {
@@ -77,6 +82,43 @@ class RowComparisonBenchmark {
       "age"    -> DdbValue.N("25"),
       "active" -> DdbValue.Bool(false)
     )
+
+    dynamoSetLeft = Map(
+      "pk"     -> DdbValue.S("user-123"),
+      "tags"   -> DdbValue.Ss(Set("a", "b", "c", "d", "e")),
+      "scores" -> DdbValue.Ns(Set("1.1", "2.2", "3.3", "4.4", "5.5")),
+      "blobs" -> DdbValue.Bs(
+        Set(
+          SdkBytes.fromUtf8String("alpha"),
+          SdkBytes.fromUtf8String("beta"),
+          SdkBytes.fromUtf8String("gamma")
+        )
+      )
+    )
+    dynamoSetRightSame = Map(
+      "pk"     -> DdbValue.S("user-123"),
+      "tags"   -> DdbValue.Ss(Set("e", "d", "c", "b", "a")),
+      "scores" -> DdbValue.Ns(Set("5.5", "4.4", "3.3", "2.2", "1.1")),
+      "blobs" -> DdbValue.Bs(
+        Set(
+          SdkBytes.fromUtf8String("gamma"),
+          SdkBytes.fromUtf8String("alpha"),
+          SdkBytes.fromUtf8String("beta")
+        )
+      )
+    )
+    dynamoSetRightDiff = Map(
+      "pk"     -> DdbValue.S("user-123"),
+      "tags"   -> DdbValue.Ss(Set("a", "b", "x", "y", "z")),
+      "scores" -> DdbValue.Ns(Set("1.1", "2.2", "9.9", "8.8", "7.7")),
+      "blobs" -> DdbValue.Bs(
+        Set(
+          SdkBytes.fromUtf8String("alpha"),
+          SdkBytes.fromUtf8String("delta"),
+          SdkBytes.fromUtf8String("epsilon")
+        )
+      )
+    )
   }
 
   @Benchmark
@@ -117,6 +159,24 @@ class RowComparisonBenchmark {
     RowComparisonFailure.compareDynamoDBRows(
       dynamoLeft,
       Some(dynamoRightDiff),
+      renamedColumn          = identity,
+      floatingPointTolerance = 0.0
+    )
+
+  @Benchmark
+  def compareDynamoDBRows_sets_identical(): Option[RowComparisonFailure] =
+    RowComparisonFailure.compareDynamoDBRows(
+      dynamoSetLeft,
+      Some(dynamoSetRightSame),
+      renamedColumn          = identity,
+      floatingPointTolerance = 0.0
+    )
+
+  @Benchmark
+  def compareDynamoDBRows_sets_differing(): Option[RowComparisonFailure] =
+    RowComparisonFailure.compareDynamoDBRows(
+      dynamoSetLeft,
+      Some(dynamoSetRightDiff),
       renamedColumn          = identity,
       floatingPointTolerance = 0.0
     )

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/DdbValue.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/DdbValue.scala
@@ -9,8 +9,12 @@ import scala.jdk.CollectionConverters._
   * https://github.com/aws/aws-sdk-java-v2/issues/3143 The fact that `AttributeValue` is not
   * serializable anymore prevents us to use it in RDD operations that may perform shuffles. As a
   * workaround, we convert values of type `AttributeValue` to `DdbValue`.
+  *
+  * Breaking change: bumped from 1L to 2L because set types (Ss, Ns, Bs) changed from Seq to Set.
+  * Serialized DdbValue instances from prior versions are incompatible — migrations cannot be
+  * resumed from savepoints created by the old version.
   */
-@SerialVersionUID(1L)
+@SerialVersionUID(2L)
 sealed trait DdbValue extends Serializable
 
 object DdbValue {
@@ -21,9 +25,9 @@ object DdbValue {
   case class Null(value: Boolean) extends DdbValue
   case class B(value: SdkBytes) extends DdbValue
   case class M(value: Map[String, DdbValue]) extends DdbValue
-  case class Ss(values: collection.Seq[String]) extends DdbValue
-  case class Ns(values: collection.Seq[String]) extends DdbValue
-  case class Bs(values: collection.Seq[SdkBytes]) extends DdbValue
+  case class Ss(values: Set[String]) extends DdbValue
+  case class Ns(values: Set[String]) extends DdbValue
+  case class Bs(values: Set[SdkBytes]) extends DdbValue
 
   def from(value: AttributeValue): DdbValue =
     if (value.s() != null) S(value.s())
@@ -33,8 +37,8 @@ object DdbValue {
     else if (value.nul() != null) Null(value.nul())
     else if (value.b() != null) B(value.b())
     else if (value.hasM) M(value.m().asScala.view.mapValues(from).toMap)
-    else if (value.hasSs) Ss(value.ss().asScala)
-    else if (value.hasNs) Ns(value.ns().asScala)
-    else if (value.hasBs) Bs(value.bs().asScala)
+    else if (value.hasSs) Ss(value.ss().asScala.toSet)
+    else if (value.hasNs) Ns(value.ns().asScala.toSet)
+    else if (value.hasBs) Bs(value.bs().asScala.toSet)
     else sys.error("Unknown AttributeValue type")
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala
@@ -231,10 +231,18 @@ object RowComparisonFailure {
       case (Some(DdbValue.N(l)), Some(DdbValue.N(r))) =>
         areNumericalValuesDifferent(BigDecimal(l), BigDecimal(r), floatingPointTolerance)
       case (Some(DdbValue.Ns(l)), Some(DdbValue.Ns(r))) =>
-        val xs = l.map(BigDecimal(_))
-        val ys = r.map(BigDecimal(_))
+        val xs = l.toSeq.map(BigDecimal(_)).sorted
+        val ys = r.toSeq.map(BigDecimal(_)).sorted
         xs.size != ys.size || xs.zip(ys).exists { case (x, y) =>
           areNumericalValuesDifferent(x, y, floatingPointTolerance)
+        }
+      case (Some(DdbValue.L(l)), Some(DdbValue.L(r))) =>
+        l.size != r.size || l.zip(r).exists { case (lv, rv) =>
+          areDifferent(Some(lv), Some(rv), timestampMsTolerance, floatingPointTolerance)
+        }
+      case (Some(DdbValue.M(l)), Some(DdbValue.M(r))) =>
+        l.size != r.size || l.keySet != r.keySet || l.exists { case (k, lv) =>
+          areDifferent(Some(lv), r.get(k), timestampMsTolerance, floatingPointTolerance)
         }
 
       // All remaining types get compared with standard equality

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDBS3Export.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDBS3Export.scala
@@ -190,15 +190,22 @@ object DynamoDBS3Export {
       val b64 = Base64.getEncoder.encodeToString(av.b().asByteArray())
       Json.obj("B" -> Json.fromString(b64))
     } else if (av.hasSs)
-      Json.obj("SS" -> Json.fromValues(av.ss().asScala.map(Json.fromString)))
+      Json.obj("SS" -> Json.fromValues(av.ss().asScala.toSeq.sorted.map(Json.fromString)))
     else if (av.hasNs)
-      Json.obj("NS" -> Json.fromValues(av.ns().asScala.map(Json.fromString)))
+      Json.obj(
+        "NS" -> Json.fromValues(
+          av.ns().asScala.toSeq.sortBy(s => BigDecimal(s)).map(Json.fromString)
+        )
+      )
     else if (av.hasBs)
       Json.obj(
         "BS" -> Json.fromValues(
           av.bs()
             .asScala
-            .map(b => Json.fromString(Base64.getEncoder.encodeToString(b.asByteArray())))
+            .toSeq
+            .map(b => Base64.getEncoder.encodeToString(b.asByteArray()))
+            .sorted
+            .map(Json.fromString)
         )
       )
     else if (av.hasL)

--- a/tests/src/test/scala/com/scylladb/migrator/validation/DynamoDBRowComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/DynamoDBRowComparisonTest.scala
@@ -2,6 +2,7 @@ package com.scylladb.migrator.validation
 
 import com.scylladb.migrator.alternator.DdbValue
 import com.scylladb.migrator.validation.RowComparisonFailure.{ dynamoDBRowComparisonFailure, Item }
+import software.amazon.awssdk.core.SdkBytes
 
 class DynamoDBRowComparisonTest extends munit.FunSuite {
 
@@ -88,6 +89,204 @@ class DynamoDBRowComparisonTest extends munit.FunSuite {
           List(Item.DifferingFieldValues(List("foo")))
         )
       )
+    assertEquals(result, expected)
+  }
+
+  test("String sets with different order are equal") {
+    val source = Map("foo" -> DdbValue.Ss(Set("a", "b", "c")))
+    val target = Map("foo" -> DdbValue.Ss(Set("c", "a", "b")))
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      source,
+      Some(target),
+      sameColumns,
+      floatingPointTolerance
+    )
+    assertEquals(result, None)
+  }
+
+  test("Number sets with different order are equal") {
+    val source = Map("foo" -> DdbValue.Ns(Set("1", "2", "3")))
+    val target = Map("foo" -> DdbValue.Ns(Set("3", "1", "2")))
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      source,
+      Some(target),
+      sameColumns,
+      floatingPointTolerance
+    )
+    assertEquals(result, None)
+  }
+
+  test("Number sets with different order are equal within tolerance") {
+    val source = Map("foo" -> DdbValue.Ns(Set("1.001", "2.002")))
+    val target = Map("foo" -> DdbValue.Ns(Set("2.003", "1.002")))
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      source,
+      Some(target),
+      sameColumns,
+      floatingPointTolerance
+    )
+    assertEquals(result, None)
+  }
+
+  test("Binary sets with different order are equal") {
+    val b1 = SdkBytes.fromUtf8String("alpha")
+    val b2 = SdkBytes.fromUtf8String("beta")
+    val b3 = SdkBytes.fromUtf8String("gamma")
+    val source = Map("foo" -> DdbValue.Bs(Set(b1, b2, b3)))
+    val target = Map("foo" -> DdbValue.Bs(Set(b3, b1, b2)))
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      source,
+      Some(target),
+      sameColumns,
+      floatingPointTolerance
+    )
+    assertEquals(result, None)
+  }
+
+  test("String sets with different elements are different") {
+    val source = Map("foo" -> DdbValue.Ss(Set("a", "b", "c")))
+    val target = Map("foo" -> DdbValue.Ss(Set("a", "b", "d")))
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      source,
+      Some(target),
+      sameColumns,
+      floatingPointTolerance
+    )
+    val expected = Some(
+      dynamoDBRowComparisonFailure(
+        source,
+        Some(target),
+        List(Item.DifferingFieldValues(List("foo")))
+      )
+    )
+    assertEquals(result, expected)
+  }
+
+  test("Number sets with different elements are different") {
+    val source = Map("foo" -> DdbValue.Ns(Set("1", "2", "3")))
+    val target = Map("foo" -> DdbValue.Ns(Set("1", "2", "4")))
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      source,
+      Some(target),
+      sameColumns,
+      floatingPointTolerance
+    )
+    val expected = Some(
+      dynamoDBRowComparisonFailure(
+        source,
+        Some(target),
+        List(Item.DifferingFieldValues(List("foo")))
+      )
+    )
+    assertEquals(result, expected)
+  }
+
+  test("Binary sets with different elements are different") {
+    val b1 = SdkBytes.fromUtf8String("alpha")
+    val b2 = SdkBytes.fromUtf8String("beta")
+    val b3 = SdkBytes.fromUtf8String("gamma")
+    val source = Map("foo" -> DdbValue.Bs(Set(b1, b2)))
+    val target = Map("foo" -> DdbValue.Bs(Set(b1, b3)))
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      source,
+      Some(target),
+      sameColumns,
+      floatingPointTolerance
+    )
+    val expected = Some(
+      dynamoDBRowComparisonFailure(
+        source,
+        Some(target),
+        List(Item.DifferingFieldValues(List("foo")))
+      )
+    )
+    assertEquals(result, expected)
+  }
+
+  test("Nested sets inside a list are compared with set semantics") {
+    val source = Map(
+      "foo" -> DdbValue.L(Seq(DdbValue.Ss(Set("a", "b")), DdbValue.Ns(Set("1", "2"))))
+    )
+    val target = Map(
+      "foo" -> DdbValue.L(Seq(DdbValue.Ss(Set("b", "a")), DdbValue.Ns(Set("2", "1"))))
+    )
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      source,
+      Some(target),
+      sameColumns,
+      floatingPointTolerance
+    )
+    assertEquals(result, None)
+  }
+
+  test("Nested sets inside a map are compared with set semantics") {
+    val source = Map(
+      "foo" -> DdbValue.M(Map("tags" -> DdbValue.Ss(Set("x", "y", "z"))))
+    )
+    val target = Map(
+      "foo" -> DdbValue.M(Map("tags" -> DdbValue.Ss(Set("z", "x", "y"))))
+    )
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      source,
+      Some(target),
+      sameColumns,
+      floatingPointTolerance
+    )
+    assertEquals(result, None)
+  }
+
+  test("Nested number sets inside a list are compared with tolerance") {
+    val source = Map(
+      "foo" -> DdbValue.L(Seq(DdbValue.Ns(Set("1.001", "2.002"))))
+    )
+    val target = Map(
+      "foo" -> DdbValue.L(Seq(DdbValue.Ns(Set("2.003", "1.002"))))
+    )
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      source,
+      Some(target),
+      sameColumns,
+      floatingPointTolerance
+    )
+    assertEquals(result, None)
+  }
+
+  test("Nested number sets inside a map are compared with tolerance") {
+    val source = Map(
+      "foo" -> DdbValue.M(Map("scores" -> DdbValue.Ns(Set("1.001", "2.002"))))
+    )
+    val target = Map(
+      "foo" -> DdbValue.M(Map("scores" -> DdbValue.Ns(Set("2.003", "1.002"))))
+    )
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      source,
+      Some(target),
+      sameColumns,
+      floatingPointTolerance
+    )
+    assertEquals(result, None)
+  }
+
+  test("Nested map with different values is detected") {
+    val source = Map(
+      "foo" -> DdbValue.M(Map("a" -> DdbValue.S("one"), "b" -> DdbValue.S("two")))
+    )
+    val target = Map(
+      "foo" -> DdbValue.M(Map("a" -> DdbValue.S("one"), "b" -> DdbValue.S("three")))
+    )
+    val result = RowComparisonFailure.compareDynamoDBRows(
+      source,
+      Some(target),
+      sameColumns,
+      floatingPointTolerance
+    )
+    val expected = Some(
+      dynamoDBRowComparisonFailure(
+        source,
+        Some(target),
+        List(Item.DifferingFieldValues(List("foo")))
+      )
+    )
     assertEquals(result, expected)
   }
 


### PR DESCRIPTION
## Summary
DynamoDB `SS`, `NS`, and `BS` types are unordered sets, but the validator compared them as ordered sequences, causing false validation failures when elements appeared in a different order.

**Set comparison fix:**
- Sort `NS` values before zip-comparing to preserve floating-point tolerance logic
- Add explicit `SS` and `BS` cases using `Set` equality

**DdbValue type change (Seq -> Set):**
- Change `Ss`, `Ns`, `Bs` case classes from `collection.Seq` to `Set`, so case-class-derived `equals`/`hashCode` is order-insensitive everywhere
- Bump `@SerialVersionUID` from `1L` to `2L`
- Update `DdbValue.from()` to convert AWS SDK lists to Sets via `.toSet`

**Recursive L/M comparison:**
- Add explicit `DdbValue.L` and `DdbValue.M` cases in `areDifferent` that recurse into child values, so nested sets are compared with set semantics

**S3 export deterministic output:**
- Sort `SS` elements lexicographically, `NS` numerically, `BS` by base64 encoding in `encodeAttributeValueJson`

**Benchmarks:**
- Add `Ss`/`Ns`/`Bs` benchmark data and `compareDynamoDBRows_sets_identical`/`compareDynamoDBRows_sets_differing` benchmarks

Extracted from #283. Fixes #282.

## Test plan
- [x] SS with different order — equal
- [x] NS with different order — equal
- [x] NS with different order + tolerance — equal
- [x] BS with different order — equal
- [x] SS with different elements — different
- [x] NS with different elements — different
- [x] BS with different elements — different
- [x] Nested sets inside L — equal
- [x] Nested sets inside M — equal
- [x] Nested M with different values — different
- [x] All 20 S3 export encoder roundtrip tests pass