### PR TITLE
Add Docker image build and publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,45 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g. 2.0.0). The image will be tagged as scylladb/scylla-migrator:<version> and scylladb/scylla-migrator:latest."
+        required: true
+
+jobs:
+  publish:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.release
+          push: true
+          tags: |
+            scylladb/scylla-migrator:${{ steps.version.outputs.tag }}
+            scylladb/scylla-migrator:latest

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,41 @@
+# Stage 1: Build the assembly JAR
+FROM openjdk:17-jdk-slim AS build
+
+RUN apt-get update && apt-get install -y curl gnupg && \
+    echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list && \
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x99E82A75642AC823" | apt-key add && \
+    apt-get update && apt-get install -y sbt && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+ENV JAVA_HOME=/usr/local/openjdk-17
+
+RUN export TERM=xterm-color && sbt -mem 8192 migrator/assembly
+
+# Stage 2: Runtime image with Spark and the migrator JAR
+FROM alpine:3.20
+
+ENV SPARK_VERSION=4.0.2 \
+    HADOOP_VERSION=3 \
+    SPARK_HOME="/spark"
+
+RUN set -ex; \
+    apk add --no-cache openjdk17-jre bash coreutils; \
+    wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz; \
+    tar --directory / -xvzf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz; \
+    mv /spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} ${SPARK_HOME}; \
+    rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+
+ENV PATH="${SPARK_HOME}/sbin:${SPARK_HOME}/bin:${PATH}"
+
+WORKDIR ${SPARK_HOME}
+
+COPY --from=build /app/migrator/target/scala-2.13/scylla-migrator-assembly.jar /jars/scylla-migrator-assembly.jar
+
+ENTRYPOINT ["spark-submit", \
+    "--class", "com.scylladb.migrator.Migrator", \
+    "--master", "local[*]", \
+    "--conf", "spark.driver.host=localhost", \
+    "/jars/scylla-migrator-assembly.jar"]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := bash
 .ONESHELL:
 .SHELLFLAGS := -ec
 
-.PHONY: help build docker-build-jar lint lint-fix \
+.PHONY: help build docker-build-jar docker-image lint lint-fix \
         spark-image start-services stop-services wait-for-services \
         start-services-scylla wait-for-services-scylla \
         start-services-cassandra wait-for-services-cassandra test-integration-cassandra \
@@ -20,6 +20,8 @@ SHELL := bash
 
 COMPOSE_FILE := docker-compose-tests.yml
 CACHE_REPO ?= scylladb/migrator-cache
+DOCKER_IMAGE ?= scylladb/scylla-migrator
+DOCKER_TAG ?= latest
 MAX_ATTEMPTS ?= 480
 COVERAGE ?= false
 VERBOSE ?= false
@@ -87,6 +89,9 @@ build: ## Build assembly JAR
 # a local JDK/sbt installation. Not used by CI workflows.
 docker-build-jar: ## Build assembly JAR using Docker (local-dev convenience)
 	$(Q)docker buildx build --file Dockerfile --output type=local,dest=./migrator/target/scala-2.13 .
+
+docker-image: ## Build the migrator Docker image
+	$(Q)docker buildx build --file Dockerfile.release -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
 
 spark-image: ## Pull or build the Spark Docker image
 	$(Q)HASH=$$(find dockerfiles/spark -type f | sort | xargs sha256sum | sha256sum | cut -d' ' -f1 | head -c 16)


### PR DESCRIPTION
## Summary
- Add `Dockerfile.release` — multi-stage build producing a self-contained image with Spark 4.0.2 and the migrator assembly JAR
- Add `make docker-image` target for local builds (configurable via `DOCKER_IMAGE` / `DOCKER_TAG`)
- Add `.github/workflows/docker-publish.yml` — publishes `scylladb/scylla-migrator:latest` and `scylladb/scylla-migrator:<version>` to Docker Hub, triggered on release publish or manual dispatch

## Test plan
- [x] Run `make docker-image` locally and verify the image starts
- [x] Trigger the workflow manually via Actions tab with a test version
- [x] Verify both tags appear on Docker Hub after a release publish