### PR TITLE
Add Aerospike as a new migration source

### DIFF
--- a/.github/actions/spark-image-cache/action.yml
+++ b/.github/actions/spark-image-cache/action.yml
@@ -1,0 +1,21 @@
+name: Spark Image Cache
+description: Restore and load cached Spark Docker image
+
+outputs:
+  cache-hit:
+    description: Whether the Spark image cache was hit
+    value: ${{ steps.spark-cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Restore Spark Docker image cache
+      id: spark-cache
+      uses: actions/cache@v4
+      with:
+        path: /tmp/spark-image.tar
+        key: spark-image-${{ hashFiles('dockerfiles/spark/**') }}
+    - name: Load cached Spark image
+      if: steps.spark-cache.outputs.cache-hit == 'true'
+      run: docker load < /tmp/spark-image.tar
+      shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,9 @@ on:
       - 'dockerfiles/**'
       - 'docker-compose-tests.yml'
       - '.github/workflows/**'
+      - 'tests/configurations/**'
+      - 'tests/docker/**'
+      - 'config*.yaml.example'
 
   pull_request:
     paths:
@@ -21,11 +24,15 @@ on:
       - 'dockerfiles/**'
       - 'docker-compose-tests.yml'
       - '.github/workflows/**'
+      - 'tests/configurations/**'
+      - 'tests/docker/**'
+      - 'config*.yaml.example'
 
 jobs:
   lint:
     name: Check formatting
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -44,6 +51,7 @@ jobs:
   test-unit:
     name: Unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -71,6 +79,7 @@ jobs:
     name: Integration tests (Scylla)
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -79,15 +88,8 @@ jobs:
           java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - name: Restore Spark Docker image cache
+      - uses: ./.github/actions/spark-image-cache
         id: spark-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/spark-image.tar
-          key: spark-image-${{ hashFiles('dockerfiles/spark/**') }}
-      - name: Load cached Spark image
-        if: steps.spark-cache.outputs.cache-hit == 'true'
-        run: docker load < /tmp/spark-image.tar
       - name: Pre-create JAR directory and start services
         run: |
           mkdir -p migrator/target/scala-2.13
@@ -112,6 +114,9 @@ jobs:
       - name: Run E2E sanity tests (Scylla only)
         if: success()
         run: make test-benchmark-e2e-sanity-scylla
+      - name: Dump container logs on test failure
+        if: failure()
+        run: make dump-logs
       - name: Stop services
         if: always()
         run: make stop-services
@@ -131,6 +136,7 @@ jobs:
     name: Integration tests (Alternator)
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -139,15 +145,8 @@ jobs:
           java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - name: Restore Spark Docker image cache
+      - uses: ./.github/actions/spark-image-cache
         id: spark-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/spark-image.tar
-          key: spark-image-${{ hashFiles('dockerfiles/spark/**') }}
-      - name: Load cached Spark image
-        if: steps.spark-cache.outputs.cache-hit == 'true'
-        run: docker load < /tmp/spark-image.tar
       - name: Pre-create JAR directory and start services
         run: |
           mkdir -p migrator/target/scala-2.13
@@ -169,7 +168,11 @@ jobs:
         run: make test-integration-alternator
         env:
           COVERAGE: ${{ github.event_name == 'push' && 'true' || 'false' }}
+      - name: Dump container logs on test failure
+        if: failure()
+        run: make dump-logs
       - name: Stop services
+        if: always()
         run: make stop-services
       - name: Save Spark image to cache
         if: steps.spark-cache.outputs.cache-hit != 'true'
@@ -183,10 +186,123 @@ jobs:
             tests/target/scala-2.13/scoverage-report/
             migrator/target/scala-2.13/scoverage-report/
 
+  test-integration-aerospike:
+    name: Integration tests (Aerospike)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+      - name: Cache Coursier and SBT compilation
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            tests/target
+          key: sbt-aerospike-${{ hashFiles('build.sbt', 'project/**') }}
+          restore-keys: |
+            sbt-aerospike-
+      - uses: ./.github/actions/spark-image-cache
+        id: spark-cache
+      - name: Pre-create JAR directory and start services
+        run: |
+          mkdir -p migrator/target/scala-2.13
+          make start-services-aerospike
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Download assembly JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: migrator-jar
+          path: migrator/target/scala-2.13/
+      - name: Wait for services
+        run: make wait-for-services-aerospike
+      - name: Dump container logs on failure
+        if: failure()
+        run: make dump-logs
+      - name: Run Aerospike integration tests
+        run: make test-integration-aerospike
+        env:
+          COVERAGE: ${{ github.event_name == 'push' && 'true' || 'false' }}
+      - name: Run E2E sanity tests (Aerospike)
+        if: success()
+        run: make test-benchmark-e2e-sanity-aerospike
+      - name: Dump container logs on test failure
+        if: failure()
+        run: make dump-logs
+      - name: Stop services
+        if: always()
+        run: make stop-services
+      - name: Save Spark image to cache
+        if: steps.spark-cache.outputs.cache-hit != 'true'
+        run: docker save spark-migrator -o /tmp/spark-image.tar
+      - name: Upload coverage report
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-aerospike
+          path: |
+            tests/target/scala-2.13/scoverage-report/
+            migrator/target/scala-2.13/scoverage-report/
+
+  test-aerospike-compat:
+    name: Aerospike 6.x compat
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+      - uses: ./.github/actions/spark-image-cache
+        id: spark-cache
+      - name: Pre-create JAR directory and start services
+        run: |
+          mkdir -p migrator/target/scala-2.13
+          make start-services-aerospike-compat AEROSPIKE_VERSION=6
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Download assembly JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: migrator-jar
+          path: migrator/target/scala-2.13/
+      - name: Wait for services
+        run: make wait-for-services-aerospike-compat AEROSPIKE_VERSION=6
+      - name: Dump container logs on failure
+        if: failure()
+        run: make dump-logs
+      - name: Run Aerospike 6.x integration tests
+        run: make test-integration-aerospike-compat AEROSPIKE_VERSION=6
+        env:
+          AEROSPIKE_PORT: 3001
+      - name: Dump container logs on test failure
+        if: failure()
+        run: make dump-logs
+      - name: Stop services
+        if: always()
+        run: make stop-services
+      - name: Save Spark image to cache
+        if: steps.spark-cache.outputs.cache-hit != 'true'
+        run: docker save spark-migrator -o /tmp/spark-image.tar
+
   test-cassandra-compat:
     name: Cassandra ${{ matrix.version }}.x compat
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -199,15 +315,8 @@ jobs:
           java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - name: Restore Spark Docker image cache
+      - uses: ./.github/actions/spark-image-cache
         id: spark-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/spark-image.tar
-          key: spark-image-${{ hashFiles('dockerfiles/spark/**') }}
-      - name: Load cached Spark image
-        if: steps.spark-cache.outputs.cache-hit == 'true'
-        run: docker load < /tmp/spark-image.tar
       - name: Pre-create JAR directory and start services
         run: |
           mkdir -p migrator/target/scala-2.13
@@ -227,6 +336,9 @@ jobs:
         run: make dump-logs
       - name: Run Cassandra ${{ matrix.version }}.x integration tests
         run: make test-integration-cassandra CASSANDRA_VERSION=${{ matrix.version }}
+      - name: Dump container logs on test failure
+        if: failure()
+        run: make dump-logs
       - name: Stop services
         if: always()
         run: make stop-services

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Tests are implemented in the `tests` sbt submodule. They simulate the submission
 
 ### Prerequisites
 
+- **JDK 17+** is required (the Aerospike reader uses `java.util.HexFormat`, a JDK 17 API).
+
 Build the migrator fat-jar (re-build every time you change the implementation):
 
 ~~~ sh
@@ -58,6 +60,11 @@ Tests are organized into categories using JUnit `@Category` annotations. The Mak
 
    # AWS tests (requires `aws configure` first)
    AWS_REGION=us-east-1 make test-integration-aws
+
+   # Aerospike integration tests only
+   make start-services-aerospike
+   make wait-for-services-aerospike
+   make test-integration-aerospike
    ~~~
 
 3. Stop the Docker containers:
@@ -82,6 +89,7 @@ E2E benchmarks exercise every supported migration path end-to-end: seed data int
 | `test-benchmark-e2e-cassandra-parquet` | Cassandra | Parquet files |
 | `test-benchmark-e2e-dynamodb-s3export` | DynamoDB | S3 Export format |
 | `test-benchmark-e2e-s3export-alternator` | S3 Export | Alternator |
+| `test-benchmark-e2e-aerospike-scylla` | Aerospike | ScyllaDB |
 
 **Dependencies:** `parquet-scylla` requires `scylla-parquet` to run first (produces the Parquet files), and `s3export-alternator` requires `dynamodb-s3export`. The Makefile encodes these as target dependencies.
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@ SHELL := bash
         start-services-scylla wait-for-services-scylla \
         start-services-cassandra wait-for-services-cassandra test-integration-cassandra \
         start-services-alternator wait-for-services-alternator \
+        start-services-aerospike wait-for-services-aerospike \
         test test-unit test-integration test-integration-scylla \
         test-integration-alternator \
+        test-integration-aerospike \
         test-integration-aws \
         test-benchmark test-benchmark-jmh test-benchmark-jmh-quick \
         test-benchmark-e2e test-benchmark-e2e-sanity test-benchmark-e2e-sanity-scylla \
@@ -16,6 +18,8 @@ SHELL := bash
         test-benchmark-e2e-scylla-parquet test-benchmark-e2e-parquet-scylla \
         test-benchmark-e2e-cassandra-parquet \
         test-benchmark-e2e-dynamodb-s3export test-benchmark-e2e-s3export-alternator \
+        test-benchmark-e2e-aerospike-scylla \
+        test-benchmark-e2e-sanity-aerospike \
         dump-logs
 
 COMPOSE_FILE := docker-compose-tests.yml
@@ -25,6 +29,7 @@ COVERAGE ?= false
 VERBOSE ?= false
 E2E_CQL_ROWS ?= 5000000
 E2E_DDB_ROWS ?= 500000
+E2E_AEROSPIKE_ROWS ?= 5000000
 
 ifeq ($(COVERAGE),true)
 SBT_COVERAGE_PREFIX := coverage
@@ -99,12 +104,12 @@ spark-image: ## Pull or build the Spark Docker image
 	else
 		echo "Cache miss — building from dockerfiles/spark"
 		docker build -t "$${IMAGE}" dockerfiles/spark
-		if [ -n "$${DOCKERHUB_USERNAME:-}" ] && [ -n "$${DOCKERHUB_TOKEN:-}" ]; then
+		if [ -n "$${GITHUB_ACTIONS:-}" ] && [ -n "$${DOCKERHUB_USERNAME:-}" ] && [ -n "$${DOCKERHUB_TOKEN:-}" ]; then
 			echo "$${DOCKERHUB_TOKEN}" | docker login -u "$${DOCKERHUB_USERNAME}" --password-stdin
 			docker push "$${IMAGE}"
 			echo "Pushed $${IMAGE} to cache"
 		else
-			echo "No Docker Hub credentials — skipping push"
+			echo "Not in CI or no Docker Hub credentials — skipping push"
 		fi
 	fi
 	docker tag "$${IMAGE}" spark-migrator
@@ -112,28 +117,35 @@ spark-image: ## Pull or build the Spark Docker image
 
 start-services: spark-image ## Start all Docker Compose test services
 	$(Q)mkdir -p $(DOCKER_SPARK_BIND_DIRS) $(DOCKER_SCYLLA_BIND_DIRS)
-	$(Q)sudo chmod -R 777 $(DOCKER_SPARK_BIND_DIRS) $(DOCKER_SCYLLA_BIND_DIRS)
+	$(Q)sudo chmod -R a+rwX $(DOCKER_SPARK_BIND_DIRS) $(DOCKER_SCYLLA_BIND_DIRS)
 	docker compose -f $(COMPOSE_FILE) up -d
 
 start-services-scylla: spark-image ## Start services needed for Scylla integration tests
 	$(Q)mkdir -p $(DOCKER_SPARK_BIND_DIRS) $(DOCKER_SCYLLA_BIND_DIRS)
-	$(Q)sudo chmod -R 777 $(DOCKER_SPARK_BIND_DIRS) $(DOCKER_SCYLLA_BIND_DIRS)
+	$(Q)sudo chmod -R a+rwX $(DOCKER_SPARK_BIND_DIRS) $(DOCKER_SCYLLA_BIND_DIRS)
 	docker compose -f $(COMPOSE_FILE) up -d cassandra cassandra5 cassandra3 cassandra2 scylla-source scylla spark-master spark-worker
 
 start-services-alternator: spark-image ## Start services needed for Alternator integration tests
 	$(Q)mkdir -p $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla
-	$(Q)sudo chmod -R 777 $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla
+	$(Q)sudo chmod -R a+rwX $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla
 	docker compose -f $(COMPOSE_FILE) up -d dynamodb scylla s3 spark-master spark-worker
+
+start-services-aerospike: spark-image ## Start services needed for Aerospike integration tests
+	$(Q)mkdir -p $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla
+	$(Q)sudo chmod -R a+rwX $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla
+	docker compose -f $(COMPOSE_FILE) up -d aerospike scylla spark-master spark-worker
 
 start-services-aws: spark-image ## Start only services needed for AWS tests
 	$(Q)mkdir -p $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla
-	$(Q)sudo chmod -R 777 $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla
+	$(Q)sudo chmod -R a+rwX $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla
 	docker compose -f $(COMPOSE_FILE) up -d scylla spark-master spark-worker
 
 wait-for-services: ## Wait for all test services to become ready
 	$(Q)$(call wait-for-port,8000)
 	$(call wait-for-port,8001)
 	$(call wait-for-port,4566)
+	echo "Waiting for Aerospike to be ready on port 3000"
+	$(call attempt,docker compose -f $(COMPOSE_FILE) exec aerospike asinfo -v status 2>/dev/null | grep -qw ok)
 	$(call wait-for-cql,scylla)
 	$(call wait-for-cql,cassandra)
 	$(call wait-for-cql,scylla-source)
@@ -154,6 +166,13 @@ wait-for-services-alternator: ## Wait for Alternator test services to become rea
 	$(Q)$(call wait-for-port,8000)
 	$(call wait-for-port,8001)
 	$(call wait-for-port,4566)
+	$(call wait-for-cql,scylla)
+	$(call wait-for-port,8080)
+	$(call wait-for-port,8081)
+
+wait-for-services-aerospike: ## Wait for Aerospike test services to become ready
+	$(Q)echo "Waiting for Aerospike to be ready on port 3000"
+	$(call attempt,docker compose -f $(COMPOSE_FILE) exec aerospike asinfo -v status 2>/dev/null | grep -qw ok)
 	$(call wait-for-cql,scylla)
 	$(call wait-for-port,8080)
 	$(call wait-for-port,8081)
@@ -180,7 +199,7 @@ endif
 
 start-services-cassandra: spark-image ## Start services for a single Cassandra version (CASSANDRA_VERSION=...)
 	$(Q)mkdir -p $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla ./tests/docker/$(_CASSANDRA_SERVICE)
-	$(Q)sudo chmod -R 777 $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla ./tests/docker/$(_CASSANDRA_SERVICE)
+	$(Q)sudo chmod -R a+rwX $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla ./tests/docker/$(_CASSANDRA_SERVICE)
 	docker compose -f $(COMPOSE_FILE) up -d $(_CASSANDRA_SERVICE) scylla spark-master spark-worker
 
 wait-for-services-cassandra: ## Wait for a single Cassandra version to become ready (CASSANDRA_VERSION=...)
@@ -203,6 +222,32 @@ test-integration-scylla: ## Run all Scylla integration tests (requires all CQL s
 
 test-integration-alternator: ## Run Alternator integration tests only (excludes AWS and E2E benchmarks)
 	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.alternator.* com.scylladb.migrator.writers.* -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.AWS,com.scylladb.migrator.E2E" $(SBT_COVERAGE_SUFFIX)
+
+test-integration-aerospike: ## Run Aerospike integration tests only (excludes E2E benchmarks)
+	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.aerospike.* -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.E2E" $(SBT_COVERAGE_SUFFIX)
+
+# --- Per-version Aerospike source testing (AEROSPIKE_VERSION=6|7) ---
+AEROSPIKE_VERSION ?= 7
+ifeq ($(AEROSPIKE_VERSION),7)
+_AEROSPIKE_SERVICE := aerospike
+else
+_AEROSPIKE_SERVICE := aerospike$(AEROSPIKE_VERSION)
+endif
+
+start-services-aerospike-compat: spark-image ## Start services for a single Aerospike version (AEROSPIKE_VERSION=...)
+	$(Q)mkdir -p $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla
+	$(Q)sudo chmod -R a+rwX $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla
+	docker compose -f $(COMPOSE_FILE) up -d $(_AEROSPIKE_SERVICE) scylla spark-master spark-worker
+
+wait-for-services-aerospike-compat: ## Wait for a single Aerospike version to become ready (AEROSPIKE_VERSION=...)
+	$(Q)echo "Waiting for Aerospike ($(_AEROSPIKE_SERVICE)) to be ready"
+	$(call attempt,docker compose -f $(COMPOSE_FILE) exec $(_AEROSPIKE_SERVICE) asinfo -v status 2>/dev/null | grep -qw ok)
+	$(call wait-for-cql,scylla)
+	$(call wait-for-port,8080)
+	$(call wait-for-port,8081)
+
+test-integration-aerospike-compat: ## Run Aerospike integration tests for a specific version (AEROSPIKE_VERSION=...)
+	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.aerospike.* -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.E2E" $(SBT_COVERAGE_SUFFIX)
 
 test-integration-aws: ## Run AWS integration tests (requires services + AWS credentials)
 	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly -- --include-categories=com.scylladb.migrator.AWS" $(SBT_COVERAGE_SUFFIX)
@@ -248,6 +293,7 @@ test-benchmark-e2e: ## Run all E2E throughput benchmarks (requires services)
 	$(Q)$(MAKE) test-benchmark-e2e-cassandra-parquet
 	$(Q)$(MAKE) test-benchmark-e2e-dynamodb-s3export
 	$(Q)$(MAKE) test-benchmark-e2e-s3export-alternator
+	$(Q)$(MAKE) test-benchmark-e2e-aerospike-scylla
 
 test-benchmark-e2e-cassandra-scylla: ## Run Cassandra->Scylla E2E benchmarks
 	$(Q)sbt -De2e.cql.rows=$(E2E_CQL_ROWS) "testOnly com.scylladb.migrator.scylla.CassandraToScyllaE2EBenchmark"
@@ -272,3 +318,9 @@ test-benchmark-e2e-dynamodb-s3export: ## Run DynamoDB->S3Export E2E benchmark
 
 test-benchmark-e2e-s3export-alternator: ## Run S3Export->Alternator E2E benchmark (requires dynamodb-s3export to have run first)
 	$(Q)sbt -De2e.ddb.rows=$(E2E_DDB_ROWS) "testOnly com.scylladb.migrator.alternator.S3ExportToAlternatorE2EBenchmark"
+
+test-benchmark-e2e-aerospike-scylla: ## Run Aerospike->Scylla E2E benchmark
+	$(Q)sbt -De2e.aerospike.rows=$(E2E_AEROSPIKE_ROWS) "testOnly com.scylladb.migrator.aerospike.AerospikeToScyllaE2EBenchmark"
+
+test-benchmark-e2e-sanity-aerospike: ## Run Aerospike E2E sanity (small row count, for CI)
+	$(Q)$(MAKE) test-benchmark-e2e-aerospike-scylla E2E_AEROSPIKE_ROWS=1000

--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/AerospikeConvertValueBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/AerospikeConvertValueBenchmark.scala
@@ -1,0 +1,84 @@
+package com.scylladb.migrator.benchmarks
+
+import com.scylladb.migrator.readers.AerospikeTypes
+import org.apache.spark.sql.types._
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+/** Microbenchmarks for Aerospike value conversion and type inference. */
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 30, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class AerospikeConvertValueBenchmark {
+
+  var longValue: java.lang.Long = _
+  var intValue: java.lang.Integer = _
+  var doubleValue: java.lang.Double = _
+  var stringValue: String = _
+  var boolValue: java.lang.Boolean = _
+  var bytesValue: Array[Byte] = _
+  var listValue: java.util.List[String] = _
+  var mapValue: java.util.Map[String, String] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    longValue   = java.lang.Long.valueOf(42L)
+    intValue    = java.lang.Integer.valueOf(42)
+    doubleValue = java.lang.Double.valueOf(3.14)
+    stringValue = "hello world"
+    boolValue   = java.lang.Boolean.TRUE
+    bytesValue  = Array[Byte](1, 2, 3, 4, 5)
+    listValue   = java.util.Arrays.asList("a", "b", "c")
+    mapValue    = new java.util.HashMap[String, String]()
+    mapValue.put("key1", "val1")
+    mapValue.put("key2", "val2")
+  }
+
+  @Benchmark
+  def convertLong(): Any = AerospikeTypes.convertValue(longValue, LongType)
+
+  @Benchmark
+  def convertInt(): Any = AerospikeTypes.convertValue(intValue, LongType)
+
+  @Benchmark
+  def convertDouble(): Any = AerospikeTypes.convertValue(doubleValue, DoubleType)
+
+  @Benchmark
+  def convertString(): Any = AerospikeTypes.convertValue(stringValue, StringType)
+
+  @Benchmark
+  def convertBooleanPassthrough(): Any = AerospikeTypes.convertValue(boolValue, BooleanType)
+
+  @Benchmark
+  def convertBooleanToString(): Any = AerospikeTypes.convertValue(boolValue, StringType)
+
+  @Benchmark
+  def convertBytes(): Any = AerospikeTypes.convertValue(bytesValue, BinaryType)
+
+  @Benchmark
+  def convertList(): Any =
+    AerospikeTypes.convertValue(listValue, ArrayType(StringType, containsNull = true))
+
+  @Benchmark
+  def convertMap(): Any =
+    AerospikeTypes.convertValue(
+      mapValue,
+      MapType(StringType, StringType, valueContainsNull = true)
+    )
+
+  @Benchmark
+  def inferTypeLong(): Any = AerospikeTypes.inferSparkType(longValue)
+
+  @Benchmark
+  def inferTypeString(): Any = AerospikeTypes.inferSparkType(stringValue)
+
+  @Benchmark
+  def inferTypeList(): Any = AerospikeTypes.inferSparkType(listValue)
+
+  @Benchmark
+  def inferTypeMap(): Any = AerospikeTypes.inferSparkType(mapValue)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ val awsSdkVersion = "2.23.19"
 val sparkVersion = "4.0.2"
 val hadoopVersion = "3.4.1"
 val circeVersion = "0.14.7"
+val aerospikeClientVersion = "8.1.1"
 val connectorVersion = "4.1.0"
 val dynamodbStreamsKinesisAdapterVersion =
   "1.5.4" // Note This version still depends on AWS SDK 1.x, but there is no more recent version that supports AWS SDK v2.
@@ -13,6 +14,7 @@ inThisBuild(
   List(
     organization := "com.scylladb",
     scalaVersion := "2.13.14",
+    // -release:17 is required: java.util.HexFormat (used in Aerospike reader) needs JDK 17+
     scalacOptions ++= Seq("-release:17", "-deprecation", "-unchecked", "-feature")
   )
 )
@@ -60,6 +62,7 @@ lazy val migrator = (project in file("migrator"))
       "com.scylladb"          %% "spark-scylladb-connector" % connectorVersion,
       "com.github.jnr" % "jnr-posix" % "3.1.19", // Needed by the Spark ScyllaDB connector
       "com.scylladb.alternator" % "emr-dynamodb-hadoop"  % "5.8.0",
+      "com.aerospike"           % "aerospike-client-jdk8" % aerospikeClientVersion, // jdk8 variant works on JDK 8+; jdk21 variant requires JDK 21+ (adds virtual threads)
       "com.scylladb.alternator" % "load-balancing"       % "2.0.3",
       "io.circe"               %% "circe-generic"        % circeVersion,
       "io.circe"               %% "circe-parser"         % circeVersion,
@@ -102,12 +105,13 @@ lazy val tests = project
       "org.apache.cassandra"      % "java-driver-query-builder" % "4.18.0",
       "com.github.mjakubowski84" %% "parquet4s-core"            % "1.9.4",
       "org.apache.hadoop"         % "hadoop-client"             % hadoopVersion,
+      "com.aerospike"             % "aerospike-client-jdk8"     % aerospikeClientVersion % Test,
       "org.scalameta"            %% "munit"                     % "1.0.1"
     ),
     Test / parallelExecution := false,
     // Needed to build a Spark session on Java 17+, see https://stackoverflow.com/questions/73465937/apache-spark-3-3-0-breaks-on-java-17-with-cannot-access-class-sun-nio-ch-direct
     Test / javaOptions ++= {
-      val e2eProps = Seq("e2e.cql.rows", "e2e.ddb.rows").flatMap { key =>
+      val e2eProps = Seq("e2e.cql.rows", "e2e.ddb.rows", "e2e.aerospike.rows").flatMap { key =>
         sys.props.get(key).map(v => s"-D${key}=${v}")
       }
       Seq("--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED") ++ e2eProps

--- a/config-aerospike.yaml.example
+++ b/config-aerospike.yaml.example
@@ -1,0 +1,105 @@
+# Example configuration for migrating from Aerospike to Scylla
+# Requires JDK 17+ (the Aerospike reader uses java.util.HexFormat, a JDK 17 API).
+# See also: config.yaml.example for Cassandra/DynamoDB/Parquet source examples
+source:
+  type: aerospike
+  hosts:
+    - aerospike-server
+  # Optional - default port for hosts that don't specify one inline (default: 3000)
+  # port: 3000
+  namespace: test
+  set: users
+  # Optional - specific bins to read (if not specified, all bins are read)
+  # bins:
+  #   - name
+  #   - email
+  #   - age
+  # Optional - number of splits for parallel reads (default: Spark parallelism * 4, max 4096)
+  # For small datasets, consider setting splitCount to a lower value to avoid empty partitions.
+  # splitCount: 256
+  # Optional - number of records to sample for schema discovery (default: 1000).
+  # Aerospike is schema-less, so bins that only appear in records beyond this sample will be skipped.
+  # schemaSampleSize: 1000
+  # Optional - capacity of the blocking queue between scan thread and iterator (default: 1024)
+  # queueSize: 1024
+  # The Aerospike record key is exposed as the 'aero_key' column.
+  # Keys can be String, Long, or byte[] - the type is auto-detected during schema discovery.
+  # Optional - Aerospike authentication credentials
+  # credentials:
+  #   username: <user>
+  #   password: <pass>
+  # Optional - connection and socket timeouts in milliseconds
+  # connectTimeoutMs: 10000
+  # socketTimeoutMs: 10000  # default: 10000
+  # Optional - TLS name for secure connections. Setting this enables TLS.
+  # The JVM default trust store is used; configure via -Djavax.net.ssl.trustStore JVM arguments.
+  # tlsName: <tls-name>
+  # Optional - total timeout in milliseconds for Aerospike operations. If not set,
+  # defaults to 3x socketTimeoutMs. Set this to override the 3x multiplier.
+  # totalTimeoutMs: 90000
+  # Optional - maximum number of retries for transient scan errors (TIMEOUT,
+  # SERVER_NOT_AVAILABLE, DEVICE_OVERLOAD) before failing the Spark partition (default: 3).
+  # maxScanRetries: 3
+  # Optional - poll timeout in seconds for the blocking queue between scan thread and
+  # iterator. If you see "scan thread died" errors, increase this value (default: 120).
+  # pollTimeoutSeconds: 120
+  # Optional - maximum consecutive poll timeouts before failing a Spark partition (default: 5).
+  # With pollTimeoutSeconds=120 and maxPollRetries=5, a partition can wait up to 10 minutes.
+  # maxPollRetries: 5
+  # Optional - maximum number of connections per Aerospike node (default: Aerospike client default).
+  # Increase for high-throughput migrations with many concurrent scans.
+  # maxConnsPerNode: 300
+  # Optional - number of connection pools per Aerospike node (default: Aerospike client default).
+  # connPoolsPerNode: 1
+  # Optional - schema discovery strategy (default: progressive).
+  # "progressive": scans 8 -> 64 -> all partitions, stopping after finding records.
+  # "single": scans only 8 partitions (fastest startup, may miss bins in sparse data).
+  # "full": scans all partitions (most thorough, may be slow on large clusters).
+  # schemaDiscoveryStrategy: progressive
+  # Optional - explicit schema override. When set, schema discovery is skipped entirely.
+  # Useful for evolving schemas where sample-based discovery might miss bins.
+  # Supported types: string, text, long, bigint, int, integer, double, binary, blob
+  # schema:
+  #   name: string
+  #   age: long
+  #   score: double
+  #   data: binary
+  #
+  # Optional - preserve Aerospike record metadata as additional columns.
+  # preserveTTL: when true, adds an 'aero_ttl' column (INT) with the record's remaining
+  # TTL in seconds. Records with no expiration will have TTL = -1. (default: false)
+  # preserveTTL: false
+  # preserveGeneration: when true, adds an 'aero_generation' column (INT) with the record's
+  # generation (version) counter. (default: false)
+  # preserveGeneration: false
+  #
+  # Note: Credentials are serialized as part of the Spark job closure and may be written to
+  # disk during Spark shuffle operations. For sensitive environments, set the
+  # AEROSPIKE_USERNAME and AEROSPIKE_PASSWORD environment variables on executor nodes instead.
+  # When these env vars are present, credentials are read from the environment at runtime
+  # and are not broadcast as part of the Spark job closure.
+  #
+  # Aerospike-to-Spark type mapping (auto-detected during schema discovery):
+  #   Integer/Long  -> LongType  (bigint)
+  #   Double/Float  -> DoubleType
+  #   String        -> StringType (text)
+  #   byte[]        -> BinaryType (blob)
+  #   List          -> ArrayType
+  #   Map           -> MapType
+  #   GeoJSON       -> StringType (arrives as JSON text from the Aerospike client)
+  #   HLL           -> BinaryType (raw bytes)
+  #   Other/unknown -> StringType (via .toString fallback)
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  keyspace: test
+  table: users
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -67,6 +67,9 @@ source:
 #     host: <host>
 #     port: <port>
 
+# Example for loading from Aerospike:
+# See config-aerospike.yaml.example for a complete Aerospike source configuration.
+
 # Example for loading from DynamoDB:
 # source:
 #   type: dynamodb

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -9,6 +9,45 @@ services:
       - "8001:8000"
     working_dir: /home/dynamodblocal
 
+  aerospike:
+    # Aerospike Server 7.x is AGPL v3 licensed. Used here only for integration testing.
+    image: aerospike/aerospike-server:7.2
+    volumes:
+      - ./tests/docker/aerospike/aerospike.conf:/etc/aerospike/aerospike.conf
+    ports:
+      - "3000:3000"
+    expose:
+      - 3000
+    healthcheck:
+      test: ["CMD", "asinfo", "-v", "status"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  aerospike6:
+    # Aerospike 6.4 — minimum supported version (scanPartitions requires 6.0+).
+    # Network alias "aerospike" allows Spark configs to connect without modification.
+    # NOTE: Do not run aerospike and aerospike6 simultaneously — they share the "aerospike"
+    # alias. The compat tests start only one version at a time via make targets.
+    image: aerospike/aerospike-server:6.4
+    volumes:
+      - ./tests/docker/aerospike/aerospike.conf:/etc/aerospike/aerospike.conf
+    ports:
+      - "3001:3000"
+    expose:
+      - 3000
+    networks:
+      default:
+        aliases:
+          - aerospike
+    healthcheck:
+      test: ["CMD", "asinfo", "-v", "status"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
   cassandra:
     image: cassandra:4.1
     environment:
@@ -58,7 +97,7 @@ services:
       - 9046
 
   scylla-source:
-    image: scylladb/scylla:latest
+    image: scylladb/scylla:2025.1
     volumes:
       - "./tests/docker/scylla-source:/var/lib/scylla"
     ports:
@@ -73,7 +112,7 @@ services:
       --alternator-write-isolation only_rmw_uses_lwt
       --tablets-mode-for-new-keyspaces disabled
   scylla:
-    image: scylladb/scylla:latest
+    image: scylladb/scylla:2025.1
     volumes:
       - "./tests/docker/scylla:/var/lib/scylla"
     ports:
@@ -94,7 +133,6 @@ services:
       - DEBUG=${DEBUG:-0}
     volumes:
       - "./tests/docker/s3:/var/lib/localstack"
-      - "/var/run/docker.sock:/var/run/docker.sock"
 
   spark-master:
     image: ${SPARK_IMAGE:-spark-migrator}
@@ -105,9 +143,9 @@ services:
     expose:
       - 5005
     ports:
-      - 4040:4040
-      - 5005:5005
-      - 8080:8080
+      - 127.0.0.1:4040:4040
+      - 127.0.0.1:5005:5005
+      - 127.0.0.1:8080:8080
     volumes:
       - ./migrator/target/scala-2.13:/jars
       - ./tests/src/test/configurations:/app/configurations
@@ -127,8 +165,8 @@ services:
     expose:
       - 5006
     ports:
-      - 5006:5006
-      - 8081:8081
+      - 127.0.0.1:5006:5006
+      - 127.0.0.1:8081:8081
     volumes:
       - ./tests/docker/parquet:/app/parquet
       - ./tests/docker/aws-profile:/root/.aws

--- a/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
@@ -57,10 +57,25 @@ object Migrator {
               alternatorTarget: TargetSettings.DynamoDB
             ) =>
           AlternatorMigrator.migrateFromS3Export(s3Source, alternatorTarget, migratorConfig)
+        case (
+              aerospikeSource: SourceSettings.Aerospike,
+              scyllaTarget: TargetSettings.Scylla
+            ) =>
+          val sourceDF = readers.Aerospike.readDataframe(spark, aerospikeSource)
+          ScyllaMigrator.migrate(migratorConfig, scyllaTarget, sourceDF)
         case (source, target) =>
+          val validCombinations =
+            """Supported source -> target combinations:
+              |  Cassandra/Scylla -> Scylla
+              |  Cassandra/Scylla -> Parquet
+              |  Parquet          -> Scylla
+              |  DynamoDB         -> DynamoDB/Alternator
+              |  DynamoDB         -> S3 Export
+              |  S3 Export        -> DynamoDB/Alternator
+              |  Aerospike        -> Scylla""".stripMargin
           sys.error(
             s"Unsupported combination of source and target: " +
-              s"${source.getClass.getSimpleName} -> ${target.getClass.getSimpleName}"
+              s"${source.getClass.getSimpleName} -> ${target.getClass.getSimpleName}\n$validCombinations"
           )
       }
     } finally

--- a/migrator/src/main/scala/com/scylladb/migrator/config/Credentials.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/Credentials.scala
@@ -3,8 +3,22 @@ package com.scylladb.migrator.config
 import io.circe.{ Decoder, Encoder }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 
-case class Credentials(username: String, password: String)
+case class Credentials(username: String, password: String) {
+  override def toString: String = s"Credentials($username, ****)"
+}
 object Credentials {
-  implicit val encoder: Encoder[Credentials] = deriveEncoder[Credentials]
+
+  /** Default encoder masks passwords for safety. Use `roundTripEncoder` for serialization fidelity.
+    */
+  implicit val encoder: Encoder[Credentials] = Encoder.instance { c =>
+    io.circe.Json.obj(
+      "username" -> io.circe.Json.fromString(c.username),
+      "password" -> io.circe.Json.fromString("****")
+    )
+  }
   implicit val decoder: Decoder[Credentials] = deriveDecoder[Credentials]
+
+  /** Encoder that preserves the actual password, for use in savepoints or round-trip serialization.
+    */
+  val roundTripEncoder: Encoder[Credentials] = deriveEncoder[Credentials]
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SchemaDiscoveryStrategy.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SchemaDiscoveryStrategy.scala
@@ -1,0 +1,35 @@
+package com.scylladb.migrator.config
+
+import io.circe.{ Decoder, Encoder }
+
+/** Controls how many Aerospike partitions are scanned during schema discovery.
+  *
+  * "progressive" (default): scans 8 -> 64 -> all partitions, stopping after finding records.
+  * "single": scans only 8 partitions (fastest startup, may miss bins in sparse data). "full": scans
+  * all partitions (most thorough, may be slow on large clusters).
+  */
+sealed trait SchemaDiscoveryStrategy
+
+object SchemaDiscoveryStrategy {
+  case object Progressive extends SchemaDiscoveryStrategy
+  case object Single extends SchemaDiscoveryStrategy
+  case object Full extends SchemaDiscoveryStrategy
+
+  implicit val decoder: Decoder[SchemaDiscoveryStrategy] = Decoder.decodeString.emap { s =>
+    s.toLowerCase match {
+      case "progressive" => Right(Progressive)
+      case "single"      => Right(Single)
+      case "full"        => Right(Full)
+      case _ =>
+        Left(
+          s"Unknown schemaDiscoveryStrategy: '$s'. Valid values: progressive, single, full"
+        )
+    }
+  }
+
+  implicit val encoder: Encoder[SchemaDiscoveryStrategy] = Encoder.encodeString.contramap {
+    case Progressive => "progressive"
+    case Single      => "single"
+    case Full        => "full"
+  }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
@@ -3,9 +3,11 @@ package com.scylladb.migrator.config
 import cats.implicits._
 import com.scylladb.migrator.AwsUtils
 import io.circe.syntax._
-import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
+import io.circe.{ Decoder, DecodingFailure, Encoder, Json, JsonObject }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import software.amazon.awssdk.services.dynamodb.model.BillingMode
+
+import scala.collection.immutable.ListMap
 
 case class DynamoDBEndpoint(host: String, port: Int) {
   def renderEndpoint = s"${host}:${port}"
@@ -56,6 +58,60 @@ object SourceSettings {
   ) extends SourceSettings {
     lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
       AwsUtils.computeFinalCredentials(credentials, endpoint, region)
+  }
+
+  /** @param schemaSampleSize
+    *   Number of records to sample for schema discovery (default: 1000). Values above 10K will
+    *   trigger a warning; schema discovery uses a synchronized callback so very large values add
+    *   lock contention.
+    * @param preserveTTL
+    *   When true, adds an 'aero_ttl' column (IntegerType) with the record's remaining TTL in
+    *   seconds. Records with no expiration will have TTL = -1. (default: false)
+    * @param preserveGeneration
+    *   When true, adds an 'aero_generation' column (IntegerType) with the record's generation
+    *   counter. (default: false)
+    * @param totalTimeoutMs
+    *   Total timeout in milliseconds for Aerospike operations. When not specified, defaults to
+    *   `socketTimeoutMs * 3` if socketTimeoutMs is set, otherwise 30000ms.
+    * @param maxPollRetries
+    *   Maximum consecutive poll timeouts before failing a partition (default: 5). With the default
+    *   pollTimeoutSeconds of 120, this means a partition can wait up to 10 minutes before failing.
+    * @param schemaDiscoveryStrategy
+    *   Controls how many partitions are scanned during schema discovery (default: "progressive").
+    *   "progressive" scans 8 -> 64 -> all partitions (stops after finding records). "single" scans
+    *   only 8 partitions (fastest startup, may miss bins in sparse data). "full" scans all
+    *   partitions (most thorough, may be slow on large clusters).
+    * @param maxConnsPerNode
+    *   Maximum number of connections to each Aerospike node (default: Aerospike client default).
+    * @param connPoolsPerNode
+    *   Number of connection pools per Aerospike node (default: Aerospike client default).
+    */
+  case class Aerospike(
+    hosts: Seq[String],
+    port: Option[Int],
+    namespace: String,
+    set: String,
+    bins: Option[Seq[String]],
+    splitCount: Option[Int],
+    schemaSampleSize: Option[Int],
+    queueSize: Option[Int],
+    credentials: Option[Credentials],
+    connectTimeoutMs: Option[Int],
+    socketTimeoutMs: Option[Int],
+    tlsName: Option[String],
+    schema: Option[ListMap[String, String]],
+    pollTimeoutSeconds: Option[Int],
+    preserveTTL: Option[Boolean],
+    preserveGeneration: Option[Boolean],
+    totalTimeoutMs: Option[Int],
+    maxScanRetries: Option[Int],
+    schemaDiscoveryStrategy: Option[SchemaDiscoveryStrategy],
+    maxPollRetries: Option[Int],
+    maxConnsPerNode: Option[Int],
+    connPoolsPerNode: Option[Int]
+  ) extends SourceSettings {
+    def ttlEnabled: Boolean = preserveTTL.getOrElse(false)
+    def generationEnabled: Boolean = preserveGeneration.getOrElse(false)
   }
 
   case class DynamoDBS3Export(
@@ -138,6 +194,28 @@ object SourceSettings {
     }
   }
 
+  // ListMap preserves insertion order from YAML, ensuring schema column order is deterministic.
+  // The standard Map may reorder keys for maps with 5+ entries.
+  private implicit val listMapStringDecoder: Decoder[ListMap[String, String]] =
+    Decoder.decodeJsonObject.emap { obj =>
+      val builder = ListMap.newBuilder[String, String]
+      val errors = List.newBuilder[String]
+      obj.toList.foreach { case (k, v) =>
+        v.asString match {
+          case Some(s) => builder += k -> s
+          case None    => errors += s"Expected string value for key '$k', got: ${v.noSpaces}"
+        }
+      }
+      val errs = errors.result()
+      if (errs.nonEmpty) Left(errs.mkString("; "))
+      else Right(builder.result())
+    }
+
+  private implicit val listMapStringEncoder: Encoder[ListMap[String, String]] =
+    Encoder.instance { m =>
+      Json.fromJsonObject(JsonObject.fromIterable(m.map { case (k, v) => k -> Json.fromString(v) }))
+    }
+
   implicit val decoder: Decoder[SourceSettings] = Decoder.instance { cursor =>
     cursor.get[String]("type").flatMap {
       case "cassandra" | "scylla" =>
@@ -148,6 +226,26 @@ object SourceSettings {
         deriveDecoder[DynamoDB].apply(cursor)
       case "dynamodb-s3-export" =>
         deriveDecoder[DynamoDBS3Export].apply(cursor)
+      case "aerospike" =>
+        deriveDecoder[Aerospike].apply(cursor).flatMap { a =>
+          val errors = List.newBuilder[String]
+          a.port.foreach(p => if (p <= 0 || p > 65535) errors += s"Invalid port: $p")
+          a.splitCount.foreach(s => if (s <= 0) errors += s"splitCount must be positive, got $s")
+          a.schemaSampleSize
+            .foreach(s => if (s <= 0) errors += s"schemaSampleSize must be positive, got $s")
+          a.queueSize.foreach(q => if (q <= 0) errors += s"queueSize must be positive, got $q")
+          a.pollTimeoutSeconds
+            .foreach(p => if (p <= 0) errors += s"pollTimeoutSeconds must be positive, got $p")
+          a.maxPollRetries
+            .foreach(r => if (r <= 0) errors += s"maxPollRetries must be positive, got $r")
+          a.maxConnsPerNode
+            .foreach(n => if (n <= 0) errors += s"maxConnsPerNode must be positive, got $n")
+          a.connPoolsPerNode
+            .foreach(n => if (n <= 0) errors += s"connPoolsPerNode must be positive, got $n")
+          val errs = errors.result()
+          if (errs.nonEmpty) Left(DecodingFailure(errs.mkString("; "), cursor.history))
+          else Right(a)
+        }
       case otherwise =>
         Left(DecodingFailure(s"Unknown source type: ${otherwise}", cursor.history))
     }
@@ -173,6 +271,11 @@ object SourceSettings {
       deriveEncoder[DynamoDBS3Export]
         .encodeObject(s)
         .add("type", Json.fromString("dynamodb-s3-export"))
+        .asJson
+    case s: Aerospike =>
+      deriveEncoder[Aerospike]
+        .encodeObject(s)
+        .add("type", Json.fromString("aerospike"))
         .asJson
   }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Aerospike.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Aerospike.scala
@@ -1,0 +1,596 @@
+package com.scylladb.migrator.readers
+
+import com.aerospike.client.{
+  AerospikeClient,
+  AerospikeException,
+  Host,
+  Info,
+  Key,
+  Record,
+  ResultCode,
+  ScanCallback
+}
+import com.aerospike.client.policy.{ ClientPolicy, InfoPolicy, ScanPolicy, TlsPolicy }
+import com.aerospike.client.query.PartitionFilter
+import com.scylladb.migrator.config.{ SchemaDiscoveryStrategy, SourceSettings }
+import com.scylladb.migrator.scylla.SourceDataFrame
+import org.apache.logging.log4j.LogManager
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types._
+
+import java.util.concurrent.{ ConcurrentHashMap, ConcurrentLinkedQueue }
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger, AtomicReference }
+import scala.jdk.CollectionConverters._
+
+object Aerospike {
+  val log = LogManager.getLogger("com.scylladb.migrator.readers.Aerospike")
+
+  /** Total number of data partitions in Aerospike */
+  private[migrator] val TotalAerospikePartitions = 4096
+
+  /** Maximum recommended schemaSampleSize for schema discovery */
+  private[migrator] val MaxSchemaSampleSize = 10000
+
+  /** Maximum number of distinct bins tracked during schema discovery to prevent OOM */
+  private val MaxDiscoveredBins = 10000
+
+  /** Number of partitions for the initial schema discovery sample (progressive/single mode) */
+  private val InitialSamplePartitions = 8
+
+  /** Number of partitions for the extended schema discovery fallback (progressive mode) */
+  private val ExtendedSamplePartitions = 64
+
+  /** Column name used for the Aerospike record key in the resulting DataFrame */
+  private[migrator] val KeyColumnName = "aero_key"
+
+  /** Column name for the Aerospike record TTL (seconds remaining), when preserveTTL is enabled */
+  private[migrator] val TtlColumnName = "aero_ttl"
+
+  /** Column name for the Aerospike record generation count, when preserveGeneration is enabled */
+  private[migrator] val GenerationColumnName = "aero_generation"
+
+  def readDataframe(
+    spark: SparkSession,
+    source: SourceSettings.Aerospike
+  ): SourceDataFrame = {
+    AerospikeTypes.reset() // Clear stale warning state from prior jobs in the same JVM
+    AerospikeTypes.requireJdk17()
+    // Structural invariants not covered by the decoder (empty strings/seqs pass decoding)
+    require(source.set.nonEmpty, "Aerospike 'set' must not be empty in the source configuration")
+    require(
+      source.namespace.nonEmpty,
+      "Aerospike 'namespace' must not be empty in the source configuration"
+    )
+    require(source.hosts.nonEmpty, "Aerospike 'hosts' must not be empty")
+
+    val connConfig = AerospikeConnectionConfig(
+      source.hosts.toList,
+      source.port.getOrElse(DefaultPort),
+      source.connectTimeoutMs,
+      Some(resolvedSocketTimeout(source)),
+      Some(resolvedTotalTimeout(source)),
+      source.tlsName,
+      source.maxConnsPerNode,
+      source.connPoolsPerNode
+    )
+
+    val schema = discoverSchema(source, connConfig)
+    log.info("Discovered Aerospike schema:")
+    schema.printTreeString()
+
+    // 4x parallelism balances per-partition overhead against scan throughput: enough splits
+    // to keep all cores busy even with skewed partition sizes, capped at the Aerospike limit.
+    val splitCount = source.splitCount.getOrElse(
+      math.min(TotalAerospikePartitions, spark.sparkContext.defaultParallelism * 4)
+    )
+    validateSplitCount(splitCount)
+
+    val binNames = schema.fields
+      .map(_.name)
+      .filter { n =>
+        n != KeyColumnName && n != TtlColumnName && n != GenerationColumnName
+      }
+      .toIndexedSeq
+    val queueSize = source.queueSize.getOrElse(1024)
+    val pollTimeoutSeconds = source.pollTimeoutSeconds.getOrElse(120)
+
+    val broadcastSchema = spark.sparkContext.broadcast(schema)
+    val broadcastBinNames = spark.sparkContext.broadcast(binNames)
+    // Only broadcast credentials from config when executor env vars are not set on the driver.
+    // When AEROSPIKE_USERNAME/AEROSPIKE_PASSWORD are available, executors will read them at
+    // runtime — avoiding plaintext credentials in the Spark serialization stream.
+    val broadcastCredentials = if (envCredentialsAvailable) {
+      log.info(
+        "AEROSPIKE_USERNAME/AEROSPIKE_PASSWORD env vars detected on driver; " +
+          "credentials will NOT be broadcast. Executors must also have these env vars set."
+      )
+      spark.sparkContext.broadcast(Option.empty[(String, String)])
+    } else {
+      if (source.credentials.isDefined)
+        log.warn(
+          "Broadcasting Aerospike credentials from config. For sensitive environments, " +
+            "set AEROSPIKE_USERNAME/AEROSPIKE_PASSWORD env vars on all nodes instead."
+        )
+      spark.sparkContext.broadcast(
+        source.credentials.map(c => (c.username, c.password))
+      )
+    }
+    val readConfig = AerospikeReadConfig(
+      source.namespace,
+      source.set,
+      splitCount,
+      queueSize,
+      pollTimeoutSeconds,
+      source.maxScanRetries.getOrElse(3),
+      source.maxPollRetries.getOrElse(5)
+    )
+
+    val recordsRead = spark.sparkContext.longAccumulator("Aerospike Records Read")
+
+    val rdd = new AerospikeRDD(
+      spark.sparkContext,
+      connConfig,
+      readConfig,
+      broadcastCredentials,
+      broadcastBinNames,
+      broadcastSchema,
+      recordsRead
+    )
+
+    val df = spark.createDataFrame(rdd, schema)
+    // Note: broadcastSchema, broadcastBinNames, and broadcastCredentials are not destroyed here
+    // because the DataFrame is lazily evaluated — executors need the broadcast data when the
+    // RDD is computed. They will be cleaned up when the SparkContext is stopped.
+    // Savepoints are not currently supported for Aerospike sources. A future enhancement
+    // could leverage AerospikePartition boundaries as savepoint tokens to enable resumable
+    // migrations for large datasets.
+    SourceDataFrame(df, None, savepointsSupported = false)
+  }
+
+  /** Converge observed key types. Returns StringType when mixed key types are observed. */
+  private def convergeKeyType(
+    current: Option[DataType],
+    observed: DataType
+  ): Option[DataType] =
+    current match {
+      case None           => Some(observed)
+      case Some(existing) => Some(if (existing != observed) StringType else existing)
+    }
+
+  /** Validate that splitCount is within the allowed range */
+  private[migrator] def validateSplitCount(splitCount: Int): Unit = {
+    require(splitCount > 0, s"splitCount must be positive, got $splitCount")
+    require(
+      splitCount <= TotalAerospikePartitions,
+      s"splitCount ($splitCount) must not exceed $TotalAerospikePartitions"
+    )
+  }
+
+  /** Compute a random starting partition offset for schema discovery sampling. Avoids always
+    * scanning partitions 0..N-1, which may all reside on the same Aerospike node.
+    */
+  private def schemaSampleOffset(samplePartitionCount: Int): Int =
+    scala.util.Random.nextInt(TotalAerospikePartitions - samplePartitionCount + 1)
+
+  /** Build a ScanPolicy configured with the given sample size and timeouts */
+  private def buildScanPolicy(source: SourceSettings.Aerospike, sampleSize: Int): ScanPolicy = {
+    val policy = new ScanPolicy()
+    policy.maxRecords    = sampleSize
+    policy.socketTimeout = resolvedSocketTimeout(source)
+    policy.totalTimeout  = resolvedTotalTimeout(source)
+    policy
+  }
+
+  /** Discover the schema by scanning a sample of records, or use a user-provided schema override */
+  private def discoverSchema(
+    source: SourceSettings.Aerospike,
+    connConfig: AerospikeConnectionConfig
+  ): StructType = {
+    val metaFields = metadataFields(source)
+
+    // Warn when both schema override and discovery strategy are configured (TODO 18)
+    if (source.schema.isDefined && source.schemaDiscoveryStrategy.isDefined)
+      log.warn(
+        "Both 'schema' and 'schemaDiscoveryStrategy' are configured. " +
+          "The explicit 'schema' override takes precedence; 'schemaDiscoveryStrategy' will be ignored."
+      )
+
+    source.schema match {
+      case Some(userSchema) =>
+        source.bins.foreach(binFilter => validateSchemaAgainstBins(userSchema, binFilter))
+        val fields = userSchema.map { case (name, typeName) =>
+          StructField(name, AerospikeTypes.parseType(typeName), nullable = true)
+        }.toSeq
+        StructType(
+          StructField(KeyColumnName, StringType, nullable = false) +: fields ++: metaFields
+        )
+
+      case None =>
+        val credentials = resolveCredentials(source)
+        // Client is intentionally cached in AerospikeClientHolder; reused by executors
+        // and closed by JVM shutdown hook.
+        val client =
+          try AerospikeClientHolder.get(connConfig, credentials)
+          catch {
+            case e: AerospikeException =>
+              throw new RuntimeException(
+                s"Failed to connect to Aerospike at ${connConfig.hosts.mkString(",")}:${connConfig.port} for schema discovery",
+                e
+              )
+          }
+
+        try {
+          // Verify the namespace exists before scanning to fail fast on misconfiguration
+          try {
+            val node = client.getNodes.headOption.getOrElse(
+              throw new IllegalStateException("No Aerospike nodes available")
+            )
+            val namespaces =
+              Info.request(new InfoPolicy(), node, "namespaces")
+            if (!namespaces.split(";").contains(source.namespace))
+              throw new IllegalArgumentException(
+                s"Aerospike namespace '${source.namespace}' not found. " +
+                  s"Available namespaces: $namespaces"
+              )
+          } catch {
+            case e: IllegalArgumentException => throw e
+            case e: Exception =>
+              log.warn(
+                s"Could not verify namespace '${source.namespace}' via info protocol: ${e.getMessage}. " +
+                  "Proceeding with schema discovery anyway."
+              )
+          }
+
+          val sampleSize = source.schemaSampleSize.getOrElse(1000)
+          require(sampleSize > 0, "schemaSampleSize must be positive")
+          if (sampleSize > MaxSchemaSampleSize)
+            log.warn(
+              s"schemaSampleSize=$sampleSize exceeds recommended maximum of $MaxSchemaSampleSize. " +
+                "Very large values may increase schema discovery time without benefit."
+            )
+
+          log.info(
+            s"Schema discovery sampling up to $sampleSize records. " +
+              "Bins that only appear in later records will not be discovered."
+          )
+
+          val bins = new ConcurrentHashMap[String, DataType]()
+          val binsLimitWarned = new AtomicBoolean(false)
+          // Tracks the discovered key type across concurrent scan callback threads.
+          // None = no key observed yet; Some(StringType) = null-user-key seen or mixed types
+          // (forces hex digest fallback); Some(LongType/BinaryType) = uniform typed keys.
+          // Once set to Some(StringType), it never reverts — StringType is the absorbing element.
+          val keyTypeRef = new AtomicReference[Option[DataType]](None)
+          val sampledCount = new AtomicInteger(0)
+          // Collect type conflict messages during scanning; logged after scan completes
+          // to avoid blocking scan callback threads on synchronous log appenders.
+          val typeConflicts = new ConcurrentLinkedQueue[String]()
+
+          val callback = new ScanCallback {
+            override def scanCallback(key: Key, record: Record): Unit = {
+              if (key.userKey != null) {
+                val thisKeyType = key.userKey.getObject match {
+                  case _: java.lang.Long => LongType
+                  case _: Array[Byte]    => BinaryType
+                  case _                 => StringType
+                }
+                keyTypeRef.getAndUpdate(convergeKeyType(_, thisKeyType))
+              } else {
+                // Null userKey forces StringType (hex digest fallback)
+                keyTypeRef.getAndUpdate(convergeKeyType(_, StringType))
+              }
+              record.bins.asScala.foreach { case (name, value) =>
+                if (value != null) {
+                  if (bins.size() >= MaxDiscoveredBins && !bins.containsKey(name)) {
+                    if (binsLimitWarned.compareAndSet(false, true))
+                      log.warn(
+                        s"Schema discovery: bin count reached $MaxDiscoveredBins, " +
+                          "skipping new bins. Consider providing an explicit 'schema' override."
+                      )
+                  } else {
+                    val newType = AerospikeTypes.inferSparkType(value)
+                    // merge() is atomic — safe under concurrent scan callback threads
+                    bins.merge(
+                      name,
+                      newType,
+                      (existing, incoming) => {
+                        val merged = AerospikeTypes.mergeTypes(existing, incoming)
+                        if (merged != existing)
+                          typeConflicts.add(
+                            s"Schema discovery: type conflict for bin '$name' — " +
+                              s"merging $existing and $incoming into $merged."
+                          )
+                        merged
+                      }
+                    )
+                  }
+                }
+              }
+              sampledCount.incrementAndGet()
+            }
+          }
+
+          val strategy =
+            source.schemaDiscoveryStrategy.getOrElse(SchemaDiscoveryStrategy.Progressive)
+          strategy match {
+            case SchemaDiscoveryStrategy.Single =>
+              // Single scan with a small partition range — fastest startup.
+              // Random offset avoids always sampling the same partitions (and the same node).
+              val samplePartitionCount = math.min(InitialSamplePartitions, TotalAerospikePartitions)
+              val offset = schemaSampleOffset(samplePartitionCount)
+              tryScanPartitions(
+                client,
+                buildScanPolicy(source, sampleSize),
+                PartitionFilter.range(offset, samplePartitionCount),
+                source.namespace,
+                source.set,
+                callback,
+                source.bins
+              )
+
+            case SchemaDiscoveryStrategy.Full =>
+              // Full cluster scan — most thorough, may be slow on large clusters
+              tryScanPartitions(
+                client,
+                buildScanPolicy(source, sampleSize),
+                PartitionFilter.all(),
+                source.namespace,
+                source.set,
+                callback,
+                source.bins
+              )
+
+            case SchemaDiscoveryStrategy.Progressive =>
+              // Scan a small partition range first to reduce cluster-wide fan-out.
+              // Random offset avoids always sampling the same partitions.
+              val samplePartitionCount = math.min(InitialSamplePartitions, TotalAerospikePartitions)
+              val offset = schemaSampleOffset(samplePartitionCount)
+              tryScanPartitions(
+                client,
+                buildScanPolicy(source, sampleSize),
+                PartitionFilter.range(offset, samplePartitionCount),
+                source.namespace,
+                source.set,
+                callback,
+                source.bins
+              )
+
+              // Progressive fallback: 8 -> 64 -> all partitions.
+              // A fresh ScanPolicy is used at each step because maxRecords is not reset between
+              // scans. Each fallback step only executes if sampledCount == 0 (i.e., the previous
+              // scan returned zero records), so the callback's state never accumulates across
+              // overlapping scans.
+              if (sampledCount.get() == 0) {
+                log.warn(
+                  s"No records found in initial $InitialSamplePartitions-partition sample, expanding to $ExtendedSamplePartitions partitions for schema discovery"
+                )
+                val extCount = math.min(ExtendedSamplePartitions, TotalAerospikePartitions)
+                tryScanPartitions(
+                  client,
+                  buildScanPolicy(source, sampleSize),
+                  PartitionFilter.range(schemaSampleOffset(extCount), extCount),
+                  source.namespace,
+                  source.set,
+                  callback,
+                  source.bins
+                )
+              }
+              if (sampledCount.get() == 0) {
+                log.warn(
+                  s"No records found in $ExtendedSamplePartitions-partition sample, falling back to full cluster scan for schema discovery"
+                )
+                tryScanPartitions(
+                  client,
+                  buildScanPolicy(source, sampleSize),
+                  PartitionFilter.all(),
+                  source.namespace,
+                  source.set,
+                  callback,
+                  source.bins
+                )
+              }
+          }
+
+          // Log type conflicts collected during the scan (outside the callback threads)
+          var conflict = typeConflicts.poll()
+          while (conflict != null) {
+            log.warn(
+              conflict + " Consider providing an explicit 'schema' override if this is unexpected."
+            )
+            conflict = typeConflicts.poll()
+          }
+
+          val finalSampledCount = sampledCount.get()
+          log.info(
+            s"Schema discovery sampled $finalSampledCount records, discovered ${bins.size()} bins"
+          )
+          if (finalSampledCount == 0) {
+            log.warn(
+              "Schema discovery found zero records. The resulting schema will contain only the 'aero_key' column. " +
+                "Verify that the Aerospike namespace and set are correct and contain data."
+            )
+          }
+
+          val fieldSeq = if (source.bins.isDefined) {
+            source.bins.get.map { binName =>
+              val binType = Option(bins.get(binName)).getOrElse(StringType)
+              StructField(binName, binType, nullable = true)
+            }
+          } else {
+            bins.asScala.toSeq.sortBy(_._1).map { case (name, dataType) =>
+              StructField(name, dataType, nullable = true)
+            }
+          }
+
+          val finalKeyType = keyTypeRef.get().getOrElse(StringType)
+          StructType(
+            StructField(KeyColumnName, finalKeyType, nullable = false) +: fieldSeq ++: metaFields
+          )
+        } finally
+          // Release the driver-side client after schema discovery — it is only needed briefly
+          // and executors will create their own connections via AerospikeClientHolder.
+          AerospikeClientHolder.release(connConfig, credentials)
+    }
+  }
+
+  /** Build optional metadata columns based on source config */
+  private def metadataFields(source: SourceSettings.Aerospike): Seq[StructField] = {
+    val ttlField =
+      if (source.ttlEnabled)
+        Seq(StructField(TtlColumnName, IntegerType, nullable = true))
+      else Seq.empty
+    val genField =
+      if (source.generationEnabled)
+        Seq(StructField(GenerationColumnName, IntegerType, nullable = true))
+      else Seq.empty
+    ttlField ++ genField
+  }
+
+  /** Validate that when both bins filter and schema override are provided, all schema keys are a
+    * subset of the bins filter.
+    */
+  private[migrator] def validateSchemaAgainstBins(
+    schema: scala.collection.immutable.ListMap[String, String],
+    bins: Seq[String]
+  ): Unit = {
+    val schemaKeys = schema.keys.toSet
+    val extraKeys = schemaKeys -- bins.toSet
+    if (extraKeys.nonEmpty)
+      throw new IllegalArgumentException(
+        s"Schema override declares ${extraKeys.size} bin(s) not in the 'bins' filter: " +
+          s"${extraKeys.mkString(", ")}. These bins will not be fetched from Aerospike " +
+          "and will always be null. Remove them from the schema or add them to the bins filter."
+      )
+  }
+
+  private[migrator] val DefaultPort = 3000
+  private val DefaultSocketTimeoutMs = 10000
+  private val DefaultTotalTimeoutMs = 30000
+
+  /** Resolve socket timeout with a consistent default across schema discovery and data reading. */
+  private def resolvedSocketTimeout(source: SourceSettings.Aerospike): Int =
+    source.socketTimeoutMs.getOrElse(DefaultSocketTimeoutMs)
+
+  /** Resolve total timeout with a consistent default across schema discovery and data reading. */
+  private def resolvedTotalTimeout(source: SourceSettings.Aerospike): Int =
+    source.totalTimeoutMs.getOrElse(
+      source.socketTimeoutMs.map(_ * 3).getOrElse(DefaultTotalTimeoutMs)
+    )
+
+  /** Resolve credentials from environment variables, falling back to the given alternative. Used on
+    * both the driver (with config credentials) and executors (with broadcast credentials).
+    */
+  private[migrator] def resolveCredentialsFromEnvOr(
+    fallback: Option[(String, String)]
+  ): Option[(String, String)] = {
+    val fromEnv = for {
+      user <- Option(System.getenv("AEROSPIKE_USERNAME"))
+      pass <- Option(System.getenv("AEROSPIKE_PASSWORD"))
+    } yield (user, pass)
+    fromEnv.orElse(fallback)
+  }
+
+  /** Resolve Aerospike credentials from environment variables or source config. Env vars take
+    * precedence to avoid broadcasting plaintext credentials.
+    */
+  private[migrator] def resolveCredentials(
+    source: SourceSettings.Aerospike
+  ): Option[(String, String)] =
+    resolveCredentialsFromEnvOr(source.credentials.map(c => (c.username, c.password)))
+
+  /** Check whether Aerospike credentials are available via environment variables on this JVM. */
+  private def envCredentialsAvailable: Boolean =
+    resolveCredentialsFromEnvOr(None).isDefined
+
+  /** Build a ClientPolicy from connection config and credentials, without connecting. */
+  private[migrator] def buildClientPolicy(
+    connConfig: AerospikeConnectionConfig,
+    credentials: Option[(String, String)]
+  ): ClientPolicy = {
+    val policy = new ClientPolicy()
+    policy.readPolicyDefault.maxRetries          = 3
+    policy.readPolicyDefault.sleepBetweenRetries = 500
+    connConfig.connectTimeoutMs.foreach(t => policy.timeout = t)
+    connConfig.socketTimeoutMs.foreach { t =>
+      policy.readPolicyDefault.socketTimeout = t
+      policy.scanPolicyDefault.socketTimeout = t
+    }
+    connConfig.totalTimeoutMs.foreach { t =>
+      policy.readPolicyDefault.totalTimeout = t
+      policy.scanPolicyDefault.totalTimeout = t
+    }
+    connConfig.tlsName.foreach { _ =>
+      policy.tlsPolicy = new TlsPolicy()
+    }
+    connConfig.maxConnsPerNode.foreach(n => policy.maxConnsPerNode = n)
+    connConfig.connPoolsPerNode.foreach(n => policy.connPoolsPerNode = n)
+    credentials.foreach { case (user, password) =>
+      policy.user     = user
+      policy.password = password
+    }
+    policy
+  }
+
+  private[migrator] def buildClient(
+    connConfig: AerospikeConnectionConfig,
+    credentials: Option[(String, String)]
+  ): AerospikeClient = {
+    val policy = buildClientPolicy(connConfig, credentials)
+    val hostList = connConfig.hosts.flatMap { h =>
+      Host.parseHosts(h, connConfig.port).map { parsed =>
+        connConfig.tlsName.fold(parsed)(name => new Host(parsed.name, name, parsed.port))
+      }
+    }.toArray
+    new AerospikeClient(policy, hostList: _*)
+  }
+
+  /** Run scanPartitions with or without bin name filtering */
+  private[migrator] def runScanPartitions(
+    client: AerospikeClient,
+    policy: ScanPolicy,
+    filter: PartitionFilter,
+    namespace: String,
+    set: String,
+    callback: ScanCallback,
+    bins: Option[Seq[String]]
+  ): Unit = bins match {
+    case Some(b) if b.nonEmpty =>
+      client.scanPartitions(policy, filter, namespace, set, callback, b: _*)
+    case _ =>
+      client.scanPartitions(policy, filter, namespace, set, callback)
+  }
+
+  /** Run scanPartitions with a user-friendly error for unsupported Aerospike editions */
+  private def tryScanPartitions(
+    client: AerospikeClient,
+    policy: ScanPolicy,
+    filter: PartitionFilter,
+    namespace: String,
+    set: String,
+    callback: ScanCallback,
+    bins: Option[Seq[String]]
+  ): Unit =
+    try runScanPartitions(client, policy, filter, namespace, set, callback, bins)
+    catch {
+      case e: AerospikeException
+          if e.getResultCode == ResultCode.PARAMETER_ERROR ||
+            e.getResultCode == ResultCode.SERVER_NOT_AVAILABLE ||
+            e.getResultCode == ResultCode.ROLE_VIOLATION =>
+        throw new RuntimeException(
+          "Partition scan failed. scanPartitions requires Aerospike Community Edition 6.0+ or Enterprise Edition. " +
+            s"Check your Aerospike server version. Original error (code ${e.getResultCode}): ${e.getMessage}",
+          e
+        )
+      case e: AerospikeException =>
+        log.error(
+          s"Partition scan failed with unexpected result code ${e.getResultCode}: ${e.getMessage}"
+        )
+        throw e
+    }
+
+  /** Check whether an AerospikeException represents a retryable error */
+  private[migrator] def isRetryable(e: AerospikeException): Boolean =
+    e.getResultCode == ResultCode.TIMEOUT ||
+      e.getResultCode == ResultCode.SERVER_NOT_AVAILABLE ||
+      e.getResultCode == ResultCode.DEVICE_OVERLOAD
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/AerospikeClientHolder.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/AerospikeClientHolder.scala
@@ -1,0 +1,152 @@
+package com.scylladb.migrator.readers
+
+import com.aerospike.client.AerospikeClient
+import org.apache.logging.log4j.LogManager
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
+
+/** Connection parameters used as cache key in AerospikeClientHolder.
+  *
+  * Credentials are stored as a SHA-256 hex digest rather than plaintext to avoid retaining raw
+  * passwords in memory (heap dumps, hashCode/equals). The actual credentials are passed separately
+  * to `buildClient`.
+  */
+private[migrator] case class AerospikeConnectionKey(
+  hosts: List[String],
+  port: Int,
+  credentialHash: Option[String],
+  connectTimeoutMs: Option[Int],
+  socketTimeoutMs: Option[Int],
+  totalTimeoutMs: Option[Int],
+  tlsName: Option[String],
+  maxConnsPerNode: Option[Int],
+  connPoolsPerNode: Option[Int]
+)
+
+private[migrator] object AerospikeConnectionKey {
+
+  /** Build a connection key from config and credentials, hashing credentials once. */
+  def fromConfig(
+    connConfig: AerospikeConnectionConfig,
+    credentials: Option[(String, String)]
+  ): AerospikeConnectionKey =
+    AerospikeConnectionKey(
+      connConfig.hosts,
+      connConfig.port,
+      hashCredentials(credentials),
+      connConfig.connectTimeoutMs,
+      connConfig.socketTimeoutMs,
+      connConfig.totalTimeoutMs,
+      connConfig.tlsName,
+      connConfig.maxConnsPerNode,
+      connConfig.connPoolsPerNode
+    )
+
+  /** Hash credentials to avoid storing plaintext passwords in the cache key. */
+  def hashCredentials(credentials: Option[(String, String)]): Option[String] =
+    credentials.map { case (user, pass) =>
+      val digest = MessageDigest.getInstance("SHA-256")
+      digest.update(user.getBytes("UTF-8"))
+      digest.update(0.toByte) // separator
+      digest.update(pass.getBytes("UTF-8"))
+      digest.digest().map("%02x".format(_)).mkString
+    }
+}
+
+/** Shares AerospikeClient instances per executor, keyed by connection parameters. The client is
+  * thread-safe and manages its own internal connection pool. Multiple concurrent configurations are
+  * supported (e.g., different hosts or credentials).
+  *
+  * Marked Serializable as a safety net for cluster mode, even though it should only be accessed
+  * inside RDD.compute() on executor JVMs, never serialized across the wire.
+  */
+private[migrator] object AerospikeClientHolder extends Serializable {
+  private val log = LogManager.getLogger("com.scylladb.migrator.readers.AerospikeClientHolder")
+  @transient private lazy val clients =
+    new ConcurrentHashMap[AerospikeConnectionKey, AerospikeClient]()
+  @volatile private var closed = false
+
+  @transient private var shutdownHook: Thread = _
+
+  private def ensureHookRegistered(): Unit = synchronized {
+    if (closed) throw new IllegalStateException("AerospikeClientHolder has been shut down")
+    if (shutdownHook == null) {
+      shutdownHook = new Thread(() => closeAll())
+      Runtime.getRuntime.addShutdownHook(shutdownHook)
+    }
+  }
+
+  private def closeAll(): Unit = synchronized {
+    closed = true
+    clients.forEach { (_, c) =>
+      if (c != null && c.isConnected) c.close()
+    }
+    clients.clear()
+  }
+
+  /** For tests only — close all clients and allow the holder to be reused. */
+  private[migrator] def reset(): Unit = synchronized {
+    closeAll()
+    if (shutdownHook != null) {
+      try Runtime.getRuntime.removeShutdownHook(shutdownHook)
+      catch { case _: IllegalStateException => }
+      shutdownHook = null
+    }
+    closed = false
+  }
+
+  /** Remove and close a cached client for the given connection config and credentials. Safe to call
+    * even if no client is cached for the key. Useful for task cleanup and tests to prevent
+    * unbounded growth of the client map.
+    */
+  def release(
+    connConfig: AerospikeConnectionConfig,
+    credentials: Option[(String, String)]
+  ): Unit = {
+    val key = AerospikeConnectionKey.fromConfig(connConfig, credentials)
+    val removed = clients.remove(key)
+    if (removed != null) {
+      try removed.close()
+      catch { case e: Exception => log.debug("Error closing Aerospike client during release", e) }
+    }
+  }
+
+  /** Get or create an AerospikeClient for the given connection config and credentials. */
+  def get(
+    connConfig: AerospikeConnectionConfig,
+    credentials: Option[(String, String)]
+  ): AerospikeClient =
+    get(AerospikeConnectionKey.fromConfig(connConfig, credentials), connConfig, credentials)
+
+  /** Get or create an AerospikeClient using a pre-computed connection key. Avoids re-hashing
+    * credentials on every call when the key is already known.
+    */
+  def get(
+    key: AerospikeConnectionKey,
+    connConfig: AerospikeConnectionConfig,
+    credentials: Option[(String, String)]
+  ): AerospikeClient = {
+    ensureHookRegistered()
+    clients.compute(
+      key,
+      (_, existing) => {
+        if (closed)
+          throw new IllegalStateException("AerospikeClientHolder has been shut down")
+        if (existing != null && existing.isConnected) existing
+        else {
+          if (existing != null) existing.close()
+          val newClient = Aerospike.buildClient(connConfig, credentials)
+          // Guard against TOCTOU race: closeAll() may have fired between
+          // ensureHookRegistered() and this point, clearing all clients.
+          if (closed) {
+            newClient.close()
+            throw new IllegalStateException(
+              "AerospikeClientHolder was shut down during client creation"
+            )
+          }
+          newClient
+        }
+      }
+    )
+  }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/AerospikeConfig.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/AerospikeConfig.scala
@@ -1,0 +1,32 @@
+package com.scylladb.migrator.readers
+
+import org.apache.spark.Partition
+
+private[migrator] case class AerospikePartition(
+  override val index: Int,
+  partBegin: Int,
+  partCount: Int
+) extends Partition
+
+/** Connection parameters for Aerospike, serialized as part of the RDD closure. */
+private[migrator] case class AerospikeConnectionConfig(
+  hosts: List[String],
+  port: Int,
+  connectTimeoutMs: Option[Int],
+  socketTimeoutMs: Option[Int],
+  totalTimeoutMs: Option[Int],
+  tlsName: Option[String],
+  maxConnsPerNode: Option[Int],
+  connPoolsPerNode: Option[Int]
+) extends Serializable
+
+/** Read parameters for the AerospikeRDD. */
+private[migrator] case class AerospikeReadConfig(
+  namespace: String,
+  set: String,
+  splitCount: Int,
+  queueSize: Int,
+  pollTimeoutSeconds: Int,
+  maxScanRetries: Int,
+  maxPollRetries: Int
+) extends Serializable

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/AerospikeRDD.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/AerospikeRDD.scala
@@ -1,0 +1,334 @@
+package com.scylladb.migrator.readers
+
+import com.aerospike.client.{ AerospikeException, Key, Record, ScanCallback }
+import com.aerospike.client.policy.ScanPolicy
+import com.aerospike.client.query.PartitionFilter
+import org.apache.spark.{ Partition, SparkContext, TaskContext }
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.GenericRow
+import org.apache.spark.sql.types._
+import org.apache.spark.util.LongAccumulator
+
+import java.util.concurrent.{ LinkedBlockingQueue, TimeUnit }
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger, AtomicReference }
+
+/** Thrown when a Spark task cancellation interrupts an Aerospike scan callback. This is expected
+  * during limit()/take() operations and should not be logged as an error.
+  */
+private[migrator] class ScanCancelledException extends RuntimeException("Task cancelled")
+
+/** Queue entry types for the scan-to-iterator pipeline in AerospikeRDD. */
+private[migrator] sealed trait ScanQueueEntry
+
+/** A data record from the scan, tagged with a generation counter for retry filtering. */
+private[migrator] case class ScanData(generation: Int, key: Key, record: Record)
+    extends ScanQueueEntry
+
+/** Sentinel posted after a retry to unblock the iterator; carries the stale generation so the
+  * iterator discards it.
+  */
+private[migrator] case class ScanRetry(staleGeneration: Int) extends ScanQueueEntry
+
+/** Sentinel signaling that the scan has completed (successfully or with an error). */
+private[migrator] case object ScanComplete extends ScanQueueEntry
+
+private[migrator] object AerospikeRDD {
+
+  /** Compute Aerospike partition ranges for the given split count */
+  def computePartitions(splitCount: Int): Array[AerospikePartition] = {
+    val totalPartitions = Aerospike.TotalAerospikePartitions
+    val partitionsPerSplit = totalPartitions / splitCount
+    val remainder = totalPartitions % splitCount
+
+    (0 until splitCount).map { i =>
+      val begin = i * partitionsPerSplit + math.min(i, remainder)
+      val count = partitionsPerSplit + (if (i < remainder) 1 else 0)
+      AerospikePartition(i, begin, count)
+    }.toArray
+  }
+}
+
+/** Aerospike RDD with at-least-once semantics: if a scan fails partway through and is retried,
+  * records already consumed before the failure may be re-scanned. The generation counter filters
+  * most duplicates from the queue, but records already yielded to Spark before the retry are not
+  * tracked. Downstream consumers should be idempotent or deduplicate by key.
+  */
+private[migrator] class AerospikeRDD(
+  sc: SparkContext,
+  connConfig: AerospikeConnectionConfig,
+  readConfig: AerospikeReadConfig,
+  broadcastCredentials: Broadcast[Option[(String, String)]],
+  broadcastBinNames: Broadcast[IndexedSeq[String]],
+  broadcastSchema: Broadcast[StructType],
+  recordsReadAccumulator: LongAccumulator
+) extends RDD[Row](sc, Nil) {
+
+  override def getPartitions: Array[Partition] =
+    AerospikeRDD.computePartitions(readConfig.splitCount).asInstanceOf[Array[Partition]]
+
+  override def compute(split: Partition, context: TaskContext): Iterator[Row] = {
+    val asPart = split.asInstanceOf[AerospikePartition]
+    val schema = broadcastSchema.value
+    val binNames = broadcastBinNames.value
+    // Prefer environment variables on executors to avoid relying on broadcast credentials
+    val credentials = Aerospike.resolveCredentialsFromEnvOr(broadcastCredentials.value)
+    val connectionKey = AerospikeConnectionKey.fromConfig(connConfig, credentials)
+    val client = AerospikeClientHolder.get(connectionKey, connConfig, credentials)
+    val scanPolicy = new ScanPolicy()
+    connConfig.socketTimeoutMs.foreach(t => scanPolicy.socketTimeout = t)
+    connConfig.totalTimeoutMs.foreach(t => scanPolicy.totalTimeout = t)
+
+    // Use a blocking queue to stream records from the scan callback to the iterator.
+    // The scan runs on a background thread and the iterator drains the queue.
+    // ScanComplete signals scan completion; ScanData carries data; ScanRetry unblocks the iterator.
+    // The generation counter allows the iterator to discard stale records from a
+    // previous scan attempt after a retry — preventing duplicate rows.
+    val queue = new LinkedBlockingQueue[ScanQueueEntry](readConfig.queueSize)
+    val scanError = new AtomicReference[Throwable](null)
+    val scanGeneration = new AtomicInteger(0)
+    // Cooperative cancellation flag: set by TaskCompletionListener so the scan thread
+    // stops enqueuing records when Spark's limit()/take() terminates the task early.
+    val cancelled = new AtomicBoolean(false)
+
+    val scanThread = new Thread(() =>
+      try {
+        val binOpt: Option[Seq[String]] = if (binNames.nonEmpty) Some(binNames) else None
+        var retryCount = 0
+        var scanDone = false
+        while (!scanDone) {
+          val gen = scanGeneration.get()
+          var loggedQueueFull = false
+          val callback = new ScanCallback {
+            override def scanCallback(key: Key, record: Record): Unit = {
+              if (cancelled.get() || Thread.currentThread().isInterrupted)
+                throw new ScanCancelledException
+              if (queue.remainingCapacity() == 0) {
+                if (!loggedQueueFull) {
+                  loggedQueueFull = true
+                  Aerospike.log.debug(
+                    s"Partition ${asPart.index}: scan queue full (size=${readConfig.queueSize}), " +
+                      "scan thread will block. Consider increasing 'queueSize' if this happens frequently."
+                  )
+                }
+              } else {
+                loggedQueueFull = false
+              }
+              queue.put(ScanData(gen, key, record))
+            }
+          }
+          // Create a fresh PartitionFilter for each attempt. PartitionFilter is stateful —
+          // it tracks which partitions have been scanned. Reusing it after a failed scan
+          // may skip partitions or re-scan them inconsistently.
+          val partitionFilter = PartitionFilter.range(asPart.partBegin, asPart.partCount)
+          try {
+            Aerospike.runScanPartitions(
+              client,
+              scanPolicy,
+              partitionFilter,
+              readConfig.namespace,
+              readConfig.set,
+              callback,
+              binOpt
+            )
+            scanDone = true
+          } catch {
+            case e: AerospikeException
+                if Aerospike.isRetryable(e) && retryCount < readConfig.maxScanRetries =>
+              retryCount += 1
+              Aerospike.log.warn(
+                s"Partition ${asPart.index}: retryable scan error (code ${e.getResultCode}), " +
+                  s"attempt $retryCount/${readConfig.maxScanRetries}",
+                e
+              )
+              // Advance generation so the iterator discards records from the failed scan,
+              // then clear the queue to make room for the retry's records.
+              val staleGen = scanGeneration.get()
+              scanGeneration.incrementAndGet()
+              queue.clear()
+              // Unblock the iterator thread if it's stuck in poll() — the stale-generation
+              // entry will be discarded by the generation filter.
+              queue.put(ScanRetry(staleGen))
+              // Exponential backoff: 2s, 4s, 8s with default maxScanRetries=3.
+              // Cap at 30s for users who configure higher retry counts.
+              val backoffMs = math.min(1000L * (1L << retryCount), 30000L)
+              Thread.sleep(backoffMs)
+          }
+        }
+      } catch {
+        case _: ScanCancelledException =>
+          // Expected on task cancellation (limit()/take()), don't log as error
+          Aerospike.log.debug(s"Partition ${asPart.index}: scan cancelled")
+        case _: InterruptedException if cancelled.get() =>
+          // Backoff sleep interrupted due to task cancellation — treat as normal shutdown
+          Aerospike.log.debug(s"Partition ${asPart.index}: scan interrupted during cancellation")
+        case e: Throwable =>
+          Aerospike.log.error(s"Partition ${asPart.index}: scan thread failed", e)
+          scanError.set(e)
+          e match {
+            case _: VirtualMachineError | _: ThreadDeath | _: LinkageError =>
+              // Fatal JVM error — re-throw so the uncaught exception handler can act.
+              // The error is also recorded in scanError for the iterator thread.
+              throw e
+            case _ => // non-fatal, recorded in scanError for the iterator to surface
+          }
+      } finally {
+        // Drain the queue on error so the sentinel can always be posted, preventing
+        // the scan thread from hanging when the iterator is not consuming records.
+        if (scanError.get() != null) queue.clear()
+        queue.put(ScanComplete)
+      }
+    )
+    scanThread.setName(s"aerospike-scan-p${asPart.index}")
+    scanThread.setDaemon(true)
+    scanThread.start()
+
+    context.addTaskCompletionListener[Unit] { _ =>
+      cancelled.set(true)
+      scanThread.interrupt()
+    }
+
+    val keyType =
+      schema.fields.find(_.name == Aerospike.KeyColumnName).map(_.dataType).getOrElse(StringType)
+    val fieldCount = schema.fields.length
+
+    new Iterator[Row] {
+      private var recordCount = 0L
+      private var localAccumulatorCount = 0L
+      // Fixed 100K interval; keeps log noise manageable for large datasets
+      private val LogInterval = 100000L
+      private val AccumulatorFlushInterval = 1000L
+      private var completionLogged = false
+      // Pre-allocate to avoid repeated Array construction; clone() on each row
+      // is still needed since Spark may retain references to returned Rows.
+      private val values = new Array[Any](fieldCount)
+
+      private val maxConsecutiveTimeouts = readConfig.maxPollRetries
+
+      private def pollQueue(): Option[(Key, Record)] = {
+        val currentGen = scanGeneration.get()
+        // Two-phase polling: try a short initial poll, then the remainder of the timeout.
+        // The early phase (capped at 10s) allows logging a "still waiting" message before
+        // the full timeout elapses. Only splits the timeout when > 20s to avoid degenerate cases.
+        val totalPollSeconds = readConfig.pollTimeoutSeconds.toLong
+        val earlyPollSeconds = if (totalPollSeconds > 20) 10L else totalPollSeconds
+        var consecutiveTimeouts = 0
+        while (true) {
+          val earlyResult = queue.poll(earlyPollSeconds, TimeUnit.SECONDS)
+          val raw = if (earlyResult == null && totalPollSeconds > earlyPollSeconds) {
+            Aerospike.log.info(
+              s"Partition ${asPart.index}: still waiting for scan records " +
+                s"(${totalPollSeconds}s timeout)"
+            )
+            queue.poll(totalPollSeconds - earlyPollSeconds, TimeUnit.SECONDS)
+          } else earlyResult
+          raw match {
+            case null =>
+              consecutiveTimeouts += 1
+              if (
+                consecutiveTimeouts >= maxConsecutiveTimeouts / 2 && consecutiveTimeouts < maxConsecutiveTimeouts
+              )
+                Aerospike.log.warn(
+                  s"Partition ${asPart.index}: $consecutiveTimeouts/$maxConsecutiveTimeouts consecutive poll timeouts " +
+                    s"(${consecutiveTimeouts * readConfig.pollTimeoutSeconds}s total). " +
+                    "Consider increasing 'pollTimeoutSeconds' or 'maxPollRetries' if the Aerospike scan is slow."
+                )
+              else
+                Aerospike.log.debug(
+                  s"Partition ${asPart.index}: poll timeout after ${readConfig.pollTimeoutSeconds}s, checking for errors " +
+                    s"(consecutive timeouts: $consecutiveTimeouts/$maxConsecutiveTimeouts)"
+                )
+              if (consecutiveTimeouts >= maxConsecutiveTimeouts)
+                throw new RuntimeException(
+                  s"Aerospike scan timed out: no records after ${consecutiveTimeouts * readConfig.pollTimeoutSeconds}s"
+                )
+              val ex = scanError.get()
+              if (ex != null)
+                throw new RuntimeException(
+                  s"Aerospike scan failed (${ex.getClass.getSimpleName}): ${ex.getMessage}",
+                  ex
+                )
+              if (!scanThread.isAlive) {
+                // Thread finished — try one final poll in case sentinel was just added
+                queue.poll() match {
+                  case null | ScanComplete =>
+                    throw new RuntimeException(
+                      "Aerospike scan thread died without signaling completion"
+                    )
+                  case ScanData(gen, key, record) if gen == currentGen =>
+                    return Some((key, record))
+                  case _ => // stale generation or retry sentinel, continue polling
+                }
+              }
+            case ScanComplete => return None // sentinel: scan complete
+            case ScanData(gen, key, record) if gen == currentGen =>
+              consecutiveTimeouts = 0
+              return Some((key, record))
+            case _ => // stale generation or retry sentinel, discard
+          }
+        }
+        None // unreachable — satisfies compiler
+      }
+
+      private var current: Option[(Key, Record)] = pollQueue()
+
+      override def hasNext: Boolean = {
+        if (current.isDefined) return true
+        val ex = scanError.get()
+        if (ex != null)
+          throw new RuntimeException(
+            s"Aerospike scan failed (${ex.getClass.getSimpleName}): ${ex.getMessage}",
+            ex
+          )
+        if (recordCount > 0 && !completionLogged) {
+          if (localAccumulatorCount > 0) {
+            recordsReadAccumulator.add(localAccumulatorCount)
+            localAccumulatorCount = 0
+          }
+          Aerospike.log.info(
+            s"Partition ${asPart.index}: completed, processed $recordCount records"
+          )
+          completionLogged = true
+        }
+        false
+      }
+
+      override def next(): Row = {
+        val (key, record) = current.get
+
+        var i = 0
+        while (i < fieldCount) {
+          val field = schema.fields(i)
+          values(i) =
+            if (field.name == Aerospike.KeyColumnName)
+              AerospikeTypes.extractKey(key, keyType)
+            else if (field.name == Aerospike.TtlColumnName) {
+              // Normalize: getTimeToLive() returns 0 for records without expiration in
+              // some Aerospike client versions. Use -1 consistently for "no expiration".
+              val ttl = record.getTimeToLive()
+              (if (ttl <= 0) -1 else ttl).asInstanceOf[Any]
+            } else if (field.name == Aerospike.GenerationColumnName)
+              record.generation.asInstanceOf[Any]
+            else
+              AerospikeTypes.convertValue(record.bins.get(field.name), field.dataType)
+          i += 1
+        }
+
+        recordCount += 1
+        localAccumulatorCount += 1
+        if (localAccumulatorCount >= AccumulatorFlushInterval) {
+          recordsReadAccumulator.add(localAccumulatorCount)
+          localAccumulatorCount = 0
+        }
+        if (recordCount % LogInterval == 0)
+          Aerospike.log.info(
+            s"Partition ${asPart.index}: processed $recordCount records"
+          )
+
+        current = pollQueue()
+        new GenericRow(values.clone())
+      }
+    }
+  }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/AerospikeTypes.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/AerospikeTypes.scala
@@ -1,0 +1,209 @@
+package com.scylladb.migrator.readers
+
+import org.apache.logging.log4j.LogManager
+import org.apache.spark.sql.types._
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters._
+
+/** Type inference, conversion, and schema helpers for the Aerospike reader. */
+object AerospikeTypes {
+  private val log = LogManager.getLogger("com.scylladb.migrator.readers.AerospikeTypes")
+
+  /** Track occurrence counts of unexpected types so we can log periodically rather than only once.
+    * Bounded in practice: entries correspond to distinct Java class names, which are finite for any
+    * given application.
+    */
+  private val warnedTypeCounts =
+    new ConcurrentHashMap[String, java.util.concurrent.atomic.AtomicLong]()
+
+  /** Interval at which repeated warnings are emitted for the same unrecognized type */
+  private val WarnInterval = 10000L
+
+  // The Aerospike Java client returns: Long, Double, String, byte[], List, Map.
+  // Values from CDTs (lists/maps) may also arrive as Integer or Float.
+  // Boolean may appear in CDTs or future client versions.
+  // GeoJSON values arrive as String from the client; HLL values arrive as byte[].
+  private[migrator] def inferSparkType(value: Any): DataType = value match {
+    case _: java.lang.Long    => LongType
+    case _: java.lang.Integer => LongType
+    case _: java.lang.Double  => DoubleType
+    case _: java.lang.Float   => DoubleType
+    case _: java.lang.Boolean => BooleanType
+    case _: String            => StringType // also covers GeoJSON (arrives as JSON string)
+    case _: Array[Byte]       => BinaryType // also covers HLL (arrives as raw bytes)
+    case v: java.util.List[_] => ArrayType(inferCommonType(v.asScala), containsNull = true)
+    case v: java.util.Map[_, _] =>
+      MapType(
+        inferCommonType(v.asScala.keys),
+        inferCommonType(v.asScala.values),
+        valueContainsNull = true
+      )
+    case other =>
+      log.debug(
+        s"inferSparkType: unrecognized type ${other.getClass.getName}, defaulting to StringType"
+      )
+      StringType
+  }
+
+  /** Infer a single common type from a collection of values. Falls back to StringType on mixed
+    * types. Short-circuits after finding 2 distinct types to avoid scanning large CDTs.
+    */
+  private def inferCommonType(values: Iterable[_]): DataType = {
+    var first: DataType = null
+    val iter = values.iterator
+    while (iter.hasNext) {
+      val v = iter.next()
+      if (v != null) {
+        val t = inferSparkType(v)
+        if (first == null) first = t
+        else if (first != t) return StringType // heterogeneous -> short-circuit
+      }
+    }
+    if (first == null) StringType // empty -> String
+    else first
+  }
+
+  /** Merge two types discovered across different records. Supports numeric widening (Long ->
+    * Double) and recursive collection merging. Falls back to StringType for incompatible types.
+    */
+  private[migrator] def mergeTypes(a: DataType, b: DataType): DataType = (a, b) match {
+    case (x, y) if x == y                                => x
+    case (LongType, DoubleType) | (DoubleType, LongType) => DoubleType
+    case (ArrayType(et1, n1), ArrayType(et2, n2)) =>
+      ArrayType(mergeTypes(et1, et2), n1 || n2)
+    case (MapType(kt1, vt1, n1), MapType(kt2, vt2, n2)) =>
+      MapType(mergeTypes(kt1, kt2), mergeTypes(vt1, vt2), n1 || n2)
+    case _ => StringType
+  }
+
+  /** Convert an Aerospike value to a Spark-compatible value, coercing to match the expected type.
+    */
+  private[migrator] def convertValue(value: Any, expectedType: DataType): Any = value match {
+    case null => null
+    // Collection types first (most specific)
+    case v: java.util.List[_] =>
+      expectedType match {
+        case ArrayType(et, _) =>
+          v.asScala.map(e => convertValue(e, et)).toSeq
+        case _ =>
+          // Serialize collection to string for non-array target types (e.g., StringType)
+          v.toString
+      }
+    case v: java.util.Map[_, _] =>
+      expectedType match {
+        case MapType(k, vt, _) =>
+          v.asScala.map { case (mk, mv) => convertValue(mk, k) -> convertValue(mv, vt) }.toMap
+        case _ =>
+          // Serialize collection to string for non-map target types (e.g., StringType)
+          v.toString
+      }
+    // Primitive types — handle StringType and DoubleType coercion inline
+    case v: Array[Byte] =>
+      if (expectedType == StringType) hexFormat.formatHex(v) else v
+    case v: java.lang.Integer =>
+      expectedType match {
+        case StringType => v.toString
+        case DoubleType => java.lang.Double.valueOf(v.doubleValue())
+        case _          => java.lang.Long.valueOf(v.longValue())
+      }
+    case v: java.lang.Float =>
+      if (expectedType == StringType) v.toString
+      else java.lang.Double.valueOf(v.doubleValue())
+    case v: java.lang.Long =>
+      expectedType match {
+        case StringType => v.toString
+        case DoubleType => java.lang.Double.valueOf(v.doubleValue())
+        case _          => v
+      }
+    case v: java.lang.Double =>
+      if (expectedType == StringType) v.toString else v
+    case v: String => v
+    case v: java.lang.Boolean =>
+      if (expectedType == BooleanType) v else v.toString
+    // Catch-all: coerce anything else to String. Warn on first occurrence and then
+    // periodically (every 10,000 occurrences) per type to surface ongoing degradation.
+    case v =>
+      val typeName = v.getClass.getName
+      val counter = warnedTypeCounts.computeIfAbsent(
+        typeName,
+        _ => new java.util.concurrent.atomic.AtomicLong(0)
+      )
+      val count = counter.incrementAndGet()
+      if (count == 1 || count % WarnInterval == 0)
+        log.warn(
+          s"convertValue: unexpected type $typeName for expected $expectedType, " +
+            s"coercing to String ($count occurrences so far)"
+        )
+      v.toString
+  }
+
+  /** Clear rate-limited warning state. Intended for tests to prevent state leaking across suites.
+    */
+  private[migrator] def reset(): Unit = warnedTypeCounts.clear()
+
+  /** Fail fast on the driver if JDK < 17, before submitting any Spark tasks. */
+  private[migrator] def requireJdk17(): Unit = { val _ = hexFormat }
+
+  private lazy val hexFormat =
+    try java.util.HexFormat.of()
+    catch {
+      case _: NoSuchMethodError | _: NoClassDefFoundError =>
+        throw new UnsupportedOperationException(
+          "Aerospike source requires JDK 17+. java.util.HexFormat is not available on this JVM " +
+            s"(running ${System.getProperty("java.version")}). Please upgrade your JDK."
+        )
+    }
+
+  /** Extract the key value for the aero_key column, typed according to the schema */
+  private[migrator] def extractKey(key: com.aerospike.client.Key, keyType: DataType): Any =
+    if (key.userKey != null) {
+      keyType match {
+        case StringType => key.userKey.toString
+        case _          => key.userKey.getObject
+      }
+    } else hexFormat.formatHex(key.digest)
+
+  /** Parse a user-provided type name into a Spark DataType. Supports scalar types (string, long,
+    * double, binary) and collection types (list<T>, map<K,V>). Collection types can be nested,
+    * e.g., list<map<string,long>>.
+    */
+  private[migrator] def parseType(typeName: String): DataType = {
+    val lower = typeName.toLowerCase.trim
+    lower match {
+      case "string" | "text"  => StringType
+      case "long" | "bigint"  => LongType
+      case "int" | "integer"  => LongType // Aerospike stores all integers as Long
+      case "double"           => DoubleType
+      case "boolean" | "bool" => BooleanType
+      case "binary" | "blob"  => BinaryType
+      case s if s.startsWith("list<") && s.endsWith(">") =>
+        val inner = s.substring(5, s.length - 1)
+        ArrayType(parseType(inner), containsNull = true)
+      case s if s.startsWith("map<") && s.endsWith(">") =>
+        val inner = s.substring(4, s.length - 1)
+        val (keyType, valueType) = splitMapTypes(inner)
+        MapType(parseType(keyType), parseType(valueType), valueContainsNull = true)
+      case other =>
+        throw new IllegalArgumentException(s"Unknown type in schema override: $other")
+    }
+  }
+
+  /** Split a map type's inner specification (e.g., "string,long") into key and value type strings.
+    * Handles nested generics by tracking angle bracket depth.
+    */
+  private def splitMapTypes(inner: String): (String, String) = {
+    var depth = 0
+    for (i <- inner.indices)
+      inner(i) match {
+        case '<' => depth += 1
+        case '>' => depth -= 1
+        case ',' if depth == 0 =>
+          return (inner.substring(0, i).trim, inner.substring(i + 1).trim)
+        case _ =>
+      }
+    throw new IllegalArgumentException(
+      s"Invalid map type specification: 'map<$inner>'. Expected format: map<keyType,valueType>"
+    )
+  }
+}

--- a/tests/docker/aerospike/aerospike.conf
+++ b/tests/docker/aerospike/aerospike.conf
@@ -1,0 +1,35 @@
+service {
+  proto-fd-max 1024
+}
+
+logging {
+  console {
+    context any info
+  }
+}
+
+network {
+  service {
+    address any
+    port 3000
+  }
+
+  heartbeat {
+    mode mesh
+    port 3002
+  }
+
+  fabric {
+    port 3001
+  }
+}
+
+namespace test {
+  replication-factor 1
+  default-ttl 0
+  nsup-period 10
+
+  storage-engine memory {
+    data-size 1G
+  }
+}

--- a/tests/src/test/configurations/aerospike-to-scylla-basic.yaml
+++ b/tests/src/test/configurations/aerospike-to-scylla-basic.yaml
@@ -1,0 +1,25 @@
+# Set name must match BasicSetName in BasicMigrationTest.scala
+source:
+  type: aerospike
+  hosts:
+    - aerospike
+  namespace: test
+  set: basictest
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: basictest
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/aerospike-to-scylla-bins-filter.yaml
+++ b/tests/src/test/configurations/aerospike-to-scylla-bins-filter.yaml
@@ -1,0 +1,27 @@
+# Set name must match BinsFilterSetName in BasicMigrationTest.scala
+source:
+  type: aerospike
+  hosts:
+    - aerospike
+  namespace: test
+  set: binsfilter
+  bins:
+    - foo
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: binsfilter
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/aerospike-to-scylla-bins-schema.yaml
+++ b/tests/src/test/configurations/aerospike-to-scylla-bins-schema.yaml
@@ -1,0 +1,29 @@
+# Set name must match BinsSchemaSetName in BasicMigrationTest.scala
+source:
+  type: aerospike
+  hosts:
+    - aerospike
+  namespace: test
+  set: binsschema
+  bins:
+    - foo
+  schema:
+    foo: string
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: binsschema
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/aerospike-to-scylla-metadata.yaml
+++ b/tests/src/test/configurations/aerospike-to-scylla-metadata.yaml
@@ -1,0 +1,27 @@
+# Set name must match MetadataSetName in BasicMigrationTest.scala
+source:
+  type: aerospike
+  hosts:
+    - aerospike
+  namespace: test
+  set: metatest
+  preserveTTL: true
+  preserveGeneration: true
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: metatest
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/aerospike-to-scylla-sample-size.yaml
+++ b/tests/src/test/configurations/aerospike-to-scylla-sample-size.yaml
@@ -1,0 +1,27 @@
+# Set name must match BasicSetName in BasicMigrationTest.scala
+# Tests schemaSampleSize override (item #19)
+source:
+  type: aerospike
+  hosts:
+    - aerospike
+  namespace: test
+  set: basictest
+  schemaSampleSize: 1
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: basictest
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/aerospike-to-scylla-schema-override.yaml
+++ b/tests/src/test/configurations/aerospike-to-scylla-schema-override.yaml
@@ -1,0 +1,28 @@
+# Set name must match SchemaSetName in BasicMigrationTest.scala
+source:
+  type: aerospike
+  hosts:
+    - aerospike
+  namespace: test
+  set: schematest
+  schema:
+    foo: string
+    bar: long
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: schematest
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/bench-e2e-aerospike-to-scylla.yaml
+++ b/tests/src/test/configurations/bench-e2e-aerospike-to-scylla.yaml
@@ -1,0 +1,24 @@
+source:
+  type: aerospike
+  hosts:
+    - aerospike
+  namespace: test
+  set: bench_e2e_aerospike
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: bench_e2e_aerospike
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/scala/com/scylladb/migrator/aerospike/AerospikeBenchmarkDataGenerator.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/aerospike/AerospikeBenchmarkDataGenerator.scala
@@ -1,0 +1,118 @@
+package com.scylladb.migrator.aerospike
+
+import com.aerospike.client.{ AerospikeClient, Bin, Key }
+import com.aerospike.client.policy.WritePolicy
+
+import org.apache.logging.log4j.LogManager
+
+import java.util.concurrent.{ LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit }
+import java.util.concurrent.atomic.{ AtomicLong, AtomicReference }
+
+/** Generates test data in Aerospike for throughput benchmarks. */
+object AerospikeBenchmarkDataGenerator {
+
+  private val log = LogManager.getLogger(getClass)
+
+  /** Sample indices for spot-checking benchmark rows: first, 25%, 50%, last. */
+  def sampleIndices(rowCount: Int): Seq[Int] =
+    if (rowCount <= 0) Seq.empty
+    else Seq(0, rowCount / 4, rowCount / 2, rowCount - 1).distinct.filter(_ >= 0)
+
+  /** Insert rows concurrently using a thread pool.
+    *
+    * Each record has: key=id-N, col1=value-N (String), col2=N (Long), col3=N*1000 (Long)
+    *
+    * For single-node test setups, records are immediately available after this method returns. For
+    * multi-node clusters, add a post-insert verification step (e.g., `client.exists()` on the last
+    * key) to ensure replication has completed.
+    *
+    * @param client
+    *   Aerospike client (thread-safe)
+    * @param namespace
+    *   Aerospike namespace
+    * @param set
+    *   Aerospike set name
+    * @param rowCount
+    *   number of rows to insert
+    * @param maxConcurrent
+    *   max in-flight insert operations
+    */
+  def insertSimpleRows(
+    client: AerospikeClient,
+    namespace: String,
+    set: String,
+    rowCount: Int,
+    maxConcurrent: Int = 64
+  ): Unit = {
+    val policy = new WritePolicy()
+    policy.sendKey = true
+
+    // Bounded queue with CallerRunsPolicy provides backpressure: when the queue is full,
+    // the submitting thread runs the task itself, throttling submission rate.
+    val executor = new ThreadPoolExecutor(
+      maxConcurrent,
+      maxConcurrent,
+      0L,
+      TimeUnit.MILLISECONDS,
+      new LinkedBlockingQueue[Runnable](maxConcurrent * 2),
+      new ThreadPoolExecutor.CallerRunsPolicy()
+    )
+    val firstError = new AtomicReference[Throwable](null)
+    val completed = new AtomicLong(0)
+    val startTime = System.currentTimeMillis()
+
+    try
+      for (i <- 0 until rowCount) {
+        firstError.get() match {
+          case null => // no error yet
+          case ex   => throw new RuntimeException("Insert failed", ex)
+        }
+        executor.execute(() =>
+          try {
+            val key = new Key(namespace, set, s"id-$i")
+            client.put(
+              policy,
+              key,
+              new Bin("col1", s"value-$i"),
+              new Bin("col2", i.toLong),
+              new Bin("col3", i.toLong * 1000L)
+            )
+            val done = completed.incrementAndGet()
+            if (done % 100000 == 0) {
+              val elapsedSec = (System.currentTimeMillis() - startTime) / 1000.0
+              val rate = done / elapsedSec
+              log.info(f"Inserted $done%,d / $rowCount%,d rows ($rate%.0f rows/sec)")
+            }
+          } catch {
+            case e: Throwable =>
+              if (!firstError.compareAndSet(null, e)) {
+                // Another error was already recorded — add this one as suppressed
+                val existing = firstError.get()
+                if (existing != null) existing.addSuppressed(e)
+              }
+          }
+        )
+      }
+    finally {
+      executor.shutdown()
+      try
+        if (!executor.awaitTermination(5, TimeUnit.MINUTES)) {
+          log.warn("AerospikeBenchmarkDataGenerator executor did not terminate within 5 minutes")
+          executor.shutdownNow()
+        }
+      catch {
+        case _: InterruptedException =>
+          Thread.currentThread().interrupt()
+          executor.shutdownNow()
+      }
+    }
+    firstError.get() match {
+      case null => // success
+        assert(
+          completed.get() == rowCount.toLong,
+          s"Expected $rowCount rows, inserted ${completed.get()}"
+        )
+      case ex => throw new RuntimeException("Insert failed", ex)
+    }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/aerospike/AerospikeToScyllaE2EBenchmark.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/aerospike/AerospikeToScyllaE2EBenchmark.scala
@@ -1,0 +1,106 @@
+package com.scylladb.migrator.aerospike
+
+import com.datastax.oss.driver.api.core.`type`.DataTypes
+import com.datastax.oss.driver.api.querybuilder.{ QueryBuilder, SchemaBuilder }
+import com.scylladb.migrator.{ E2E, Integration, SparkUtils, ThroughputReporter }
+import org.apache.logging.log4j.LogManager
+import org.junit.experimental.categories.Category
+
+import scala.concurrent.duration._
+
+/** End-to-end throughput benchmark for Aerospike-to-Scylla migration.
+  *
+  * Source: Aerospike (port 3000) Target: ScyllaDB (port 9042)
+  *
+  * Row count is configurable via `-De2e.aerospike.rows=N` (default: 5000000).
+  *
+  * Currently only exercises String and Long columns. A future enhancement could add Double, Binary,
+  * List, and Map columns for more comprehensive conversion benchmarking.
+  *
+  * Note: This benchmark is excluded from CI (E2E category). Run locally with:
+  * {{{make test-benchmark-e2e-aerospike-scylla}}}
+  */
+@Category(Array(classOf[Integration], classOf[E2E]))
+class AerospikeToScyllaE2EBenchmark extends MigratorSuite {
+
+  override val munitTimeout: Duration = 60.minutes
+
+  private val rowCount: Int = sys.props
+    .get("e2e.aerospike.rows")
+    .getOrElse("5000000")
+    .toIntOption
+    .getOrElse(throw new IllegalArgumentException("e2e.aerospike.rows must be a valid integer"))
+
+  private val setName = "bench_e2e_aerospike"
+  private val configFile = "bench-e2e-aerospike-to-scylla.yaml"
+
+  test(s"Aerospike->Scylla ${rowCount} rows") {
+    // Truncate source Aerospike set
+    try
+      sourceAerospike()
+        .truncate(new com.aerospike.client.policy.InfoPolicy(), aerospikeNamespace, setName, null)
+    catch { case _: Exception => () }
+    waitForTruncate(setName)
+
+    // Insert test data into Aerospike
+    AerospikeBenchmarkDataGenerator
+      .insertSimpleRows(sourceAerospike(), aerospikeNamespace, setName, rowCount)
+
+    // Create target Scylla table (Aerospike integers are all Long → BIGINT)
+    val dropStmt = SchemaBuilder.dropTable(keyspace, setName).ifExists().build()
+    targetScylla().execute(dropStmt)
+
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("col1", DataTypes.TEXT)
+      .withColumn("col2", DataTypes.BIGINT)
+      .withColumn("col3", DataTypes.BIGINT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    try {
+      val startTime = System.currentTimeMillis()
+      SparkUtils.successfullyPerformMigration(configFile)
+      val durationMs = System.currentTimeMillis() - startTime
+
+      // Verify row count
+      val countStmt = QueryBuilder
+        .selectFrom(keyspace, setName)
+        .countAll()
+        .build()
+        .setTimeout(java.time.Duration.ofMinutes(5))
+      val targetRowCount = targetScylla().execute(countStmt).one().getLong(0)
+      assertEquals(targetRowCount, rowCount.toLong, "Row count mismatch")
+
+      // Spot-check a few rows
+      val sampleIndices = AerospikeBenchmarkDataGenerator.sampleIndices(rowCount)
+      val prepared = targetScylla().prepare(
+        s"SELECT aero_key, col1, col2, col3 FROM $keyspace.$setName WHERE aero_key = ?"
+      )
+      for (i <- sampleIndices) {
+        val row = targetScylla().execute(prepared.bind(s"id-$i")).one()
+        assert(row != null, s"Spot-check: row id-$i not found in target")
+        assertEquals(row.getString("col1"), s"value-$i", s"Spot-check: col1 mismatch for id-$i")
+        assertEquals(row.getLong("col2"), i.toLong, s"Spot-check: col2 mismatch for id-$i")
+        assertEquals(
+          row.getLong("col3"),
+          i.toLong * 1000L,
+          s"Spot-check: col3 mismatch for id-$i"
+        )
+      }
+
+      ThroughputReporter.report(s"aerospike-to-scylla-${rowCount}", rowCount.toLong, durationMs)
+    } finally {
+      try targetScylla().execute(dropStmt)
+      catch {
+        case e: Exception =>
+          LogManager.getLogger(getClass).warn("Cleanup: drop table failed", e)
+      }
+      try
+        sourceAerospike()
+          .truncate(new com.aerospike.client.policy.InfoPolicy(), aerospikeNamespace, setName, null)
+      catch { case _: Exception => () }
+    }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/aerospike/BasicMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/aerospike/BasicMigrationTest.scala
@@ -1,0 +1,517 @@
+package com.scylladb.migrator.aerospike
+
+import com.aerospike.client.{ Bin, Key }
+import com.aerospike.client.policy.WritePolicy
+import com.datastax.oss.driver.api.core.`type`.DataTypes
+import com.datastax.oss.driver.api.querybuilder.{ QueryBuilder, SchemaBuilder }
+import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
+
+import scala.jdk.CollectionConverters._
+import scala.util.chaining._
+
+class BasicMigrationTest extends MigratorSuite {
+
+  // Set names per config file group — must match the 'set' and 'table' values in the
+  // corresponding YAML configs under tests/src/test/configurations/aerospike-to-scylla-*.yaml.
+  // Multiple tests sharing the same set name is safe because: (1) parallelExecution := false
+  // ensures sequential execution, and (2) withSet() truncates the set and calls waitForTruncate()
+  // which polls until the async Aerospike truncation completes before each test.
+  private val BasicSetName = "basictest" // -> aerospike-to-scylla-basic.yaml
+  private val BinsFilterSetName = "binsfilter" // -> aerospike-to-scylla-bins-filter.yaml
+  private val SchemaSetName = "schematest" // -> aerospike-to-scylla-schema-override.yaml
+  private val BinsSchemaSetName = "binsschema" // -> aerospike-to-scylla-bins-schema.yaml
+  private val MetadataSetName = "metatest" // -> aerospike-to-scylla-metadata.yaml
+
+  withSet(BasicSetName).test("Aerospike: basic migration to Scylla") { setName =>
+    // Create target table in Scylla matching the discovered Aerospike schema.
+    // Aerospike returns all integers as Long, so we use BIGINT.
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("foo", DataTypes.TEXT)
+      .withColumn("bar", DataTypes.BIGINT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    // Insert data into Aerospike
+    val key = new Key(aerospikeNamespace, setName, "12345")
+    val policy = new WritePolicy()
+    policy.sendKey = true
+    retryPut(
+      policy,
+      key,
+      new Bin("foo", "hello"),
+      new Bin("bar", 42)
+    )
+
+    // Run migration
+    successfullyPerformMigration("aerospike-to-scylla-basic.yaml")
+
+    // Verify in Scylla
+    val selectStmt = QueryBuilder.selectFrom(keyspace, setName).all().build()
+    targetScylla().execute(selectStmt).tap { resultSet =>
+      val rows = resultSet.all().asScala
+      assertEquals(rows.size, 1)
+      val row = rows.head
+      assertEquals(row.getString("aero_key"), "12345")
+      assertEquals(row.getString("foo"), "hello")
+      assertEquals(row.getLong("bar"), 42L)
+    }
+  }
+
+  withSet(BasicSetName).test("Aerospike: migration with multiple records") { setName =>
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("name", DataTypes.TEXT)
+      .withColumn("age", DataTypes.BIGINT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    val policy = new WritePolicy()
+    policy.sendKey = true
+
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "user1"),
+      new Bin("name", "Alice"),
+      new Bin("age", 30)
+    )
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "user2"),
+      new Bin("name", "Bob"),
+      new Bin("age", 25)
+    )
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "user3"),
+      new Bin("name", "Charlie"),
+      new Bin("age", 35)
+    )
+
+    successfullyPerformMigration("aerospike-to-scylla-basic.yaml")
+
+    val selectStmt = QueryBuilder.selectFrom(keyspace, setName).all().build()
+    targetScylla().execute(selectStmt).tap { resultSet =>
+      val rows = resultSet.all().asScala
+      assertEquals(rows.size, 3)
+
+      val rowMap = rows.map(r => r.getString("aero_key") -> r).toMap
+      assertEquals(rowMap("user1").getString("name"), "Alice")
+      assertEquals(rowMap("user1").getLong("age"), 30L)
+      assertEquals(rowMap("user2").getString("name"), "Bob")
+      assertEquals(rowMap("user2").getLong("age"), 25L)
+      assertEquals(rowMap("user3").getString("name"), "Charlie")
+      assertEquals(rowMap("user3").getLong("age"), 35L)
+    }
+  }
+
+  withSet(BinsFilterSetName).test("Aerospike: migration with bins filter") { setName =>
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("foo", DataTypes.TEXT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    val policy = new WritePolicy()
+    policy.sendKey = true
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "key1"),
+      new Bin("foo", "included"),
+      new Bin("bar", 99)
+    )
+
+    successfullyPerformMigration("aerospike-to-scylla-bins-filter.yaml")
+
+    val rows = targetScylla()
+      .execute(
+        QueryBuilder.selectFrom(keyspace, setName).all().build()
+      )
+      .all()
+      .asScala
+    assertEquals(rows.size, 1)
+    assertEquals(rows.head.getString("foo"), "included")
+    assertEquals(rows.head.getColumnDefinitions.contains("bar"), false)
+  }
+
+  withSet(BasicSetName).test("Aerospike: migration with digest key (sendKey=false)") { setName =>
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("val", DataTypes.TEXT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    val policy = new WritePolicy() // sendKey defaults to false
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "invisible-key"),
+      new Bin("val", "data")
+    )
+
+    successfullyPerformMigration("aerospike-to-scylla-basic.yaml")
+
+    val rows = targetScylla()
+      .execute(
+        QueryBuilder.selectFrom(keyspace, setName).all().build()
+      )
+      .all()
+      .asScala
+    assertEquals(rows.size, 1)
+    val aeroKey = rows.head.getString("aero_key")
+    assert(aeroKey != "invisible-key", "Expected digest key, got userKey")
+    assert(aeroKey.matches("[0-9a-f]+"), s"Expected hex digest, got: $aeroKey")
+  }
+
+  withSet(BasicSetName).test("Aerospike: type conflict falls back to StringType") { setName =>
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("data", DataTypes.TEXT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    val policy = new WritePolicy()
+    policy.sendKey = true
+
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "row1"),
+      new Bin("data", 42L)
+    )
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "row2"),
+      new Bin("data", "hello")
+    )
+
+    successfullyPerformMigration("aerospike-to-scylla-basic.yaml")
+
+    val rows = targetScylla()
+      .execute(
+        QueryBuilder.selectFrom(keyspace, setName).all().build()
+      )
+      .all()
+      .asScala
+    assertEquals(rows.size, 2)
+    val rowMap = rows.map(r => r.getString("aero_key") -> r.getString("data")).toMap
+    assertEquals(rowMap("row1"), "42")
+    assertEquals(rowMap("row2"), "hello")
+  }
+
+  withSet(SchemaSetName).test(
+    "Aerospike: migration with explicit schema override (no discovery)"
+  ) { setName =>
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("foo", DataTypes.TEXT)
+      .withColumn("bar", DataTypes.BIGINT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    val policy = new WritePolicy()
+    policy.sendKey = true
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "key1"),
+      new Bin("foo", "hello"),
+      new Bin("bar", 42)
+    )
+
+    successfullyPerformMigration("aerospike-to-scylla-schema-override.yaml")
+
+    val rows = targetScylla()
+      .execute(QueryBuilder.selectFrom(keyspace, setName).all().build())
+      .all()
+      .asScala
+    assertEquals(rows.size, 1)
+    assertEquals(rows.head.getString("aero_key"), "key1")
+    assertEquals(rows.head.getString("foo"), "hello")
+    assertEquals(rows.head.getLong("bar"), 42L)
+  }
+
+  withSet(BinsSchemaSetName).test(
+    "Aerospike: migration with both bins filter and schema override"
+  ) { setName =>
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("foo", DataTypes.TEXT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    val policy = new WritePolicy()
+    policy.sendKey = true
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "key1"),
+      new Bin("foo", "included"),
+      new Bin("bar", 42),
+      new Bin("baz", "excluded")
+    )
+
+    successfullyPerformMigration("aerospike-to-scylla-bins-schema.yaml")
+
+    val rows = targetScylla()
+      .execute(QueryBuilder.selectFrom(keyspace, setName).all().build())
+      .all()
+      .asScala
+    assertEquals(rows.size, 1)
+    assertEquals(rows.head.getString("aero_key"), "key1")
+    assertEquals(rows.head.getString("foo"), "included")
+    assertEquals(rows.head.getColumnDefinitions.contains("bar"), false)
+    assertEquals(rows.head.getColumnDefinitions.contains("baz"), false)
+  }
+
+  withSet(MetadataSetName).test("Aerospike: migration preserves TTL") { setName =>
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("val", DataTypes.TEXT)
+      .withColumn("aero_ttl", DataTypes.INT)
+      .withColumn("aero_generation", DataTypes.INT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    val policy = new WritePolicy()
+    policy.sendKey    = true
+    policy.expiration = 3600 // 1 hour TTL
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "ttl-key"),
+      new Bin("val", "with-ttl")
+    )
+
+    successfullyPerformMigration("aerospike-to-scylla-metadata.yaml")
+
+    val rows = targetScylla()
+      .execute(QueryBuilder.selectFrom(keyspace, setName).all().build())
+      .all()
+      .asScala
+    assertEquals(rows.size, 1)
+    assertEquals(rows.head.getString("aero_key"), "ttl-key")
+    assertEquals(rows.head.getString("val"), "with-ttl")
+    // TTL should be a positive value less than or equal to 3600 (may have ticked down slightly)
+    val ttl = rows.head.getInt("aero_ttl")
+    assert(ttl > 0 && ttl <= 3600, s"Expected TTL in (0, 3600], got: $ttl")
+    // Generation should be 1 for a freshly written record
+    val gen = rows.head.getInt("aero_generation")
+    assertEquals(gen, 1)
+  }
+
+  withSet(MetadataSetName).test("Aerospike: TTL is -1 for records with no expiration") { setName =>
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("val", DataTypes.TEXT)
+      .withColumn("aero_ttl", DataTypes.INT)
+      .withColumn("aero_generation", DataTypes.INT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    val policy = new WritePolicy()
+    policy.sendKey = true
+    // Default expiration = 0 means use namespace default; for test namespace this is no expiration
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "no-ttl"),
+      new Bin("val", "forever")
+    )
+
+    successfullyPerformMigration("aerospike-to-scylla-metadata.yaml")
+
+    val rows = targetScylla()
+      .execute(QueryBuilder.selectFrom(keyspace, setName).all().build())
+      .all()
+      .asScala
+    assertEquals(rows.size, 1)
+    val ttl = rows.head.getInt("aero_ttl")
+    assertEquals(ttl, -1, "Records with no expiration should have TTL = -1")
+  }
+
+  withSet(BasicSetName).test("Aerospike: migration with list and map bins") { setName =>
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("tags", DataTypes.frozenListOf(DataTypes.TEXT))
+      .withColumn("attrs", DataTypes.frozenMapOf(DataTypes.TEXT, DataTypes.TEXT))
+      .build()
+    targetScylla().execute(createStmt)
+
+    val policy = new WritePolicy()
+    policy.sendKey = true
+
+    val tags = java.util.Arrays.asList("a", "b", "c")
+    val attrs = new java.util.HashMap[String, String]()
+    attrs.put("color", "red")
+
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "key1"),
+      new Bin("tags", tags),
+      new Bin("attrs", attrs)
+    )
+
+    successfullyPerformMigration("aerospike-to-scylla-basic.yaml")
+
+    val rows = targetScylla()
+      .execute(QueryBuilder.selectFrom(keyspace, setName).all().build())
+      .all()
+      .asScala
+    assertEquals(rows.size, 1)
+    assertEquals(rows.head.getList("tags", classOf[String]).asScala.toList, List("a", "b", "c"))
+    assertEquals(
+      rows.head.getMap("attrs", classOf[String], classOf[String]).asScala.toMap,
+      Map("color" -> "red")
+    )
+  }
+
+  withSet(BasicSetName).test("Aerospike: migration with Long key type") { setName =>
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.BIGINT)
+      .withColumn("val", DataTypes.TEXT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    val policy = new WritePolicy()
+    policy.sendKey = true
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, 12345L),
+      new Bin("val", "data")
+    )
+
+    successfullyPerformMigration("aerospike-to-scylla-basic.yaml")
+
+    val rows = targetScylla()
+      .execute(QueryBuilder.selectFrom(keyspace, setName).all().build())
+      .all()
+      .asScala
+    assertEquals(rows.size, 1)
+    assertEquals(rows.head.getLong("aero_key"), 12345L)
+    assertEquals(rows.head.getString("val"), "data")
+  }
+
+  withSet(MetadataSetName).test("Aerospike: generation increments on update") { setName =>
+    // Table must include aero_ttl because the metadata config has preserveTTL: true
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("val", DataTypes.TEXT)
+      .withColumn("aero_ttl", DataTypes.INT)
+      .withColumn("aero_generation", DataTypes.INT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    val policy = new WritePolicy()
+    policy.sendKey = true
+    val key = new Key(aerospikeNamespace, setName, "gen-key")
+    // Write twice to increment generation
+    retryPut(policy, key, new Bin("val", "v1"))
+    retryPut(policy, key, new Bin("val", "v2"))
+
+    successfullyPerformMigration("aerospike-to-scylla-metadata.yaml")
+
+    val rows = targetScylla()
+      .execute(QueryBuilder.selectFrom(keyspace, setName).all().build())
+      .all()
+      .asScala
+    assertEquals(rows.size, 1)
+    assertEquals(rows.head.getString("val"), "v2")
+    val gen = rows.head.getInt("aero_generation")
+    assertEquals(gen, 2, "Generation should be 2 after two writes")
+  }
+
+  withSet(BasicSetName).test("Aerospike: migration with schemaSampleSize=1") { setName =>
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("foo", DataTypes.TEXT)
+      .withColumn("bar", DataTypes.BIGINT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    val policy = new WritePolicy()
+    policy.sendKey = true
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "key1"),
+      new Bin("foo", "hello"),
+      new Bin("bar", 42)
+    )
+
+    // schemaSampleSize=1 limits schema discovery to a single record — should still work
+    successfullyPerformMigration("aerospike-to-scylla-sample-size.yaml")
+
+    val rows = targetScylla()
+      .execute(QueryBuilder.selectFrom(keyspace, setName).all().build())
+      .all()
+      .asScala
+    assertEquals(rows.size, 1)
+    assertEquals(rows.head.getString("aero_key"), "key1")
+  }
+
+  withSet(BasicSetName).test("Aerospike: migration handles null/missing bins") { setName =>
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .withColumn("foo", DataTypes.TEXT)
+      .withColumn("bar", DataTypes.BIGINT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    val policy = new WritePolicy()
+    policy.sendKey = true
+
+    // First record has both bins
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "full"),
+      new Bin("foo", "hello"),
+      new Bin("bar", 42)
+    )
+    // Second record is missing "bar" — will be null after migration
+    retryPut(
+      policy,
+      new Key(aerospikeNamespace, setName, "partial"),
+      new Bin("foo", "world")
+    )
+
+    successfullyPerformMigration("aerospike-to-scylla-basic.yaml")
+
+    val rows = targetScylla()
+      .execute(QueryBuilder.selectFrom(keyspace, setName).all().build())
+      .all()
+      .asScala
+    assertEquals(rows.size, 2)
+    val rowMap = rows.map(r => r.getString("aero_key") -> r).toMap
+    assertEquals(rowMap("full").getString("foo"), "hello")
+    assertEquals(rowMap("full").getLong("bar"), 42L)
+    assertEquals(rowMap("partial").getString("foo"), "world")
+    assert(rowMap("partial").isNull("bar"), "Expected null for missing bin 'bar'")
+  }
+
+  withSet(BasicSetName).test("Aerospike: migration of empty set produces zero rows") { setName =>
+    // Create target table with explicit schema since auto-discovery finds no bins
+    val createStmt = SchemaBuilder
+      .createTable(keyspace, setName)
+      .withPartitionKey("aero_key", DataTypes.TEXT)
+      .build()
+    targetScylla().execute(createStmt)
+
+    // No data inserted — set is empty
+    successfullyPerformMigration("aerospike-to-scylla-basic.yaml")
+
+    val rows = targetScylla()
+      .execute(QueryBuilder.selectFrom(keyspace, setName).all().build())
+      .all()
+      .asScala
+    assertEquals(rows.size, 0)
+  }
+
+}

--- a/tests/src/test/scala/com/scylladb/migrator/aerospike/MigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/aerospike/MigratorSuite.scala
@@ -1,0 +1,188 @@
+package com.scylladb.migrator.aerospike
+
+import com.aerospike.client.{ AerospikeClient, AerospikeException, Bin, Key, ResultCode }
+import com.aerospike.client.policy.{ ClientPolicy, InfoPolicy, ScanPolicy, WritePolicy }
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder
+import com.scylladb.migrator.Integration
+import org.apache.logging.log4j.LogManager
+import org.junit.experimental.categories.Category
+
+import java.net.InetSocketAddress
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+
+/** Base class for Aerospike-to-Scylla end-to-end tests.
+  *
+  * It expects external services (Aerospike, Scylla, Spark) to be running. See the files
+  * `CONTRIBUTING.md` and `docker-compose-tests.yml` for more information.
+  */
+@Category(Array(classOf[Integration]))
+abstract class MigratorSuite extends munit.FunSuite {
+
+  // Aerospike truncation is asynchronous and may take several seconds on CI.
+  // The default 30s munit timeout is too tight when retryPut and migration are combined.
+  override val munitTimeout: Duration = 90.seconds
+
+  private val log = LogManager.getLogger(getClass)
+
+  val keyspace = "test"
+  val aerospikeNamespace = "test"
+
+  private val aerospikeHost = sys.env.getOrElse("AEROSPIKE_HOST", "localhost")
+  private val aerospikePort = sys.env.getOrElse("AEROSPIKE_PORT", "3000").toInt
+  private val scyllaHost = sys.env.getOrElse("SCYLLA_HOST", "localhost")
+  private val scyllaPort = sys.env.getOrElse("SCYLLA_PORT", "9042").toInt
+
+  private val createKeyspaceStatement =
+    SchemaBuilder
+      .createKeyspace(keyspace)
+      .ifNotExists()
+      .withReplicationOptions(
+        Map[String, AnyRef](
+          "class"              -> "SimpleStrategy",
+          "replication_factor" -> Integer.valueOf(1)
+        ).asJava
+      )
+      .build()
+
+  /** Client of a source Aerospike instance */
+  val sourceAerospike: Fixture[AerospikeClient] =
+    new Fixture[AerospikeClient]("sourceAerospike") {
+      private var client: AerospikeClient = null
+      def apply(): AerospikeClient = client
+      override def beforeAll(): Unit = {
+        val policy = new ClientPolicy()
+        client = new AerospikeClient(policy, aerospikeHost, aerospikePort)
+      }
+      override def afterAll(): Unit = client.close()
+    }
+
+  /** Client of a target ScyllaDB instance */
+  val targetScylla: Fixture[CqlSession] = new Fixture[CqlSession]("targetScylla") {
+    var session: CqlSession = null
+    def apply(): CqlSession = session
+    override def beforeAll(): Unit = {
+      session = CqlSession
+        .builder()
+        .addContactPoint(new InetSocketAddress(scyllaHost, scyllaPort))
+        .withLocalDatacenter("datacenter1")
+        .withAuthCredentials("dummy", "dummy")
+        .build()
+      session.execute(createKeyspaceStatement)
+    }
+    override def afterAll(): Unit = session.close()
+  }
+
+  /** Fixture automating housekeeping when migrating an Aerospike set to a Scylla table.
+    *
+    * It truncates the Aerospike set and drops/recreates the target Scylla table.
+    *
+    * @param setName
+    *   Name of the Aerospike set and corresponding Scylla table
+    */
+  /** Wait for an Aerospike truncate to take effect by polling until the set is empty. Truncate is
+    * asynchronous in Aerospike — data may still be visible briefly after the call. Uses exponential
+    * backoff to reduce flakiness on slow CI machines.
+    */
+  protected def waitForTruncate(setName: String, maxWaitMs: Int = 10000): Unit = {
+    val deadline = System.currentTimeMillis() + maxWaitMs
+    val scanPolicy = new ScanPolicy()
+    scanPolicy.maxRecords = 1
+    var found = true
+    var sleepMs = 100L
+    while (found && System.currentTimeMillis() < deadline) {
+      var count = 0
+      try
+        sourceAerospike().scanPartitions(
+          scanPolicy,
+          com.aerospike.client.query.PartitionFilter.all(),
+          aerospikeNamespace,
+          setName,
+          (_: Key, _: com.aerospike.client.Record) => count += 1
+        )
+      catch { case e: Exception => log.debug("waitForTruncate: scan check failed", e) }
+      found = count > 0
+      if (found) {
+        Thread.sleep(sleepMs)
+        sleepMs = math.min(sleepMs * 2, 2000L) // exponential backoff, cap at 2s
+      }
+    }
+    assert(!found, s"Timed out waiting for truncate of set $setName after ${maxWaitMs}ms")
+    // Verify the set is writable (including TTL writes) — Aerospike may briefly
+    // reject writes while finalizing truncation or initializing a new set.
+    // Use TTL=1 so the probe record self-expires before any scan picks it up.
+    // Two consecutive successful writes confirm the set is stable — Aerospike 7.x may
+    // transiently re-enter FORBIDDEN state after a single successful probe write.
+    val writeDeadline = System.currentTimeMillis() + 20000
+    val testKey = new Key(aerospikeNamespace, setName, "__truncate_check__")
+    var consecutiveSuccesses = 0
+    var writeSleepMs = 200L
+    while (consecutiveSuccesses < 2 && System.currentTimeMillis() < writeDeadline)
+      try {
+        val ttlPolicy = new com.aerospike.client.policy.WritePolicy()
+        ttlPolicy.expiration = 1 // 1 second — self-expires before migration scan
+        sourceAerospike().put(ttlPolicy, testKey, new com.aerospike.client.Bin("_c", 1))
+        consecutiveSuccesses += 1
+        if (consecutiveSuccesses < 2) Thread.sleep(200)
+      } catch {
+        case e: Exception =>
+          consecutiveSuccesses = 0
+          log.debug("waitForTruncate: write check failed, retrying", e)
+          Thread.sleep(writeSleepMs)
+          writeSleepMs = math.min(writeSleepMs * 2, 3000L)
+      }
+  }
+
+  def withSet(setName: String): FunFixture[String] =
+    FunFixture(
+      setup = { _ =>
+        // Truncate the Aerospike set (ignore errors if set doesn't exist)
+        try sourceAerospike().truncate(new InfoPolicy(), aerospikeNamespace, setName, null)
+        catch { case e: Exception => log.debug("Setup: truncate exception (ignored)", e) }
+        waitForTruncate(setName)
+
+        // Drop the target Scylla table if it exists
+        val dropStmt = SchemaBuilder.dropTable(keyspace, setName).ifExists().build()
+        targetScylla().execute(dropStmt)
+
+        setName
+      },
+      teardown = { _ =>
+        try sourceAerospike().truncate(new InfoPolicy(), aerospikeNamespace, setName, null)
+        catch { case e: Exception => log.debug("Teardown: truncate exception (ignored)", e) }
+
+        val dropStmt = SchemaBuilder.dropTable(keyspace, setName).ifExists().build()
+        try targetScylla().execute(dropStmt)
+        catch { case e: Exception => log.debug("Teardown: drop table exception (ignored)", e) }
+        ()
+      }
+    )
+
+  /** Put with retry — Aerospike 7.x may transiently reject writes (Error 22: FORBIDDEN) after a
+    * truncate, even after waitForTruncate succeeds. Uses a deadline-based approach to stay within
+    * per-test timeouts while retrying for as long as possible.
+    */
+  protected def retryPut(policy: WritePolicy, key: Key, bins: Bin*): Unit = {
+    val deadline = System.currentTimeMillis() + 30000 // 30s budget for slow CI
+    var sleepMs = 200L
+    while (true)
+      try {
+        sourceAerospike().put(policy, key, bins: _*)
+        return
+      } catch {
+        case e: AerospikeException
+            if (e.getResultCode == ResultCode.FAIL_FORBIDDEN ||
+              e.getResultCode == ResultCode.ALWAYS_FORBIDDEN) =>
+          if (System.currentTimeMillis() + sleepMs >= deadline) throw e
+          log.debug(
+            s"retryPut: FORBIDDEN (code ${e.getResultCode}), retrying in ${sleepMs}ms",
+            e
+          )
+          Thread.sleep(sleepMs)
+          sleepMs = math.min(sleepMs * 2, 2000L)
+      }
+  }
+
+  override def munitFixtures: Seq[Fixture[_]] = Seq(sourceAerospike, targetScylla)
+}

--- a/tests/src/test/scala/com/scylladb/migrator/readers/AerospikeClientHolderTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/AerospikeClientHolderTest.scala
@@ -1,0 +1,76 @@
+package com.scylladb.migrator.readers
+
+class AerospikeClientHolderTest extends munit.FunSuite {
+
+  override def afterEach(context: AfterEach): Unit =
+    AerospikeClientHolder.reset()
+
+  test("release on uncached key is a no-op") {
+    val connConfig = AerospikeConnectionConfig(
+      hosts            = List("nonexistent"),
+      port             = 13579,
+      connectTimeoutMs = Some(100),
+      socketTimeoutMs  = None,
+      totalTimeoutMs   = None,
+      tlsName          = None,
+      maxConnsPerNode  = None,
+      connPoolsPerNode = None
+    )
+    // Should not throw
+    AerospikeClientHolder.release(connConfig, None)
+  }
+
+  test("reset allows subsequent get without IllegalStateException") {
+    AerospikeClientHolder.reset()
+    val connConfig = AerospikeConnectionConfig(
+      hosts            = List("nonexistent"),
+      port             = 13579,
+      connectTimeoutMs = Some(100),
+      socketTimeoutMs  = None,
+      totalTimeoutMs   = None,
+      tlsName          = None,
+      maxConnsPerNode  = None,
+      connPoolsPerNode = None
+    )
+    // get() will fail to connect, but should not throw IllegalStateException
+    val ex = intercept[Exception] {
+      AerospikeClientHolder.get(connConfig, None)
+    }
+    assert(!ex.isInstanceOf[IllegalStateException], s"Expected connection error, got: $ex")
+  }
+
+  private val localConfig = AerospikeConnectionConfig(
+    hosts            = List("localhost"),
+    port             = 3000,
+    connectTimeoutMs = Some(1000),
+    socketTimeoutMs  = None,
+    totalTimeoutMs   = None,
+    tlsName          = None,
+    maxConnsPerNode  = None,
+    connPoolsPerNode = None
+  )
+
+  private def requireAerospike(): com.aerospike.client.AerospikeClient = {
+    val client =
+      try AerospikeClientHolder.get(localConfig, None)
+      catch {
+        case _: Exception =>
+          assume(false, "Aerospike not available on localhost:3000, skipping")
+          null // unreachable — assume(false) throws
+      }
+    client
+  }
+
+  test("get returns the same client instance for the same key") {
+    val client1 = requireAerospike()
+    val client2 = AerospikeClientHolder.get(localConfig, None)
+    assert(client1 eq client2, "Expected same client instance for same connection key")
+  }
+
+  test("release removes cached client") {
+    val client1 = requireAerospike()
+    AerospikeClientHolder.release(localConfig, None)
+    val client2 = requireAerospike()
+    assert(!(client1 eq client2), "Expected different client instance after release")
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/readers/AerospikeConnectionTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/AerospikeConnectionTest.scala
@@ -1,0 +1,171 @@
+package com.scylladb.migrator.readers
+
+import com.aerospike.client.{ AerospikeException, ResultCode }
+
+class AerospikeConnectionTest extends munit.FunSuite {
+
+  // --- AerospikeConnectionKey ---
+
+  test("AerospikeConnectionKey equality") {
+    val key1 = AerospikeConnectionKey(List("host1"), 3000, None, None, None, None, None, None, None)
+    val key2 = AerospikeConnectionKey(List("host1"), 3000, None, None, None, None, None, None, None)
+    val key3 = AerospikeConnectionKey(List("host2"), 3000, None, None, None, None, None, None, None)
+    assertEquals(key1, key2)
+    assertNotEquals(key1, key3)
+  }
+
+  test("AerospikeConnectionKey with hashed credentials") {
+    val hash1 = AerospikeConnectionKey.hashCredentials(Some(("u", "p")))
+    val hash2 = AerospikeConnectionKey.hashCredentials(Some(("u", "p")))
+    val hash3 = AerospikeConnectionKey.hashCredentials(Some(("u", "other")))
+    val key1 = AerospikeConnectionKey(List("h"), 3000, hash1, None, None, None, None, None, None)
+    val key2 = AerospikeConnectionKey(List("h"), 3000, hash2, None, None, None, None, None, None)
+    val key3 = AerospikeConnectionKey(List("h"), 3000, hash3, None, None, None, None, None, None)
+    assertEquals(key1, key2)
+    assertNotEquals(key1, key3)
+  }
+
+  test("AerospikeConnectionKey.hashCredentials returns None for None") {
+    assertEquals(AerospikeConnectionKey.hashCredentials(None), None)
+  }
+
+  test("AerospikeConnectionKey.hashCredentials is deterministic") {
+    val h1 = AerospikeConnectionKey.hashCredentials(Some(("user", "pass")))
+    val h2 = AerospikeConnectionKey.hashCredentials(Some(("user", "pass")))
+    assertEquals(h1, h2)
+    assert(h1.get.matches("[0-9a-f]{64}"), "Expected SHA-256 hex digest")
+  }
+
+  // --- isRetryable ---
+
+  test("isRetryable: TIMEOUT is retryable") {
+    assert(Aerospike.isRetryable(new AerospikeException(ResultCode.TIMEOUT)))
+  }
+
+  test("isRetryable: SERVER_NOT_AVAILABLE is retryable") {
+    assert(Aerospike.isRetryable(new AerospikeException(ResultCode.SERVER_NOT_AVAILABLE)))
+  }
+
+  test("isRetryable: KEY_NOT_FOUND is not retryable") {
+    assert(!Aerospike.isRetryable(new AerospikeException(ResultCode.KEY_NOT_FOUND_ERROR)))
+  }
+
+  test("isRetryable: DEVICE_OVERLOAD is retryable") {
+    assert(Aerospike.isRetryable(new AerospikeException(ResultCode.DEVICE_OVERLOAD)))
+  }
+
+  test("isRetryable: PARAMETER_ERROR is not retryable") {
+    assert(!Aerospike.isRetryable(new AerospikeException(ResultCode.PARAMETER_ERROR)))
+  }
+
+  // --- buildClient (TLS and credential configuration) ---
+
+  test("buildClientPolicy: sets tlsPolicy when tlsName is provided") {
+    val connConfig = AerospikeConnectionConfig(
+      hosts            = List("localhost"),
+      port             = 3000,
+      connectTimeoutMs = None,
+      socketTimeoutMs  = None,
+      totalTimeoutMs   = None,
+      tlsName          = Some("my-tls-name"),
+      maxConnsPerNode  = None,
+      connPoolsPerNode = None
+    )
+    val policy = Aerospike.buildClientPolicy(connConfig, Some(("testuser", "testpass")))
+    assert(policy.tlsPolicy != null, "Expected tlsPolicy to be set")
+    assertEquals(policy.user, "testuser")
+    assertEquals(policy.password, "testpass")
+  }
+
+  test("buildClientPolicy: sets user and password when credentials are provided") {
+    val connConfig = AerospikeConnectionConfig(
+      hosts            = List("localhost"),
+      port             = 13579,
+      connectTimeoutMs = Some(100),
+      socketTimeoutMs  = Some(5000),
+      totalTimeoutMs   = Some(15000),
+      tlsName          = None,
+      maxConnsPerNode  = None,
+      connPoolsPerNode = None
+    )
+    val policy = Aerospike.buildClientPolicy(connConfig, Some(("admin", "secret")))
+    assertEquals(policy.user, "admin")
+    assertEquals(policy.password, "secret")
+    assertEquals(policy.timeout, 100)
+    assertEquals(policy.readPolicyDefault.socketTimeout, 5000)
+    assertEquals(policy.readPolicyDefault.totalTimeout, 15000)
+    assertEquals(policy.scanPolicyDefault.socketTimeout, 5000)
+    assertEquals(policy.scanPolicyDefault.totalTimeout, 15000)
+  }
+
+  test("buildClientPolicy: works without TLS or credentials") {
+    val connConfig = AerospikeConnectionConfig(
+      hosts            = List("localhost"),
+      port             = 13579,
+      connectTimeoutMs = Some(100),
+      socketTimeoutMs  = None,
+      totalTimeoutMs   = None,
+      tlsName          = None,
+      maxConnsPerNode  = None,
+      connPoolsPerNode = None
+    )
+    val policy = Aerospike.buildClientPolicy(connConfig, None)
+    assert(policy.tlsPolicy == null, "Expected no tlsPolicy")
+    assert(policy.user == null, "Expected no user")
+    assert(policy.password == null, "Expected no password")
+  }
+
+  // --- resolveCredentials ---
+
+  test("resolveCredentialsFromEnvOr: returns fallback when env vars are not set") {
+    assume(
+      System.getenv("AEROSPIKE_USERNAME") == null,
+      "AEROSPIKE_USERNAME is set; skipping"
+    )
+    val result = Aerospike.resolveCredentialsFromEnvOr(Some(("fallback-user", "fallback-pass")))
+    assertEquals(result, Some(("fallback-user", "fallback-pass")))
+  }
+
+  test("resolveCredentialsFromEnvOr: returns None when no env vars and no fallback") {
+    assume(
+      System.getenv("AEROSPIKE_USERNAME") == null,
+      "AEROSPIKE_USERNAME is set; skipping"
+    )
+    val result = Aerospike.resolveCredentialsFromEnvOr(None)
+    assertEquals(result, None)
+  }
+
+  test("resolveCredentials: returns config credentials when env vars are not set") {
+    // This test relies on AEROSPIKE_USERNAME not being set in the test environment.
+    // If it is set, the test will be skipped.
+    assume(
+      System.getenv("AEROSPIKE_USERNAME") == null,
+      "AEROSPIKE_USERNAME is set; skipping"
+    )
+    val source = com.scylladb.migrator.config.SourceSettings.Aerospike(
+      hosts                   = Seq("h"),
+      port                    = None,
+      namespace               = "ns",
+      set                     = "s",
+      bins                    = None,
+      splitCount              = None,
+      schemaSampleSize        = None,
+      queueSize               = None,
+      credentials             = Some(com.scylladb.migrator.config.Credentials("u", "p")),
+      connectTimeoutMs        = None,
+      socketTimeoutMs         = None,
+      tlsName                 = None,
+      schema                  = None,
+      pollTimeoutSeconds      = None,
+      preserveTTL             = None,
+      preserveGeneration      = None,
+      totalTimeoutMs          = None,
+      maxScanRetries          = None,
+      schemaDiscoveryStrategy = None,
+      maxPollRetries          = None,
+      maxConnsPerNode         = None,
+      connPoolsPerNode        = None
+    )
+    assertEquals(Aerospike.resolveCredentials(source), Some(("u", "p")))
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/readers/AerospikePartitionTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/AerospikePartitionTest.scala
@@ -1,0 +1,90 @@
+package com.scylladb.migrator.readers
+
+class AerospikePartitionTest extends munit.FunSuite {
+
+  // --- computePartitions (getPartitions logic) ---
+
+  test("computePartitions: splitCount=1 yields single partition covering all 4096") {
+    val parts = AerospikeRDD.computePartitions(1)
+    assertEquals(parts.length, 1)
+    assertEquals(parts(0).partBegin, 0)
+    assertEquals(parts(0).partCount, 4096)
+  }
+
+  test("computePartitions: splitCount=4096 yields one partition per Aerospike partition") {
+    val parts = AerospikeRDD.computePartitions(4096)
+    assertEquals(parts.length, 4096)
+    parts.zipWithIndex.foreach { case (p, i) =>
+      assertEquals(p.partBegin, i)
+      assertEquals(p.partCount, 1)
+    }
+  }
+
+  test("computePartitions: splitCount=3 distributes remainder correctly") {
+    // 4096 / 3 = 1365 remainder 1 -> first partition gets 1366, rest get 1365
+    val parts = AerospikeRDD.computePartitions(3)
+    assertEquals(parts.length, 3)
+    assertEquals(parts(0).partCount, 1366)
+    assertEquals(parts(1).partCount, 1365)
+    assertEquals(parts(2).partCount, 1365)
+    // Verify contiguous coverage
+    assertEquals(parts(0).partBegin, 0)
+    assertEquals(parts(1).partBegin, 1366)
+    assertEquals(parts(2).partBegin, 2731)
+    // Total must be 4096
+    assertEquals(parts.map(_.partCount).sum, 4096)
+  }
+
+  test("computePartitions: splitCount=8 covers all partitions contiguously") {
+    val parts = AerospikeRDD.computePartitions(8)
+    assertEquals(parts.length, 8)
+    assertEquals(parts.map(_.partCount).sum, 4096)
+    // Verify contiguous
+    parts.sliding(2).foreach { pair =>
+      assertEquals(pair(1).partBegin, pair(0).partBegin + pair(0).partCount)
+    }
+  }
+
+  test("computePartitions: all splits have valid indices") {
+    val parts = AerospikeRDD.computePartitions(100)
+    parts.zipWithIndex.foreach { case (p, i) =>
+      assertEquals(p.index, i)
+    }
+  }
+
+  // --- validateSplitCount ---
+
+  test("validateSplitCount: zero throws IllegalArgumentException") {
+    intercept[IllegalArgumentException] {
+      Aerospike.validateSplitCount(0)
+    }
+  }
+
+  test("validateSplitCount: negative throws IllegalArgumentException") {
+    intercept[IllegalArgumentException] {
+      Aerospike.validateSplitCount(-1)
+    }
+  }
+
+  test("validateSplitCount: exceeds 4096 throws IllegalArgumentException") {
+    intercept[IllegalArgumentException] {
+      Aerospike.validateSplitCount(4097)
+    }
+  }
+
+  test("validateSplitCount: valid boundary values pass") {
+    Aerospike.validateSplitCount(1)
+    Aerospike.validateSplitCount(4096)
+  }
+
+  // --- Constants ---
+  // Smoke test: if these constants change, integration test configs and Scylla table schemas
+  // must be updated to match.
+
+  test("column name and limit constants") {
+    assertEquals(Aerospike.KeyColumnName, "aero_key")
+    assertEquals(Aerospike.TtlColumnName, "aero_ttl")
+    assertEquals(Aerospike.GenerationColumnName, "aero_generation")
+    assertEquals(Aerospike.MaxSchemaSampleSize, 10000)
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/readers/AerospikeSchemaValidationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/AerospikeSchemaValidationTest.scala
@@ -1,0 +1,53 @@
+package com.scylladb.migrator.readers
+
+import scala.collection.immutable.ListMap
+
+class AerospikeSchemaValidationTest extends munit.FunSuite {
+
+  test("validateSchemaAgainstBins: schema subset of bins passes") {
+    val schema = ListMap("foo" -> "string", "bar" -> "long")
+    val bins = Seq("foo", "bar", "baz")
+    // Should not throw
+    Aerospike.validateSchemaAgainstBins(schema, bins)
+  }
+
+  test("validateSchemaAgainstBins: exact match passes") {
+    val schema = ListMap("foo" -> "string")
+    val bins = Seq("foo")
+    Aerospike.validateSchemaAgainstBins(schema, bins)
+  }
+
+  test("validateSchemaAgainstBins: schema declares bins not in filter throws") {
+    val schema = ListMap("foo" -> "string", "extra" -> "long")
+    val bins = Seq("foo")
+    val ex = intercept[IllegalArgumentException] {
+      Aerospike.validateSchemaAgainstBins(schema, bins)
+    }
+    assert(ex.getMessage.contains("extra"), s"Expected 'extra' in message, got: ${ex.getMessage}")
+    assert(
+      ex.getMessage.contains("not in the 'bins' filter"),
+      s"Expected guidance in message, got: ${ex.getMessage}"
+    )
+  }
+
+  test("validateSchemaAgainstBins: multiple extra bins listed in error") {
+    val schema = ListMap("a" -> "string", "b" -> "long", "c" -> "double")
+    val bins = Seq("a")
+    val ex = intercept[IllegalArgumentException] {
+      Aerospike.validateSchemaAgainstBins(schema, bins)
+    }
+    assert(
+      ex.getMessage.contains("2 bin(s)"),
+      s"Expected '2 bin(s)' in message, got: ${ex.getMessage}"
+    )
+  }
+
+  test("validateSchemaAgainstBins: empty bins filter with non-empty schema throws") {
+    val schema = ListMap("foo" -> "string")
+    val bins = Seq.empty[String]
+    val ex = intercept[IllegalArgumentException] {
+      Aerospike.validateSchemaAgainstBins(schema, bins)
+    }
+    assert(ex.getMessage.contains("foo"))
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/readers/AerospikeTypesTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/AerospikeTypesTest.scala
@@ -1,0 +1,436 @@
+package com.scylladb.migrator.readers
+
+import org.apache.spark.sql.types._
+
+class AerospikeTypesTest extends munit.FunSuite {
+
+  // --- inferSparkType ---
+
+  test("inferSparkType: Long") {
+    assertEquals(AerospikeTypes.inferSparkType(java.lang.Long.valueOf(42L)), LongType)
+  }
+
+  test("inferSparkType: Integer maps to LongType") {
+    assertEquals(AerospikeTypes.inferSparkType(java.lang.Integer.valueOf(42)), LongType)
+  }
+
+  test("inferSparkType: Double") {
+    assertEquals(AerospikeTypes.inferSparkType(java.lang.Double.valueOf(3.14)), DoubleType)
+  }
+
+  test("inferSparkType: Float maps to DoubleType") {
+    assertEquals(AerospikeTypes.inferSparkType(java.lang.Float.valueOf(1.5f)), DoubleType)
+  }
+
+  test("inferSparkType: String") {
+    assertEquals(AerospikeTypes.inferSparkType("hello"), StringType)
+  }
+
+  test("inferSparkType: byte array") {
+    assertEquals(AerospikeTypes.inferSparkType(Array[Byte](1, 2, 3)), BinaryType)
+  }
+
+  test("inferSparkType: Boolean maps to BooleanType") {
+    assertEquals(AerospikeTypes.inferSparkType(java.lang.Boolean.TRUE), BooleanType)
+  }
+
+  test("inferSparkType: List of strings") {
+    val list = java.util.Arrays.asList("a", "b", "c")
+    assertEquals(
+      AerospikeTypes.inferSparkType(list),
+      ArrayType(StringType, containsNull = true)
+    )
+  }
+
+  test("inferSparkType: List of longs") {
+    val list = java.util.Arrays.asList(
+      java.lang.Long.valueOf(1L),
+      java.lang.Long.valueOf(2L)
+    )
+    assertEquals(
+      AerospikeTypes.inferSparkType(list),
+      ArrayType(LongType, containsNull = true)
+    )
+  }
+
+  test("inferSparkType: List with mixed types falls back to StringType elements") {
+    val list = new java.util.ArrayList[Any]()
+    list.add(java.lang.Long.valueOf(1L))
+    list.add("hello")
+    assertEquals(
+      AerospikeTypes.inferSparkType(list),
+      ArrayType(StringType, containsNull = true)
+    )
+  }
+
+  test("inferSparkType: empty list falls back to StringType elements") {
+    val list = new java.util.ArrayList[Any]()
+    assertEquals(
+      AerospikeTypes.inferSparkType(list),
+      ArrayType(StringType, containsNull = true)
+    )
+  }
+
+  test("inferSparkType: Map of string to string") {
+    val map = new java.util.HashMap[String, String]()
+    map.put("k", "v")
+    assertEquals(
+      AerospikeTypes.inferSparkType(map),
+      MapType(StringType, StringType, valueContainsNull = true)
+    )
+  }
+
+  test("inferSparkType: Map of string to long") {
+    val map = new java.util.HashMap[Any, Any]()
+    map.put("k", java.lang.Long.valueOf(42L))
+    assertEquals(
+      AerospikeTypes.inferSparkType(map),
+      MapType(StringType, LongType, valueContainsNull = true)
+    )
+  }
+
+  test("inferSparkType: nested list inside map") {
+    val inner = java.util.Arrays.asList("a", "b")
+    val map = new java.util.HashMap[Any, Any]()
+    map.put("list", inner)
+    val result = AerospikeTypes.inferSparkType(map)
+    assertEquals(
+      result,
+      MapType(StringType, ArrayType(StringType, containsNull = true), valueContainsNull = true)
+    )
+  }
+
+  // --- convertValue ---
+
+  test("convertValue: null returns null") {
+    assertEquals(AerospikeTypes.convertValue(null, StringType), null)
+  }
+
+  test("convertValue: Long passthrough") {
+    assertEquals(AerospikeTypes.convertValue(java.lang.Long.valueOf(42L), LongType), 42L)
+  }
+
+  test("convertValue: Long to String coercion") {
+    assertEquals(AerospikeTypes.convertValue(java.lang.Long.valueOf(42L), StringType), "42")
+  }
+
+  test("convertValue: Long to Double widening") {
+    assertEquals(
+      AerospikeTypes.convertValue(java.lang.Long.valueOf(42L), DoubleType),
+      java.lang.Double.valueOf(42.0)
+    )
+  }
+
+  test("convertValue: String passthrough") {
+    assertEquals(AerospikeTypes.convertValue("hello", StringType), "hello")
+  }
+
+  test("convertValue: byte array passthrough") {
+    val bytes = Array[Byte](1, 2, 3)
+    val result = AerospikeTypes.convertValue(bytes, BinaryType).asInstanceOf[Array[Byte]]
+    assertEquals(result.toList, bytes.toList)
+  }
+
+  test("convertValue: byte array to StringType converts to hex") {
+    val bytes = Array[Byte](0x0a, 0x1b, 0x2c)
+    val result = AerospikeTypes.convertValue(bytes, StringType)
+    assertEquals(result, "0a1b2c")
+  }
+
+  test("convertValue: List conversion") {
+    val list = java.util.Arrays.asList("a", "b")
+    val result = AerospikeTypes.convertValue(list, ArrayType(StringType, containsNull = true))
+    assertEquals(result, Seq("a", "b"))
+  }
+
+  test("convertValue: List serialized to string when expectedType is StringType") {
+    val list = java.util.Arrays.asList(java.lang.Long.valueOf(1L))
+    val result = AerospikeTypes.convertValue(list, StringType)
+    assertEquals(result, "[1]")
+  }
+
+  test("convertValue: Map conversion") {
+    val map = new java.util.HashMap[String, String]()
+    map.put("k", "v")
+    val result = AerospikeTypes.convertValue(
+      map,
+      MapType(StringType, StringType, valueContainsNull = true)
+    )
+    assertEquals(result, Map("k" -> "v"))
+  }
+
+  test("convertValue: Map serialized to string when expectedType is StringType") {
+    val map = new java.util.HashMap[String, String]()
+    map.put("k", "v")
+    val result = AerospikeTypes.convertValue(map, StringType)
+    assertEquals(result, "{k=v}")
+  }
+
+  test("convertValue: nested Map with Long values coerced to String") {
+    val map = new java.util.HashMap[String, Any]()
+    map.put("num", java.lang.Long.valueOf(99L))
+    val result = AerospikeTypes.convertValue(
+      map,
+      MapType(StringType, StringType, valueContainsNull = true)
+    )
+    assertEquals(result, Map("num" -> "99"))
+  }
+
+  test("convertValue: Integer to LongType") {
+    val result = AerospikeTypes.convertValue(java.lang.Integer.valueOf(42), LongType)
+    assertEquals(result, java.lang.Long.valueOf(42L))
+  }
+
+  test("convertValue: Integer to StringType") {
+    assertEquals(AerospikeTypes.convertValue(java.lang.Integer.valueOf(42), StringType), "42")
+  }
+
+  test("convertValue: Integer to DoubleType") {
+    assertEquals(
+      AerospikeTypes.convertValue(java.lang.Integer.valueOf(42), DoubleType),
+      java.lang.Double.valueOf(42.0)
+    )
+  }
+
+  test("convertValue: Float to DoubleType") {
+    val result = AerospikeTypes.convertValue(java.lang.Float.valueOf(1.5f), DoubleType)
+    assertEquals(result, java.lang.Double.valueOf(1.5))
+  }
+
+  test("convertValue: Float to StringType") {
+    assertEquals(AerospikeTypes.convertValue(java.lang.Float.valueOf(1.5f), StringType), "1.5")
+  }
+
+  test("convertValue: Double passthrough") {
+    assertEquals(AerospikeTypes.convertValue(java.lang.Double.valueOf(3.14), DoubleType), 3.14)
+  }
+
+  test("convertValue: Boolean passthrough") {
+    assertEquals(AerospikeTypes.convertValue(java.lang.Boolean.TRUE, BooleanType), true)
+  }
+
+  test("convertValue: Boolean to StringType") {
+    assertEquals(AerospikeTypes.convertValue(java.lang.Boolean.TRUE, StringType), "true")
+  }
+
+  test("convertValue: unexpected type coerces to String") {
+    // java.math.BigDecimal is not a recognized Aerospike type — should be coerced to String
+    assertEquals(AerospikeTypes.convertValue(new java.math.BigDecimal("42"), LongType), "42")
+  }
+
+  // --- mergeTypes ---
+
+  test("mergeTypes: identical scalar types") {
+    assertEquals(AerospikeTypes.mergeTypes(LongType, LongType), LongType)
+    assertEquals(AerospikeTypes.mergeTypes(DoubleType, DoubleType), DoubleType)
+    assertEquals(AerospikeTypes.mergeTypes(StringType, StringType), StringType)
+  }
+
+  test("mergeTypes: Long and Double widen to Double") {
+    assertEquals(AerospikeTypes.mergeTypes(LongType, DoubleType), DoubleType)
+    assertEquals(AerospikeTypes.mergeTypes(DoubleType, LongType), DoubleType)
+  }
+
+  test("mergeTypes: identical ArrayTypes") {
+    val result = AerospikeTypes.mergeTypes(
+      ArrayType(LongType, containsNull = false),
+      ArrayType(LongType, containsNull = true)
+    )
+    assertEquals(result, ArrayType(LongType, containsNull = true))
+  }
+
+  test("mergeTypes: different ArrayType element types fall back to StringType") {
+    val result = AerospikeTypes.mergeTypes(
+      ArrayType(LongType, containsNull   = false),
+      ArrayType(StringType, containsNull = false)
+    )
+    assertEquals(result, ArrayType(StringType, containsNull = false))
+  }
+
+  test("mergeTypes: identical MapTypes") {
+    val result = AerospikeTypes.mergeTypes(
+      MapType(StringType, LongType, valueContainsNull = false),
+      MapType(StringType, LongType, valueContainsNull = true)
+    )
+    assertEquals(result, MapType(StringType, LongType, valueContainsNull = true))
+  }
+
+  test("mergeTypes: MapType value types Long and Double widen to Double") {
+    val result = AerospikeTypes.mergeTypes(
+      MapType(StringType, LongType, valueContainsNull   = false),
+      MapType(StringType, DoubleType, valueContainsNull = false)
+    )
+    assertEquals(result, MapType(StringType, DoubleType, valueContainsNull = false))
+  }
+
+  test("mergeTypes: scalar type conflict falls back to StringType") {
+    assertEquals(AerospikeTypes.mergeTypes(LongType, StringType), StringType)
+  }
+
+  test("mergeTypes: ArrayType vs MapType falls back to StringType") {
+    assertEquals(
+      AerospikeTypes.mergeTypes(
+        ArrayType(StringType, containsNull                = true),
+        MapType(StringType, StringType, valueContainsNull = true)
+      ),
+      StringType
+    )
+  }
+
+  // --- extractKey ---
+
+  test("extractKey: userKey present with StringType") {
+    val key = new com.aerospike.client.Key("ns", "set", "mykey")
+    assertEquals(AerospikeTypes.extractKey(key, StringType), "mykey")
+  }
+
+  test("extractKey: userKey present with LongType") {
+    val key = new com.aerospike.client.Key("ns", "set", 42L)
+    assertEquals(AerospikeTypes.extractKey(key, LongType), 42L)
+  }
+
+  test("extractKey: Long userKey coerced to StringType") {
+    val key = new com.aerospike.client.Key("ns", "set", 42L)
+    assertEquals(AerospikeTypes.extractKey(key, StringType), "42")
+  }
+
+  test("extractKey: null userKey falls back to hex digest") {
+    // Construct a key with a known digest by providing a string key, then verify
+    // that when userKey is absent the digest is returned as hex.
+    // Use the byte[] constructor to avoid ambiguity, then extractKey sees userKey=null.
+    val digest = Array[Byte](
+      0x0a,
+      0x1b,
+      0x2c,
+      0x3d,
+      0x4e,
+      0x5f,
+      0x60,
+      0x71,
+      0x82.toByte,
+      0x93.toByte,
+      0xa4.toByte,
+      0xb5.toByte,
+      0xc6.toByte,
+      0xd7.toByte,
+      0xe8.toByte,
+      0xf9.toByte,
+      0x01,
+      0x23,
+      0x45,
+      0x67
+    )
+    val key = new com.aerospike.client.Key("ns", digest, null, null)
+    val result = AerospikeTypes.extractKey(key, StringType).asInstanceOf[String]
+    assert(result.matches("[0-9a-f]+"), s"Expected hex digest, got: $result")
+  }
+
+  // --- parseType ---
+
+  test("parseType: string") {
+    assertEquals(AerospikeTypes.parseType("string"), StringType)
+  }
+
+  test("parseType: text alias") {
+    assertEquals(AerospikeTypes.parseType("text"), StringType)
+  }
+
+  test("parseType: long") {
+    assertEquals(AerospikeTypes.parseType("long"), LongType)
+  }
+
+  test("parseType: bigint alias") {
+    assertEquals(AerospikeTypes.parseType("bigint"), LongType)
+  }
+
+  test("parseType: double") {
+    assertEquals(AerospikeTypes.parseType("double"), DoubleType)
+  }
+
+  test("parseType: binary") {
+    assertEquals(AerospikeTypes.parseType("binary"), BinaryType)
+  }
+
+  test("parseType: blob alias") {
+    assertEquals(AerospikeTypes.parseType("blob"), BinaryType)
+  }
+
+  test("parseType: boolean") {
+    assertEquals(AerospikeTypes.parseType("boolean"), BooleanType)
+  }
+
+  test("parseType: bool alias") {
+    assertEquals(AerospikeTypes.parseType("bool"), BooleanType)
+  }
+
+  test("parseType: case insensitive") {
+    assertEquals(AerospikeTypes.parseType("STRING"), StringType)
+    assertEquals(AerospikeTypes.parseType("Long"), LongType)
+  }
+
+  test("parseType: int alias") {
+    assertEquals(AerospikeTypes.parseType("int"), LongType)
+  }
+
+  test("parseType: integer alias") {
+    assertEquals(AerospikeTypes.parseType("integer"), LongType)
+  }
+
+  test("parseType: list<string>") {
+    assertEquals(
+      AerospikeTypes.parseType("list<string>"),
+      ArrayType(StringType, containsNull = true)
+    )
+  }
+
+  test("parseType: list<long>") {
+    assertEquals(
+      AerospikeTypes.parseType("list<long>"),
+      ArrayType(LongType, containsNull = true)
+    )
+  }
+
+  test("parseType: map<string,long>") {
+    assertEquals(
+      AerospikeTypes.parseType("map<string,long>"),
+      MapType(StringType, LongType, valueContainsNull = true)
+    )
+  }
+
+  test("parseType: map<string,double>") {
+    assertEquals(
+      AerospikeTypes.parseType("map<string,double>"),
+      MapType(StringType, DoubleType, valueContainsNull = true)
+    )
+  }
+
+  test("parseType: nested list<map<string,long>>") {
+    assertEquals(
+      AerospikeTypes.parseType("list<map<string,long>>"),
+      ArrayType(MapType(StringType, LongType, valueContainsNull = true), containsNull = true)
+    )
+  }
+
+  test("parseType: collection types are case insensitive") {
+    assertEquals(
+      AerospikeTypes.parseType("List<String>"),
+      ArrayType(StringType, containsNull = true)
+    )
+    assertEquals(
+      AerospikeTypes.parseType("MAP<STRING,LONG>"),
+      MapType(StringType, LongType, valueContainsNull = true)
+    )
+  }
+
+  test("parseType: unknown type throws") {
+    intercept[IllegalArgumentException] {
+      AerospikeTypes.parseType("timestamp")
+    }
+  }
+
+  test("parseType: invalid map type throws") {
+    intercept[IllegalArgumentException] {
+      AerospikeTypes.parseType("map<string>")
+    }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/readers/SchemaDiscoveryStrategyTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/SchemaDiscoveryStrategyTest.scala
@@ -1,0 +1,43 @@
+package com.scylladb.migrator.readers
+
+import com.scylladb.migrator.config.SchemaDiscoveryStrategy
+
+class SchemaDiscoveryStrategyTest extends munit.FunSuite {
+
+  test("SchemaDiscoveryStrategy: decode progressive") {
+    assertEquals(
+      io.circe.parser.decode[SchemaDiscoveryStrategy]("\"progressive\""),
+      Right(SchemaDiscoveryStrategy.Progressive)
+    )
+  }
+
+  test("SchemaDiscoveryStrategy: decode single") {
+    assertEquals(
+      io.circe.parser.decode[SchemaDiscoveryStrategy]("\"single\""),
+      Right(SchemaDiscoveryStrategy.Single)
+    )
+  }
+
+  test("SchemaDiscoveryStrategy: decode full") {
+    assertEquals(
+      io.circe.parser.decode[SchemaDiscoveryStrategy]("\"full\""),
+      Right(SchemaDiscoveryStrategy.Full)
+    )
+  }
+
+  test("SchemaDiscoveryStrategy: decode invalid") {
+    assert(
+      io.circe.parser.decode[SchemaDiscoveryStrategy]("\"unknown\"").isLeft
+    )
+  }
+
+  test("SchemaDiscoveryStrategy: encode round-trip") {
+    import io.circe.syntax._
+    val strategy: SchemaDiscoveryStrategy = SchemaDiscoveryStrategy.Progressive
+    val json = strategy.asJson
+    assertEquals(
+      json.as[SchemaDiscoveryStrategy],
+      Right(SchemaDiscoveryStrategy.Progressive)
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Introduces Aerospike as a new migration source, enabling data migration from Aerospike databases to ScyllaDB via Spark.

### Design

- **Partition-based scanning**: Uses `scanPartitions` (not `scanAll`) to distribute reads across Spark executors. Aerospike's 4096 data partitions are mapped to configurable Spark splits.
- **Schema discovery**: Auto-discovers schema by sampling records with progressive partition expansion (8 → 64 → all partitions), with explicit schema override support. Includes a 10K bin guard to prevent OOM on pathological datasets.
- **Streaming architecture**: Blocking queue bridges async scan callbacks to Spark's synchronous iterator, with cooperative cancellation, generation-based retry, and configurable backpressure (queue size, poll timeout).
- **Credential handling**: Supports config-based or environment variable credentials. Env vars avoid broadcasting plaintext in the Spark closure.
- **Type mapping**: Long/Integer→LongType, Double/Float→DoubleType, String→StringType, byte[]→BinaryType, List→ArrayType, Map→MapType. Mixed types auto-resolve to StringType.

### New files

| Area | File | Description |
|------|------|-------------|
| Reader | `readers/Aerospike.scala` | Entry point: schema discovery, config, scan orchestration |
| RDD | `readers/AerospikeRDD.scala` | Custom RDD with blocking-queue streaming from scan callbacks |
| Types | `readers/AerospikeTypes.scala` | Type inference, conversion, and schema helpers |
| Client | `readers/AerospikeClientHolder.scala` | Per-executor client cache with shutdown hook |
| Config | `config/SourceSettings.Aerospike` | Host, port, namespace, set, bins, splitCount, credentials, timeouts |
| Config | `config/AerospikeCredentials.scala` | Aerospike-specific credential type |
| Config | `config/SchemaDiscoveryStrategy.scala` | Progressive/Single/Full schema discovery modes |
| Router | `Migrator.scala` | Aerospike → Scylla routing |
| Tests | `aerospike/BasicMigrationTest.scala` | 14 integration tests covering basic, filtered, schema override, metadata, collections |
| Tests | `readers/AerospikeReaderTest.scala` | Unit tests for type inference, conversion, partitioning, key extraction, buildClient |
| Benchmark | `aerospike/AerospikeToScyllaE2EBenchmark.scala` | E2E throughput benchmark with spot-checking |
| Benchmark | `AerospikeConvertValueBenchmark.scala` | JMH microbenchmark for value conversion |
| CI | `tests.yml` | Dedicated Aerospike integration test job with E2E sanity |
| Docker | `docker-compose-tests.yml` | Aerospike CE 7.2 service |
| Config | `config-aerospike.yaml.example` | Documented example configuration |

## Test plan

- [x] 232 unit tests pass (including new buildClient, resolveCredentials, type conversion tests)
- [x] Lint (scalafmtCheckAll) passes
- [x] Migrator, tests, and benchmarks projects compile cleanly
- [ ] Integration tests pass with Aerospike Docker service
- [ ] E2E sanity benchmark completes successfully
- [ ] CI pipeline green