### PR TITLE
Add defaultTTL option relative to cell write timestamps

### DIFF
--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/ExplodeRowBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/ExplodeRowBenchmark.scala
@@ -33,7 +33,8 @@ class ExplodeRowBenchmark {
       singleTimestampRow,
       BenchmarkFixtures.timestampSchema,
       BenchmarkFixtures.primaryKeyOrdinals,
-      BenchmarkFixtures.regularKeyOrdinals
+      BenchmarkFixtures.regularKeyOrdinals,
+      ttlConfig = None
     )
 
   @Benchmark
@@ -42,7 +43,8 @@ class ExplodeRowBenchmark {
       multiTimestampRow,
       BenchmarkFixtures.timestampSchema,
       BenchmarkFixtures.primaryKeyOrdinals,
-      BenchmarkFixtures.regularKeyOrdinals
+      BenchmarkFixtures.regularKeyOrdinals,
+      ttlConfig = None
     )
 
   @Benchmark
@@ -51,7 +53,8 @@ class ExplodeRowBenchmark {
       BenchmarkFixtures.makeSimpleRow(1),
       BenchmarkFixtures.simpleSchema,
       BenchmarkFixtures.primaryKeyOrdinals,
-      regularKeyOrdinals = Map.empty
+      regularKeyOrdinals = Map.empty,
+      ttlConfig          = None
     )
 
   @Benchmark
@@ -60,7 +63,8 @@ class ExplodeRowBenchmark {
       wideSingleTimestampRow,
       BenchmarkFixtures.wideTimestampSchema,
       BenchmarkFixtures.widePrimaryKeyOrdinals,
-      BenchmarkFixtures.wideRegularKeyOrdinals
+      BenchmarkFixtures.wideRegularKeyOrdinals,
+      ttlConfig = None
     )
 
   @Benchmark
@@ -69,6 +73,7 @@ class ExplodeRowBenchmark {
       wideMultiTimestampRow,
       BenchmarkFixtures.wideTimestampSchema,
       BenchmarkFixtures.widePrimaryKeyOrdinals,
-      BenchmarkFixtures.wideRegularKeyOrdinals
+      BenchmarkFixtures.wideRegularKeyOrdinals,
+      ttlConfig = None
     )
 }

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -194,6 +194,14 @@ target:
   #writeTTLInS: 7776000
   # writetime in microseconds (sample 1640998861000 is Saturday, January 1, 2022 2:01:01 AM GMT+01:00 )
   #writeWritetimestampInuS: 1640998861000
+  # Optional TTL (in seconds) applied relative to each cell's write timestamp.
+  # Requires source preserveTimestamps: true. Only use when migrating into an empty target table.
+  # Accepts a plain number (defaults to set-if-missing policy) or "value:policy":
+  #   ttl: 7776000                       # apply only to cells without a TTL (set-if-missing)
+  #   ttl: "7776000:set-if-missing"      # same as above, explicit
+  #   ttl: "7776000:always"              # apply to all cells, overriding source TTL
+  #   ttl: "7776000:update-if-present"   # apply only to cells that already have a TTL
+  #ttl: 7776000
 
 # Example for loading into a DynamoDB target (for example, Scylla's Alternator):
 # target:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -270,6 +270,13 @@ Apache Cassandra Target
     writeTTLInS: 7776000
     # Optional - writetime in microseconds (sample 1640998861000 is Saturday, January 1, 2022 2:01:01 AM GMT+01:00 )
     writeWritetimestampInuS: 1640998861000
+    # Optional TTL (in seconds) applied relative to each cell's write timestamp.
+    # Requires source preserveTimestamps: true. Only use when migrating into an empty target table.
+    # Accepts a plain number (defaults to set-if-missing) or "value:policy":
+    #   ttl: 7776000                       # apply only to cells without a TTL
+    #   ttl: "7776000:always"              # apply to all cells, overriding source TTL
+    #   ttl: "7776000:update-if-present"   # apply only to cells that already have a TTL
+    # ttl: 7776000
     # Optional - SSL as per https://github.com/scylladb/spark-cassandra-connector/blob/master/doc/reference.md#cassandra-ssl-connection-options
     sslOptions:
       clientAuthEnabled: false

--- a/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
@@ -38,7 +38,8 @@ object Migrator {
             spark,
             cqlSource,
             cqlSource.preserveTimestamps,
-            migratorConfig.getSkipTokenRangesOrEmptySet
+            migratorConfig.getSkipTokenRangesOrEmptySet,
+            ttlConfig = scyllaTarget.ttl
           )
           ScyllaMigrator.migrate(migratorConfig, scyllaTarget, sourceDF)
         case (parquetSource: SourceSettings.Parquet, scyllaTarget: TargetSettings.Scylla) =>

--- a/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
@@ -54,10 +54,32 @@ object MigratorConfig {
   def loadFrom(path: String): MigratorConfig = {
     val configData = scala.io.Source.fromFile(path).mkString
 
-    parser
+    val config = parser
       .parse(configData)
       .leftWiden[Error]
       .flatMap(_.as[MigratorConfig])
       .valueOr(throw _)
+
+    validate(config)
+    config
   }
+
+  private def validate(config: MigratorConfig): Unit =
+    config.target match {
+      case scylla: TargetSettings.Scylla =>
+        scylla.ttl.foreach { _ =>
+          config.source match {
+            case cassandra: SourceSettings.Cassandra =>
+              require(
+                cassandra.preserveTimestamps,
+                "ttl requires preserveTimestamps to be true"
+              )
+            case _ =>
+              throw new IllegalArgumentException(
+                "ttl is only supported with Cassandra/Scylla sources"
+              )
+          }
+        }
+      case _ =>
+    }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/TTLConfig.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/TTLConfig.scala
@@ -1,0 +1,113 @@
+package com.scylladb.migrator.config
+
+import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
+
+/** TTL configuration for the target Scylla table.
+  *
+  * Parsed from a single YAML field that accepts either a plain number or a `"value:policy"` string:
+  *   - `7776000` — equivalent to `"7776000:set-if-missing"`
+  *   - `"7776000:set-if-missing"` — apply TTL only to cells that have no TTL on the source
+  *   - `"7776000:always"` — apply TTL to all cells, overriding any existing source TTL
+  *   - `"7776000:update-if-present"` — apply TTL only to cells that already have a TTL on the
+  *     source
+  */
+case class TTLConfig(value: Long, policy: TTLPolicy)
+
+sealed trait TTLPolicy
+object TTLPolicy {
+  case object SetIfMissing extends TTLPolicy
+  case object Always extends TTLPolicy
+  case object UpdateIfPresent extends TTLPolicy
+
+  def fromString(s: String): Either[String, TTLPolicy] =
+    s match {
+      case "set-if-missing"    => Right(SetIfMissing)
+      case "always"            => Right(Always)
+      case "update-if-present" => Right(UpdateIfPresent)
+      case other =>
+        Left(
+          s"Unknown TTL policy: '$other'. Valid values: set-if-missing, always, update-if-present"
+        )
+    }
+}
+
+object TTLConfig {
+
+  private def validateValue(
+    value: Long
+  ): Either[String, Long] =
+    if (value <= 0)
+      Left(s"ttl value must be positive, got: $value")
+    else if (value > Int.MaxValue)
+      Left(
+        s"ttl value must not exceed ${Int.MaxValue} (Cassandra TTL is a 32-bit integer), got: $value"
+      )
+    else
+      Right(value)
+
+  implicit val decoder: Decoder[TTLConfig] = Decoder.instance { cursor =>
+    // Try as a number first (plain value, defaults to set-if-missing)
+    cursor.as[Long] match {
+      case Right(value) =>
+        validateValue(value).left
+          .map(msg => DecodingFailure(msg, cursor.history))
+          .map(v => TTLConfig(v, TTLPolicy.SetIfMissing))
+      case Left(_) =>
+        // Try as a string "value:policy"
+        cursor.as[String].flatMap { str =>
+          str.split(":", 2) match {
+            case Array(valueStr, policyStr) =>
+              for {
+                value <- valueStr.trim.toLongOption
+                           .toRight(
+                             DecodingFailure(
+                               s"Invalid ttl value: '$valueStr'. Expected a number",
+                               cursor.history
+                             )
+                           )
+                _ <- validateValue(value).left
+                       .map(msg => DecodingFailure(msg, cursor.history))
+                policy <- TTLPolicy
+                            .fromString(policyStr.trim)
+                            .left
+                            .map(msg => DecodingFailure(msg, cursor.history))
+              } yield TTLConfig(value, policy)
+            case Array(valueStr) =>
+              // Plain number as a string, defaults to set-if-missing
+              for {
+                value <- valueStr.trim.toLongOption
+                           .toRight(
+                             DecodingFailure(
+                               s"Invalid ttl format: '$str'. Expected a number or 'value:policy'",
+                               cursor.history
+                             )
+                           )
+                _ <- validateValue(value).left
+                       .map(msg => DecodingFailure(msg, cursor.history))
+              } yield TTLConfig(value, TTLPolicy.SetIfMissing)
+            case _ =>
+              Left(
+                DecodingFailure(
+                  s"Invalid ttl format: '$str'. Expected a number or 'value:policy'",
+                  cursor.history
+                )
+              )
+          }
+        }
+    }
+  }
+
+  implicit val encoder: Encoder[TTLConfig] = Encoder.instance { config =>
+    config.policy match {
+      case TTLPolicy.SetIfMissing => Json.fromLong(config.value)
+      case _ => Json.fromString(s"${config.value}:${policyToString(config.policy)}")
+    }
+  }
+
+  private def policyToString(policy: TTLPolicy): String =
+    policy match {
+      case TTLPolicy.SetIfMissing    => "set-if-missing"
+      case TTLPolicy.Always          => "always"
+      case TTLPolicy.UpdateIfPresent => "update-if-present"
+    }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
@@ -23,7 +23,8 @@ object TargetSettings {
     writeTTLInS: Option[Int],
     writeWritetimestampInuS: Option[Long],
     consistencyLevel: String,
-    dropNullPrimaryKeys: Option[Boolean] = None
+    dropNullPrimaryKeys: Option[Boolean] = None,
+    ttl: Option[TTLConfig] = None
   ) extends TargetSettings
 
   case class DynamoDB(

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -6,7 +6,7 @@ import com.datastax.spark.connector.rdd.ReadConf
 import com.datastax.spark.connector.rdd.partitioner.dht.Token
 import com.datastax.spark.connector.types.CassandraOption
 import com.scylladb.migrator.Connectors
-import com.scylladb.migrator.config.{ CopyType, SourceSettings }
+import com.scylladb.migrator.config.{ CopyType, SourceSettings, TTLConfig, TTLPolicy }
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.cassandra.{ CassandraSQLRow, DataTypeConverter }
@@ -101,25 +101,80 @@ object Cassandra {
         Selection(columnRefs, origSchema, None)
     }
 
+  /** Compute the effective TTL for a cell based on the TTL policy.
+    *
+    * @param ttl
+    *   existing TTL on the source cell (None if not set)
+    * @param writetime
+    *   writetime of the cell in microseconds
+    * @param ttlConfig
+    *   TTL configuration (value and policy), or None to preserve source TTL as-is
+    * @param nowMillis
+    *   current time in milliseconds (for testing)
+    */
+  def computeEffectiveTTL(
+    ttl: Option[Int],
+    writetime: Option[Long],
+    ttlConfig: Option[TTLConfig],
+    nowMillis: Long = System.currentTimeMillis()
+  ): Long =
+    ttlConfig match {
+      case None => ttl.map(_.toLong).getOrElse(0L)
+      case Some(config) =>
+        config.policy match {
+          case TTLPolicy.SetIfMissing =>
+            ttl match {
+              case Some(existingTTL) => existingTTL.toLong
+              case None              => computeTTLFromWritetime(config.value, writetime, nowMillis)
+            }
+          case TTLPolicy.Always =>
+            computeTTLFromWritetime(config.value, writetime, nowMillis)
+          case TTLPolicy.UpdateIfPresent =>
+            ttl match {
+              case Some(_) => computeTTLFromWritetime(config.value, writetime, nowMillis)
+              case None    => 0L
+            }
+        }
+    }
+
+  private def computeTTLFromWritetime(
+    ttlValue: Long,
+    writetime: Option[Long],
+    nowMillis: Long
+  ): Long =
+    writetime match {
+      case Some(writetimeMicros) =>
+        val ageSeconds = (nowMillis - writetimeMicros / 1000) / 1000
+        val computed = ttlValue - ageSeconds
+        if (computed > 0) computed else 1L
+      case None => 0L
+    }
+
   def explodeRow(
     row: Row,
     schema: StructType,
     primaryKeyOrdinals: Map[String, Int],
-    regularKeyOrdinals: Map[String, (Int, Int, Int)]
+    regularKeyOrdinals: Map[String, (Int, Int, Int)],
+    ttlConfig: Option[TTLConfig]
   ) =
     if (regularKeyOrdinals.isEmpty) List(row)
     else {
       val rowTimestampsToFields =
         regularKeyOrdinals
           .map { case (fieldName, (ordinal, ttlOrdinal, writetimeOrdinal)) =>
+            val ttl =
+              if (row.isNullAt(ttlOrdinal)) None
+              else Some(row.getInt(ttlOrdinal))
+            val writetime =
+              if (row.isNullAt(writetimeOrdinal)) None
+              else Some(row.getLong(writetimeOrdinal))
+            val effectiveTTL = computeEffectiveTTL(ttl, writetime, ttlConfig)
             (
               fieldName,
               if (row.isNullAt(ordinal)) CassandraOption.Null
               else CassandraOption.Value(row.get(ordinal)),
-              if (row.isNullAt(ttlOrdinal)) None
-              else Some(row.getInt(ttlOrdinal)),
-              if (row.isNullAt(writetimeOrdinal)) None
-              else Some(row.getLong(writetimeOrdinal))
+              if (effectiveTTL == 0L) None else Some(effectiveTTL),
+              writetime
             )
           }
           .groupBy { case (fieldName, value, ttl, writetime) =>
@@ -206,7 +261,8 @@ object Cassandra {
     df: DataFrame,
     timestampColumns: Option[TimestampColumns],
     origSchema: StructType,
-    tableDef: TableDef
+    tableDef: TableDef,
+    ttlConfig: Option[TTLConfig]
   ): DataFrame =
     timestampColumns match {
       case None => df
@@ -216,6 +272,10 @@ object Cassandra {
           origSchema.fields.map(_.name).toList,
           tableDef
         )
+
+        ttlConfig.foreach { config =>
+          log.info(s"Applying TTL of ${config.value}s with policy ${config.policy}")
+        }
 
         val broadcastPrimaryKeyOrdinals = spark.sparkContext.broadcast(primaryKeyOrdinals)
         val broadcastRegularKeyOrdinals = spark.sparkContext.broadcast(regularKeyOrdinals)
@@ -233,7 +293,8 @@ object Cassandra {
             _,
             broadcastSchema.value,
             broadcastPrimaryKeyOrdinals.value,
-            broadcastRegularKeyOrdinals.value
+            broadcastRegularKeyOrdinals.value,
+            ttlConfig
           )
         }(Encoders.row(finalSchema))
 
@@ -281,7 +342,8 @@ object Cassandra {
     */
   def explodeDataframeFromPerColumnMeta(
     spark: SparkSession,
-    df: DataFrame
+    df: DataFrame,
+    ttlConfig: Option[TTLConfig] = None
   ): (DataFrame, TimestampColumns) = {
     val (primaryKeyOrdinals, regularKeyOrdinals) = indexFieldsFromSchema(df.schema)
 
@@ -307,7 +369,8 @@ object Cassandra {
         _,
         broadcastSchema.value,
         broadcastPrimaryKeyOrdinals.value,
-        broadcastRegularKeyOrdinals.value
+        broadcastRegularKeyOrdinals.value,
+        ttlConfig
       )
     }(Encoders.row(finalSchema))
 
@@ -324,7 +387,8 @@ object Cassandra {
     source: SourceSettings.Cassandra,
     preserveTimes: Boolean,
     tokenRangesToSkip: Set[(Token[_], Token[_])],
-    skipExplosion: Boolean = false
+    skipExplosion: Boolean = false,
+    ttlConfig: Option[TTLConfig] = None
   ): SourceDataFrame = {
     val connector = Connectors.sourceConnector(spark.sparkContext.getConf, source)
     val consistencyLevel = source.consistencyLevel match {
@@ -394,7 +458,8 @@ object Cassandra {
         rawDataframe,
         selection.timestampColumns,
         origSchema,
-        tableDef
+        tableDef,
+        ttlConfig
       )
       SourceDataFrame(resultingDataframe, selection.timestampColumns, true)
     }

--- a/tests/src/test/scala/com/scylladb/migrator/config/TTLConfigTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/TTLConfigTest.scala
@@ -1,0 +1,87 @@
+package com.scylladb.migrator.config
+
+import io.circe.Json
+import io.circe.syntax._
+
+class TTLConfigTest extends munit.FunSuite {
+
+  test("decode plain number defaults to set-if-missing") {
+    val result = Json.fromLong(7776000L).as[TTLConfig]
+    assertEquals(result, Right(TTLConfig(7776000L, TTLPolicy.SetIfMissing)))
+  }
+
+  test("decode string with set-if-missing policy") {
+    val result = Json.fromString("7776000:set-if-missing").as[TTLConfig]
+    assertEquals(result, Right(TTLConfig(7776000L, TTLPolicy.SetIfMissing)))
+  }
+
+  test("decode string with always policy") {
+    val result = Json.fromString("3600:always").as[TTLConfig]
+    assertEquals(result, Right(TTLConfig(3600L, TTLPolicy.Always)))
+  }
+
+  test("decode string with update-if-present policy") {
+    val result = Json.fromString("86400:update-if-present").as[TTLConfig]
+    assertEquals(result, Right(TTLConfig(86400L, TTLPolicy.UpdateIfPresent)))
+  }
+
+  test("decode rejects negative value") {
+    val result = Json.fromLong(-1L).as[TTLConfig]
+    assert(result.isLeft)
+    assert(result.left.exists(_.message.contains("must be positive")))
+  }
+
+  test("decode rejects zero value") {
+    val result = Json.fromLong(0L).as[TTLConfig]
+    assert(result.isLeft)
+    assert(result.left.exists(_.message.contains("must be positive")))
+  }
+
+  test("decode rejects value exceeding Int.MaxValue") {
+    val result = Json.fromLong(Int.MaxValue.toLong + 1).as[TTLConfig]
+    assert(result.isLeft)
+    assert(result.left.exists(_.message.contains("must not exceed")))
+  }
+
+  test("decode rejects unknown policy") {
+    val result = Json.fromString("3600:bogus").as[TTLConfig]
+    assert(result.isLeft)
+    assert(result.left.exists(_.message.contains("Unknown TTL policy")))
+  }
+
+  test("decode rejects non-numeric value in string") {
+    val result = Json.fromString("abc:always").as[TTLConfig]
+    assert(result.isLeft)
+    assert(result.left.exists(_.message.contains("Invalid ttl value")))
+  }
+
+  test("decode plain number as string defaults to set-if-missing") {
+    val result = Json.fromString("3600").as[TTLConfig]
+    assertEquals(result, Right(TTLConfig(3600L, TTLPolicy.SetIfMissing)))
+  }
+
+  test("decode rejects non-numeric string without colon") {
+    val result = Json.fromString("bogus").as[TTLConfig]
+    assert(result.isLeft)
+  }
+
+  test("encode set-if-missing as plain number") {
+    val json = TTLConfig(7776000L, TTLPolicy.SetIfMissing).asJson
+    assertEquals(json, Json.fromLong(7776000L))
+  }
+
+  test("encode always as string") {
+    val json = TTLConfig(3600L, TTLPolicy.Always).asJson
+    assertEquals(json, Json.fromString("3600:always"))
+  }
+
+  test("encode update-if-present as string") {
+    val json = TTLConfig(86400L, TTLPolicy.UpdateIfPresent).asJson
+    assertEquals(json, Json.fromString("86400:update-if-present"))
+  }
+
+  test("decode handles spaces around value and policy") {
+    val result = Json.fromString(" 3600 : always ").as[TTLConfig]
+    assertEquals(result, Right(TTLConfig(3600L, TTLPolicy.Always)))
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/readers/ComputeEffectiveTTLTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/ComputeEffectiveTTLTest.scala
@@ -1,0 +1,174 @@
+package com.scylladb.migrator.readers
+
+import com.scylladb.migrator.config.{ TTLConfig, TTLPolicy }
+
+class ComputeEffectiveTTLTest extends munit.FunSuite {
+
+  val nowMillis: Long = 1700000000000L
+
+  // --- set-if-missing policy (default) ---
+
+  test("set-if-missing: existing TTL is preserved") {
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = Some(500),
+      writetime = Some(nowMillis * 1000),
+      ttlConfig = Some(TTLConfig(3600, TTLPolicy.SetIfMissing)),
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 500L)
+  }
+
+  test("set-if-missing: no TTL computes relative TTL") {
+    val writetimeMicros = (nowMillis - 100 * 1000) * 1000
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = None,
+      writetime = Some(writetimeMicros),
+      ttlConfig = Some(TTLConfig(3600, TTLPolicy.SetIfMissing)),
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 3500L)
+  }
+
+  test("set-if-missing: expired record gets TTL of 1 second") {
+    val writetimeMicros = (nowMillis - 7200 * 1000) * 1000
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = None,
+      writetime = Some(writetimeMicros),
+      ttlConfig = Some(TTLConfig(3600, TTLPolicy.SetIfMissing)),
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 1L)
+  }
+
+  test("set-if-missing: no TTL and no writetime returns 0") {
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = None,
+      writetime = None,
+      ttlConfig = Some(TTLConfig(3600, TTLPolicy.SetIfMissing)),
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 0L)
+  }
+
+  test("set-if-missing: existing TTL of 0 is preserved") {
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = Some(0),
+      writetime = Some(nowMillis * 1000),
+      ttlConfig = Some(TTLConfig(3600, TTLPolicy.SetIfMissing)),
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 0L)
+  }
+
+  test("set-if-missing: record written just now gets full TTL") {
+    val writetimeMicros = nowMillis * 1000
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = None,
+      writetime = Some(writetimeMicros),
+      ttlConfig = Some(TTLConfig(86400, TTLPolicy.SetIfMissing)),
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 86400L)
+  }
+
+  test("set-if-missing: record at expiry boundary gets TTL of 1") {
+    val writetimeMicros = (nowMillis - 3600 * 1000) * 1000
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = None,
+      writetime = Some(writetimeMicros),
+      ttlConfig = Some(TTLConfig(3600, TTLPolicy.SetIfMissing)),
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 1L)
+  }
+
+  // --- always policy ---
+
+  test("always: overrides existing TTL") {
+    val writetimeMicros = (nowMillis - 100 * 1000) * 1000
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = Some(500),
+      writetime = Some(writetimeMicros),
+      ttlConfig = Some(TTLConfig(3600, TTLPolicy.Always)),
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 3500L)
+  }
+
+  test("always: applies to cells without TTL") {
+    val writetimeMicros = (nowMillis - 100 * 1000) * 1000
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = None,
+      writetime = Some(writetimeMicros),
+      ttlConfig = Some(TTLConfig(3600, TTLPolicy.Always)),
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 3500L)
+  }
+
+  test("always: no writetime returns 0") {
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = Some(500),
+      writetime = None,
+      ttlConfig = Some(TTLConfig(3600, TTLPolicy.Always)),
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 0L)
+  }
+
+  // --- update-if-present policy ---
+
+  test("update-if-present: recomputes when source has TTL") {
+    val writetimeMicros = (nowMillis - 100 * 1000) * 1000
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = Some(500),
+      writetime = Some(writetimeMicros),
+      ttlConfig = Some(TTLConfig(3600, TTLPolicy.UpdateIfPresent)),
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 3500L)
+  }
+
+  test("update-if-present: skips cells without TTL") {
+    val writetimeMicros = (nowMillis - 100 * 1000) * 1000
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = None,
+      writetime = Some(writetimeMicros),
+      ttlConfig = Some(TTLConfig(3600, TTLPolicy.UpdateIfPresent)),
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 0L)
+  }
+
+  test("update-if-present: no writetime returns 0 even with source TTL") {
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = Some(500),
+      writetime = None,
+      ttlConfig = Some(TTLConfig(3600, TTLPolicy.UpdateIfPresent)),
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 0L)
+  }
+
+  // --- no config ---
+
+  test("no config: preserves existing TTL") {
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = Some(500),
+      writetime = Some(nowMillis * 1000),
+      ttlConfig = None,
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 500L)
+  }
+
+  test("no config: no TTL returns 0") {
+    val result = Cassandra.computeEffectiveTTL(
+      ttl       = None,
+      writetime = Some(nowMillis * 1000),
+      ttlConfig = None,
+      nowMillis = nowMillis
+    )
+    assertEquals(result, 0L)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `defaultTTL` config option for Cassandra/Scylla sources that computes an effective TTL relative to each cell's write timestamp (`defaultTTL - age`), so data expires at the correct absolute time in the target
- Validates at config load time: must be non-negative, fit in 32 bits, require `preserveTimestamps: true`, and a Scylla target
- Includes deterministic unit tests for `computeEffectiveTTL` with injectable clock

## Test plan
- [x] `ComputeEffectiveTTLTest` — 8 unit tests covering: existing TTL preserved, no TTL/no default returns 0, relative TTL computation, expired records get TTL=1, missing writetime returns 0, boundary cases
- [x] Manual test with a Cassandra source table containing cells with and without TTLs
- [x] Verify config rejects negative `defaultTTL`, values > `Int.MaxValue`, non-Scylla targets, and `preserveTimestamps: false`