### PR TITLE
Fix AWS integration tests failing with OIDC credentials

### DIFF
--- a/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
@@ -22,7 +22,7 @@ import software.amazon.awssdk.services.dynamodb.model.{
 }
 
 import java.net.URI
-import java.nio.file.Paths
+import java.nio.file.{ Files, Paths }
 import scala.util.chaining._
 import scala.jdk.CollectionConverters._
 import scala.sys.process.stringToProcess
@@ -232,7 +232,25 @@ abstract class MigratorSuiteWithAWS extends MigratorSuite {
       // Provision the AWS credentials on the Spark nodes via a Docker volume
       val localAwsCredentials =
         Paths.get(sys.props("user.home"), ".aws", "credentials").toAbsolutePath
-      (s"cp ${localAwsCredentials} docker/aws-profile/credentials").!!
+      val targetCredentials = Paths.get("docker", "aws-profile", "credentials")
+      if (Files.exists(localAwsCredentials)) {
+        Files.copy(
+          localAwsCredentials,
+          targetCredentials,
+          java.nio.file.StandardCopyOption.REPLACE_EXISTING
+        )
+      } else {
+        // In CI, credentials are provided via environment variables (e.g., OIDC federation)
+        val accessKey = sys.env("AWS_ACCESS_KEY_ID")
+        val secretKey = sys.env("AWS_SECRET_ACCESS_KEY")
+        val sessionToken = sys.env.get("AWS_SESSION_TOKEN")
+        val content = new StringBuilder()
+          .append("[default]\n")
+          .append(s"aws_access_key_id = ${accessKey}\n")
+          .append(s"aws_secret_access_key = ${secretKey}\n")
+        sessionToken.foreach(token => content.append(s"aws_session_token = ${token}\n"))
+        Files.write(targetCredentials, content.toString().getBytes)
+      }
 
       val region = Region.of(sys.env("AWS_REGION"))
       client = DynamoDbClient


### PR DESCRIPTION
## Summary
- Fix `StreamedItemsTest.beforeAll(sourceDDb)` failing with `RuntimeException: Nonzero exit value: 1` because `~/.aws/credentials` does not exist in CI
- The `configure-aws-credentials` action with OIDC federation sets environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`) instead of creating a credentials file
- When the local credentials file is absent, generate it from environment variables so the Spark Docker containers can authenticate with AWS

Fixes https://github.com/scylladb/scylla-migrator/actions/runs/23338479704/job/67886168784

## Test plan
- [x] CI "Tests with AWS" workflow passes with this change
- [x] Local development with `~/.aws/credentials` still works (file copy path)