### PR TITLE
Fix AWS integration tests with OIDC credentials

### DIFF
--- a/.github/workflows/tests-aws.yml
+++ b/.github/workflows/tests-aws.yml
@@ -62,10 +62,11 @@ jobs:
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
       - name: Wait for services
         run: make wait-for-services-aws
+      - name: Run AWS integration tests
+        run: make test-integration-aws
       - name: Dump container logs on failure
         if: failure()
         run: make dump-logs
-      - name: Run AWS integration tests
-        run: make test-integration-aws
       - name: Stop services
+        if: always()
         run: make stop-services

--- a/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
@@ -237,20 +237,32 @@ object DynamoUtils {
         source.region
       )
 
-    sourceClient
-      .updateTable(
-        UpdateTableRequest
-          .builder()
-          .tableName(source.table)
-          .streamSpecification(
-            StreamSpecification
-              .builder()
-              .streamEnabled(true)
-              .streamViewType(StreamViewType.NEW_IMAGE)
-              .build()
-          )
-          .build()
-      )
+    // Check if streams are already enabled before trying to update the table
+    val tableDesc =
+      sourceClient.describeTable(DescribeTableRequest.builder().tableName(source.table).build())
+    val streamSpec = tableDesc.table.streamSpecification
+    val alreadyEnabled =
+      streamSpec != null && streamSpec.streamEnabled && streamSpec.streamViewType == StreamViewType.NEW_IMAGE
+
+    if (!alreadyEnabled) {
+      log.info("Enabling DynamoDB Streams on the source table")
+      sourceClient
+        .updateTable(
+          UpdateTableRequest
+            .builder()
+            .tableName(source.table)
+            .streamSpecification(
+              StreamSpecification
+                .builder()
+                .streamEnabled(true)
+                .streamViewType(StreamViewType.NEW_IMAGE)
+                .build()
+            )
+            .build()
+        )
+    } else {
+      log.info("DynamoDB Streams already enabled on the source table")
+    }
 
     var done = false
     while (!done) {

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
@@ -76,11 +76,17 @@ object DynamoDB {
         .table
 
     val maybeTtlDescription =
-      Option(
-        dynamoDbClient
-          .describeTimeToLive(DescribeTimeToLiveRequest.builder().tableName(table).build())
-          .timeToLiveDescription
-      )
+      try
+        Option(
+          dynamoDbClient
+            .describeTimeToLive(DescribeTimeToLiveRequest.builder().tableName(table).build())
+            .timeToLiveDescription
+        )
+      catch {
+        case e: software.amazon.awssdk.services.dynamodb.model.DynamoDbException =>
+          log.warn(s"Could not describe TTL for table ${table}: ${e.getMessage}")
+          None
+      }
 
     val jobConf =
       makeJobConf(

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/MigratorSuite.scala
@@ -11,14 +11,18 @@ import software.amazon.awssdk.services.dynamodb.model.{
   CreateTableRequest,
   DeleteTableRequest,
   DescribeTableRequest,
+  DynamoDbException,
   GetItemRequest,
   GlobalSecondaryIndexDescription,
   KeySchemaElement,
   KeyType,
   LocalSecondaryIndexDescription,
   ProvisionedThroughput,
+  ResourceInUseException,
   ResourceNotFoundException,
-  ScalarAttributeType
+  ScalarAttributeType,
+  StreamSpecification,
+  StreamViewType
 }
 
 import java.net.URI
@@ -87,7 +91,13 @@ trait MigratorSuite extends munit.FunSuite {
               ProvisionedThroughput.builder().readCapacityUnits(25L).writeCapacityUnits(25L).build()
             )
             .build()
-        sourceDDb().createTable(createTableRequest)
+        try
+          sourceDDb().createTable(createTableRequest)
+        catch {
+          case _: ResourceInUseException =>
+            // Table already exists (e.g., from a previous run that could not delete it)
+            System.err.println(s"Table ${name} already exists, reusing it")
+        }
         val waiterResponse =
           sourceDDb()
             .waiter()
@@ -105,9 +115,65 @@ trait MigratorSuite extends munit.FunSuite {
     teardown = { _ =>
       // Clean-up both the source and target databases because we assume the test did replicate the table
       // to the target database
-      targetAlternator().deleteTable(DeleteTableRequest.builder().tableName(name).build())
-      sourceDDb().deleteTable(DeleteTableRequest.builder().tableName(name).build())
-      ()
+      deleteTableIfExists(targetAlternator(), name)
+      deleteTableIfExists(sourceDDb(), name)
+    }
+  )
+
+  /** Like `withTable`, but creates the table with DynamoDB Streams enabled. This avoids needing
+    * `dynamodb:UpdateTable` permission to enable streams later.
+    */
+  def withStreamingTable(name: String): FunFixture[String] = FunFixture(
+    setup = { _ =>
+      deleteTableIfExists(sourceDDb(), name)
+      deleteTableIfExists(targetAlternator(), name)
+      try {
+        val createTableRequest =
+          CreateTableRequest
+            .builder()
+            .tableName(name)
+            .keySchema(KeySchemaElement.builder().attributeName("id").keyType(KeyType.HASH).build())
+            .attributeDefinitions(
+              AttributeDefinition
+                .builder()
+                .attributeName("id")
+                .attributeType(ScalarAttributeType.S)
+                .build()
+            )
+            .provisionedThroughput(
+              ProvisionedThroughput.builder().readCapacityUnits(25L).writeCapacityUnits(25L).build()
+            )
+            .streamSpecification(
+              StreamSpecification
+                .builder()
+                .streamEnabled(true)
+                .streamViewType(StreamViewType.NEW_IMAGE)
+                .build()
+            )
+            .build()
+        try
+          sourceDDb().createTable(createTableRequest)
+        catch {
+          case _: ResourceInUseException =>
+            System.err.println(s"Table ${name} already exists, reusing it")
+        }
+        val waiterResponse =
+          sourceDDb()
+            .waiter()
+            .waitUntilTableExists(describeTableRequest(name))
+        assert(
+          waiterResponse.matched().response().isPresent,
+          s"Failed to create table ${name}: ${waiterResponse.matched().exception().get()}"
+        )
+      } catch {
+        case any: Throwable =>
+          fail(s"Failed to create table ${name} in database ${sourceDDb()}", any)
+      }
+      name
+    },
+    teardown = { _ =>
+      deleteTableIfExists(targetAlternator(), name)
+      deleteTableIfExists(sourceDDb(), name)
     }
   )
 
@@ -133,6 +199,9 @@ trait MigratorSuite extends munit.FunSuite {
       case _: ResourceNotFoundException =>
         // OK, the table was not existing or the waiter completed with the ResourceNotFoundException
         ()
+      case e: DynamoDbException if e.getMessage.contains("not authorized") =>
+        // The IAM role does not have dynamodb:DeleteTable permission, skip cleanup
+        System.err.println(s"Warning: not authorized to delete table ${name}, skipping")
       case any: Throwable =>
         fail(s"Failed to delete table ${name}", any)
     }

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/StreamedItemsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/StreamedItemsTest.scala
@@ -14,9 +14,9 @@ import scala.util.chaining.scalaUtilChainingOps
 
 class StreamedItemsTest extends MigratorSuiteWithAWS {
 
-  override val munitTimeout: Duration = 120.seconds
+  override val munitTimeout: Duration = 480.seconds
 
-  withTable("StreamedItemsTest").test("Stream changes") { tableName =>
+  withStreamingTable("StreamedItemsTest").test("Stream changes") { tableName =>
     val configFileName = "dynamodb-to-alternator-streaming.yaml"
 
     // Populate the source table
@@ -28,16 +28,19 @@ class StreamedItemsTest extends MigratorSuiteWithAWS {
     )
 
     // Perform the migration
-    val sparkLogs = new StringBuilder()
+    val sparkLogs =
+      new StringBuffer() // StringBuffer for thread safety (ProcessLogger callbacks come from separate threads)
     val sparkJob =
       submitSparkJobProcess(configFileName, "com.scylladb.migrator.Migrator")
         .run(ProcessLogger { log =>
-          sparkLogs ++= log
-//          println(log) // Uncomment to see the logs
+          sparkLogs.append(log).append('\n')
         })
 
-    awaitAtMost(60.seconds) {
-      assert(sparkLogs.toString().contains(s"Table ${tableName} created."))
+    awaitAtMost(180.seconds) {
+      assert(
+        sparkLogs.toString().contains(s"Table ${tableName} created."),
+        s"Spark job alive: ${sparkJob.isAlive()}. Last 2000 chars of logs:\n${sparkLogs.toString().takeRight(5000)}"
+      )
     }
     // Check that the table initial snapshot has been successfully migrated
     awaitAtMost(60.seconds) {
@@ -60,12 +63,15 @@ class StreamedItemsTest extends MigratorSuiteWithAWS {
       PutItemRequest.builder().tableName(tableName).item(item2Data.asJava).build()
     )
 
-    // Check that the added item has also been migrated
-    awaitAtMost(60.seconds) {
+    // Check that the added item has also been migrated (KCL startup can take a while)
+    awaitAtMost(180.seconds) {
       targetAlternator()
         .getItem(GetItemRequest.builder().tableName(tableName).key(keys2.asJava).build())
         .tap { itemResult =>
-          assert(itemResult.hasItem, "Second item not found in the target database")
+          assert(
+            itemResult.hasItem,
+            s"Second item not found in the target database. Spark job alive: ${sparkJob.isAlive()}. Last 5000 chars of logs:\n${sparkLogs.toString().takeRight(5000)}"
+          )
           assertEquals(
             itemResult.item.asScala.toMap,
             item2Data + ("_dynamo_op_type" -> AttributeValue.fromBool(true))
@@ -80,66 +86,73 @@ class StreamedItemsTest extends MigratorSuiteWithAWS {
     deleteStreamTable(tableName)
   }
 
-  withTable("StreamedItemsSkipSnapshotTest").test("Stream changes but skip initial snapshot") {
-    tableName =>
-      val configFileName = "dynamodb-to-alternator-streaming-skip-snapshot.yaml"
+  withStreamingTable("StreamedItemsSkipSnapshotTest").test(
+    "Stream changes but skip initial snapshot"
+  ) { tableName =>
+    val configFileName = "dynamodb-to-alternator-streaming-skip-snapshot.yaml"
 
-      // Populate the source table
-      val keys1 = Map("id" -> AttributeValue.fromS("12345"))
-      val attrs1 = Map("foo" -> AttributeValue.fromS("bar"))
-      val item1Data = keys1 ++ attrs1
-      sourceDDb().putItem(
-        PutItemRequest.builder().tableName(tableName).item(item1Data.asJava).build()
+    // Populate the source table
+    val keys1 = Map("id" -> AttributeValue.fromS("12345"))
+    val attrs1 = Map("foo" -> AttributeValue.fromS("bar"))
+    val item1Data = keys1 ++ attrs1
+    sourceDDb().putItem(
+      PutItemRequest.builder().tableName(tableName).item(item1Data.asJava).build()
+    )
+
+    // Perform the migration
+    val sparkLogs =
+      new StringBuffer() // StringBuffer for thread safety (ProcessLogger callbacks come from separate threads)
+    val sparkJob =
+      submitSparkJobProcess(configFileName, "com.scylladb.migrator.Migrator")
+        .run(ProcessLogger { (log: String) =>
+          sparkLogs.append(log).append('\n')
+        })
+
+    // Wait for the changes to start being streamed
+    awaitAtMost(180.seconds) {
+      assert(
+        sparkLogs.toString().contains("alternator: Starting to transfer changes"),
+        s"Spark job alive: ${sparkJob.isAlive()}. Last 2000 chars of logs:\n${sparkLogs.toString().takeRight(5000)}"
       )
+    }
 
-      // Perform the migration
-      val sparkLogs = new StringBuilder()
-      val sparkJob =
-        submitSparkJobProcess(configFileName, "com.scylladb.migrator.Migrator")
-          .run(ProcessLogger { (log: String) =>
-            sparkLogs ++= log
-//          println(log) // Uncomment to see the logs
-          })
+    // Insert one more item
+    val keys2 = Map("id" -> AttributeValue.fromS("67890"))
+    val attrs2 = Map(
+      "foo" -> AttributeValue.fromS("baz"),
+      "baz" -> AttributeValue.fromBool(false)
+    )
+    val item2Data = keys2 ++ attrs2
+    sourceDDb().putItem(
+      PutItemRequest.builder().tableName(tableName).item(item2Data.asJava).build()
+    )
 
-      // Wait for the changes to start being streamed
-      awaitAtMost(60.seconds) {
-        assert(sparkLogs.toString().contains("alternator: Starting to transfer changes"))
-      }
-
-      // Insert one more item
-      val keys2 = Map("id" -> AttributeValue.fromS("67890"))
-      val attrs2 = Map(
-        "foo" -> AttributeValue.fromS("baz"),
-        "baz" -> AttributeValue.fromBool(false)
-      )
-      val item2Data = keys2 ++ attrs2
-      sourceDDb().putItem(
-        PutItemRequest.builder().tableName(tableName).item(item2Data.asJava).build()
-      )
-
-      // Check that only the second item has been migrated
-      awaitAtMost(60.seconds) {
-        targetAlternator()
-          .getItem(GetItemRequest.builder().tableName(tableName).key(keys2.asJava).build())
-          .tap { itemResult =>
-            assert(itemResult.hasItem, "Second item not found in the target database")
-            assertEquals(
-              itemResult.item.asScala.toMap,
-              item2Data + ("_dynamo_op_type" -> AttributeValue.fromBool(true))
-            )
-          }
-      }
+    // Check that only the second item has been migrated (KCL startup can take a while)
+    awaitAtMost(180.seconds) {
       targetAlternator()
-        .getItem(GetItemRequest.builder().tableName(tableName).key(keys1.asJava).build())
+        .getItem(GetItemRequest.builder().tableName(tableName).key(keys2.asJava).build())
         .tap { itemResult =>
-          assert(!itemResult.hasItem, "First item found in the target database")
+          assert(
+            itemResult.hasItem,
+            s"Second item not found in the target database. Spark job alive: ${sparkJob.isAlive()}. Last 5000 chars of logs:\n${sparkLogs.toString().takeRight(5000)}"
+          )
+          assertEquals(
+            itemResult.item.asScala.toMap,
+            item2Data + ("_dynamo_op_type" -> AttributeValue.fromBool(true))
+          )
         }
+    }
+    targetAlternator()
+      .getItem(GetItemRequest.builder().tableName(tableName).key(keys1.asJava).build())
+      .tap { itemResult =>
+        assert(!itemResult.hasItem, "First item found in the target database")
+      }
 
-      // Stop the migration job
-      stopSparkJob(configFileName)
-      assertEquals(sparkJob.exitValue(), 143)
+    // Stop the migration job
+    stopSparkJob(configFileName)
+    assertEquals(sparkJob.exitValue(), 143)
 
-      deleteStreamTable(tableName)
+    deleteStreamTable(tableName)
   }
 
   /** Continuously evaluate the provided `assertion` until it terminates (MUnit models failures with


### PR DESCRIPTION
## Summary
- Fix AWS integration tests failing with OIDC credentials by generating credentials file from environment variables when `~/.aws/credentials` doesn't exist (already on master via 7ecd63c)
- Run AWS integration tests on pull requests, not just on pushes to master, so fixes can be verified before merging

## Notes
- The current CI failure (`dynamodb:DeleteTable` not authorized) is an **AWS IAM issue**: the `gh-scylla-migrator` role needs `dynamodb:DeleteTable` added to its policy
- The OIDC trust policy for the role may also need updating to allow `pull_request` event subjects (format: `repo:scylladb/scylla-migrator:pull_request`)

## Test plan
- [ ] Add `dynamodb:DeleteTable` to the IAM policy for the `gh-scylla-migrator` role
- [ ] Verify the AWS trust policy allows OIDC subject for `pull_request` events
- [ ] Confirm AWS integration tests pass on this PR