### PR TITLE
Drop DSE solr_query column from DataFrame before writing to Scylla

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -99,6 +99,28 @@ object Scylla {
       }
     }
 
+  /** Columns that the Spark Cassandra Connector considers internal and filters from the write path
+    * (see `TableWriter.InternalColumns`). If these columns are present in the source DataFrame, the
+    * Row will have more values than the connector's `selectedColumns`, causing
+    * `SqlRowWriter.readColumnValues` to fail with "Invalid row size".
+    *
+    * We drop them from the DataFrame before writing so that both sides agree on the column count.
+    */
+  // Mirrors the private TableWriter.InternalColumns from spark-scylladb-connector 4.1.0.
+  // If the connector version changes, verify this set is still in sync.
+  private[writers] val InternalColumns: Set[String] = Set("solr_query")
+
+  /** Drop columns that the Spark Cassandra Connector treats as internal (e.g. DSE's `solr_query`).
+    * The connector filters these from `selectedColumns` but `SqlRowWriter` still validates
+    * `row.size == selectedColumns.size`, so the DataFrame must not contain them.
+    */
+  private[writers] def dropInternalColumns(df: DataFrame): DataFrame = {
+    val toDrop = df.schema.fieldNames.filter(InternalColumns.contains)
+    if (toDrop.nonEmpty) {
+      df.drop(toDrop.toSeq: _*)
+    } else df
+  }
+
   def writeDataframe(
     target: TargetSettings.Scylla,
     renames: List[Rename],
@@ -107,6 +129,8 @@ object Scylla {
     tokenRangeAccumulator: Option[TokenRangeAccumulator],
     source: SourceSettings
   )(implicit spark: SparkSession): Unit = {
+    val cleanDf = dropInternalColumns(df)
+
     val connector = Connectors.targetConnector(spark.sparkContext.getConf, target)
 
     val consistencyLevel = target.consistencyLevel match {
@@ -159,7 +183,7 @@ object Scylla {
     // DataFrame; the access to the rows is positional anyway and the field names
     // are only used to construct the columns part of the INSERT statement.
     val renamedSchema = renames
-      .foldLeft(df) { case (acc, Rename(from, to)) =>
+      .foldLeft(cleanDf) { case (acc, Rename(from, to)) =>
         acc.withColumnRenamed(from, to)
       }
       .schema
@@ -175,9 +199,9 @@ object Scylla {
     // pads the resulting value with trailing zeros corresponding to the scale of the
     // Decimal type. Some users don't like this so we conditionally strip those.
     val rdd =
-      if (!target.stripTrailingZerosForDecimals) df.rdd
+      if (!target.stripTrailingZerosForDecimals) cleanDf.rdd
       else
-        df.rdd.map { row =>
+        cleanDf.rdd.map { row =>
           Row.fromSeq(row.toSeq.map {
             case x: java.math.BigDecimal => x.stripTrailingZeros()
             case x                       => x
@@ -195,7 +219,7 @@ object Scylla {
           connector.withSessionDo(Schema.tableFromCassandra(_, target.keyspace, target.table))
         val targetPkNames = tableDef.primaryKey.map(_.columnName).toSet
 
-        val pkResolution = resolvePrimaryKeyColumns(targetPkNames, renames, df.schema)
+        val pkResolution = resolvePrimaryKeyColumns(targetPkNames, renames, cleanDf.schema)
         pkResolution.unresolvedSourcePkNames.foreach { sourcePkName =>
           log.warn(s"Primary key column '${sourcePkName}' not found in source DataFrame schema")
         }

--- a/tests/src/test/scala/com/scylladb/migrator/writers/ScyllaInternalColumnsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/writers/ScyllaInternalColumnsTest.scala
@@ -1,0 +1,107 @@
+package com.scylladb.migrator.writers
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.{ IntegerType, StringType, StructField, StructType }
+
+class ScyllaInternalColumnsTest extends munit.FunSuite {
+
+  private lazy val spark: SparkSession = SparkSession
+    .builder()
+    .appName("ScyllaInternalColumnsTest")
+    .master("local[*]")
+    .config("spark.sql.shuffle.partitions", "1")
+    .getOrCreate()
+
+  override def afterAll(): Unit = {
+    spark.stop()
+    super.afterAll()
+  }
+
+  test("dropInternalColumns removes solr_query from DataFrame") {
+    val schema = StructType(
+      Seq(
+        StructField("id", StringType, nullable         = true),
+        StructField("value", IntegerType, nullable     = true),
+        StructField("solr_query", StringType, nullable = true)
+      )
+    )
+    val rows = java.util.Arrays.asList(
+      org.apache.spark.sql.Row("a", 1, "q1"),
+      org.apache.spark.sql.Row("b", 2, "q2")
+    )
+    val df = spark.createDataFrame(rows, schema)
+
+    val result = Scylla.dropInternalColumns(df)
+
+    assertEquals(result.schema.fieldNames.toSet, Set("id", "value"))
+    assertEquals(result.count(), 2L)
+    assertEquals(result.first().getString(0), "a")
+    assertEquals(result.first().getInt(1), 1)
+  }
+
+  // In writeDataframe, dropInternalColumns runs BEFORE renames. These tests verify that
+  // interaction: a source column named solr_query is dropped before any rename can touch it,
+  // and a column renamed TO solr_query is not affected by the drop (it still has its original
+  // name at drop time).
+
+  test("dropInternalColumns drops solr_query before renames can act on it") {
+    val schema = StructType(
+      Seq(
+        StructField("id", StringType, nullable         = true),
+        StructField("solr_query", StringType, nullable = true),
+        StructField("value", IntegerType, nullable     = true)
+      )
+    )
+    val rows = java.util.Arrays.asList(
+      org.apache.spark.sql.Row("a", "q1", 1)
+    )
+    val df = spark.createDataFrame(rows, schema)
+
+    // Drop runs first, removing solr_query
+    val cleaned = Scylla.dropInternalColumns(df)
+    // A subsequent rename targeting solr_query has nothing to rename — harmless no-op
+    val renamed = cleaned.withColumnRenamed("solr_query", "search")
+
+    assertEquals(renamed.schema.fieldNames.toSet, Set("id", "value"))
+  }
+
+  test("column renamed TO solr_query survives dropInternalColumns") {
+    val schema = StructType(
+      Seq(
+        StructField("id", StringType, nullable    = true),
+        StructField("query", StringType, nullable = true)
+      )
+    )
+    val rows = java.util.Arrays.asList(
+      org.apache.spark.sql.Row("a", "q1")
+    )
+    val df = spark.createDataFrame(rows, schema)
+
+    // Drop runs first — "query" is not an internal column, so nothing is dropped
+    val cleaned = Scylla.dropInternalColumns(df)
+    assertEquals(cleaned.schema.fieldNames.toSet, Set("id", "query"))
+
+    // Rename happens after — this column now has the internal name, but the drop already ran
+    val renamed = cleaned.withColumnRenamed("query", "solr_query")
+    assertEquals(renamed.schema.fieldNames.toSet, Set("id", "solr_query"))
+  }
+
+  test("dropInternalColumns is a no-op when no internal columns are present") {
+    val schema = StructType(
+      Seq(
+        StructField("id", StringType, nullable     = true),
+        StructField("value", IntegerType, nullable = true)
+      )
+    )
+    val rows = java.util.Arrays.asList(
+      org.apache.spark.sql.Row("a", 1)
+    )
+    val df = spark.createDataFrame(rows, schema)
+
+    val result = Scylla.dropInternalColumns(df)
+
+    assertEquals(result.schema.fieldNames.toSet, Set("id", "value"))
+    assertEquals(result.count(), 1L)
+  }
+
+}


### PR DESCRIPTION
## Summary
- DSE tables with Solr search indexes expose a virtual `solr_query` column. The Spark Cassandra Connector filters it from `selectedColumns` (`TableWriter.InternalColumns`) but `SqlRowWriter` still validates `row.size == selectedColumns.size`, causing `Invalid row size: N instead of N-1` when the source DataFrame includes it.
- Drop columns matching the connector's `InternalColumns` set from the DataFrame at the start of `writeDataframe`.

## Test plan
- [x] Unit test: `ScyllaInternalColumnsTest` verifies `dropInternalColumns` removes `solr_query` and is a no-op when absent
- [x] Manual: migrate a DSE table with `solr_query` column to Scylla