### PR TITLE
Fix row size mismatch when writing DataFrames with TTL/writetime metadata

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -99,6 +99,25 @@ object Scylla {
       }
     }
 
+  /** Build the column selector for `saveToCassandra`, excluding metadata columns (ttl, writetime)
+    * that are consumed by WriteConf via TTLOption.perRow / TimestampOption.perRow rather than
+    * written as actual table columns.
+    */
+  private[writers] def buildColumnSelector(
+    schema: StructType,
+    timestampColumns: Option[TimestampColumns]
+  ): SomeColumns = {
+    val metaColumnNames =
+      timestampColumns.map(tc => Set(tc.ttl, tc.writeTime)).getOrElse(Set.empty)
+    SomeColumns(
+      ArraySeq.unsafeWrapArray(
+        schema.fields.collect {
+          case f if !metaColumnNames.contains(f.name) => f.name: ColumnRef
+        }
+      ): _*
+    )
+  }
+
   def writeDataframe(
     target: TargetSettings.Scylla,
     renames: List[Rename],
@@ -167,9 +186,7 @@ object Scylla {
     log.info("Schema after renames:")
     log.info(renamedSchema.treeString)
 
-    val columnSelector = SomeColumns(
-      ArraySeq.unsafeWrapArray(renamedSchema.fields.map(_.name: ColumnRef)): _*
-    )
+    val columnSelector = buildColumnSelector(renamedSchema, timestampColumns)
 
     // Spark's conversion from its internal Decimal type to java.math.BigDecimal
     // pads the resulting value with trailing zeros corresponding to the scale of the

--- a/tests/src/test/scala/com/scylladb/migrator/writers/ScyllaColumnSelectorTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/writers/ScyllaColumnSelectorTest.scala
@@ -1,0 +1,71 @@
+package com.scylladb.migrator.writers
+
+import com.datastax.spark.connector._
+import com.scylladb.migrator.readers.TimestampColumns
+import org.apache.spark.sql.types.{
+  IntegerType,
+  LongType,
+  StringType,
+  StructField,
+  StructType
+}
+
+class ScyllaColumnSelectorTest extends munit.FunSuite {
+
+  test("buildColumnSelector excludes ttl and writetime columns when timestampColumns is present") {
+    val schema = StructType(
+      Seq(
+        StructField("id", StringType, nullable = true),
+        StructField("foo", StringType, nullable = true),
+        StructField("bar", IntegerType, nullable = true),
+        StructField("ttl", IntegerType, nullable = true),
+        StructField("writetime", LongType, nullable = true)
+      )
+    )
+
+    val timestampColumns = Some(TimestampColumns("ttl", "writetime"))
+    val selector = Scylla.buildColumnSelector(schema, timestampColumns)
+
+    val SomeColumns(columns @ _*) = selector
+    val columnNames = columns.map { case c: ColumnName => c.columnName; case other => fail(s"unexpected ref: $other") }.toSet
+    assertEquals(columnNames, Set("id", "foo", "bar"))
+  }
+
+  test("buildColumnSelector includes all columns when timestampColumns is None") {
+    val schema = StructType(
+      Seq(
+        StructField("id", StringType, nullable = true),
+        StructField("foo", StringType, nullable = true),
+        StructField("bar", IntegerType, nullable = true)
+      )
+    )
+
+    val selector = Scylla.buildColumnSelector(schema, None)
+
+    val SomeColumns(columns @ _*) = selector
+    val columnNames = columns.map { case c: ColumnName => c.columnName; case other => fail(s"unexpected ref: $other") }.toSet
+    assertEquals(columnNames, Set("id", "foo", "bar"))
+  }
+
+  test(
+    "buildColumnSelector excludes only the specific metadata columns named in timestampColumns"
+  ) {
+    val schema = StructType(
+      Seq(
+        StructField("id", StringType, nullable = true),
+        StructField("value", StringType, nullable = true),
+        StructField("custom_ttl", IntegerType, nullable = true),
+        StructField("custom_wt", LongType, nullable = true),
+        StructField("ttl", IntegerType, nullable = true)
+      )
+    )
+
+    val timestampColumns = Some(TimestampColumns("custom_ttl", "custom_wt"))
+    val selector = Scylla.buildColumnSelector(schema, timestampColumns)
+
+    val SomeColumns(columns @ _*) = selector
+    val columnNames = columns.map { case c: ColumnName => c.columnName; case other => fail(s"unexpected ref: $other") }.toSet
+    assertEquals(columnNames, Set("id", "value", "ttl"))
+  }
+
+}


### PR DESCRIPTION
## Summary
- The column selector passed to `saveToCassandra` included `ttl` and `writetime` metadata columns that are consumed by `WriteConf` (via `TTLOption.perRow` / `TimestampOption.perRow`), not written as actual table columns. This caused an `Invalid row size` error (e.g. 137 instead of 136) in `SqlRowWriter`.
- Extracted `buildColumnSelector` helper that filters out the metadata columns named in `TimestampColumns` before building the `SomeColumns` selector.
- Added unit tests covering the fix.

## Test plan
- [x] Unit tests for `buildColumnSelector` with and without `TimestampColumns`
- [ ] Integration test: CQL -> Parquet -> Scylla round-trip with TTL/writetime preservation