### PR TITLE
Split Alternator and DynamoDB into separate config types

### DIFF
--- a/ansible/files/config.dynamodb.yml
+++ b/ansible/files/config.dynamodb.yml
@@ -26,7 +26,7 @@ source:
   maxMapTasks: 700
 
 target:
-  type: dynamodb
+  type: alternator
   table: "YOUR_TABLE_NAME"
   # For scyllaDB - Alternator target, you need to specify endpoint URL.
   # If you have multiple workers, you could use /etc/hosts, and add 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -68,42 +68,81 @@ source:
 #     port: <port>
 
 # Example for loading from DynamoDB:
+# (Fields prefixed with ## are optional)
 # source:
 #   type: dynamodb
 #   table: <table name>
-#   # Optional - load from a custom endpoint:
-#   endpoint:
-#     # Specify the hostname without a protocol
-#     host: <host>
-#     port: <port>
+#   ## endpoint:
+#   ##   # Specify the hostname without a protocol (the AWS SDK resolves it automatically)
+#   ##   host: <host>
+#   ##   port: <port>
 #
-#   # Optional - specify the region:
-#   # region: <region>
+#   ## region: <region>
 #
-#   # Optional - static credentials:
-#   credentials:
-#     accessKey: <user>
-#     secretKey: <pass>
-#     # Optional - assume role, see https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
-#     assumeRole:
-#       arn: <roleArn>
-#       # Optional - the session name to use. If not set, we use 'scylla-migrator'
-#       sessionName: <sessionName>
+#   ## credentials:
+#   ##   accessKey: <user>
+#   ##   secretKey: <pass>
+#   ##   # assume role, see https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
+#   ##   assumeRole:
+#   ##     arn: <roleArn>
+#   ##     sessionName: <sessionName>
 #
 #   # below controls split factor
-#   scanSegments: 1
+#   ## scanSegments: 1
 #
 #   # throttling settings, set based on your capacity (or wanted capacity)
-#   readThroughput: 1
+#   ## readThroughput: 1
 #
 #   # The value of dynamodb.throughput.read.percent can be between 0.1 and 1.5, inclusively.
 #   # 0.5 represents the default read rate, meaning that the job will attempt to consume half of the read capacity of the table.
 #   # If you increase the value above 0.5, spark will increase the request rate; decreasing the value below 0.5 decreases the read request rate.
 #   # (The actual read rate will vary, depending on factors such as whether there is a uniform key distribution in the DynamoDB table.)
-#   throughputReadPercent: 1.0
+#   ## throughputReadPercent: 1.0
 #
 #   # how many tasks per executor?
-#   maxMapTasks: 1
+#   ## maxMapTasks: 1
+
+# Example for loading from a Scylla Alternator source:
+# (Fields prefixed with ## are optional)
+# source:
+#   type: alternator
+#   table: <table name>
+#   # Endpoint of the Alternator instance.
+#   # Unlike AWS DynamoDB, the protocol prefix ('http://' or 'https://') must be
+#   # included because the endpoint is a custom URL (not resolved by the AWS SDK).
+#   endpoint:
+#     host: http://<alternator-host>
+#     port: 8000
+#
+#   ## region: <region>
+#
+#   ## credentials:
+#   ##   accessKey: <user>
+#   ##   secretKey: <pass>
+#
+#   # below controls split factor
+#   ## scanSegments: 1
+#   ## readThroughput: 1
+#   ## throughputReadPercent: 1.0
+#   ## maxMapTasks: 1
+#
+#   # Remove consumed capacity headers from DynamoDB requests (defaults to true for Alternator).
+#   # Needed for Scylla version > 2024.2 to avoid unnecessary capacity accounting overhead.
+#   ## removeConsumedCapacity: true
+#
+#   # Alternator-specific settings (all optional):
+#   ## datacenter: dc1
+#   ## rack: rack1  (requires datacenter)
+#   ## activeRefreshIntervalMs: 1000
+#   ## idleRefreshIntervalMs: 60000
+#   ## compression: false
+#   ## optimizeHeaders: false
+#   ## maxConnections: 400
+#   ## connectionMaxIdleTimeMs: 600000
+#   ## connectionTimeToLiveMs: 0
+#   ## connectionAcquisitionTimeoutMs: 10000
+#   ## connectionTimeoutMs: 15000
+#   ## maxItemsPerBatch: 100
 
 # Example for loading from a DynamoDB S3 export (see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.Output.html)
 # source:
@@ -195,41 +234,38 @@ target:
   # writetime in microseconds (sample 1640998861000 is Saturday, January 1, 2022 2:01:01 AM GMT+01:00 )
   #writeWritetimestampInuS: 1640998861000
 
-# Example for loading into a DynamoDB target (for example, Scylla's Alternator):
+# Example for writing into a DynamoDB target:
+# (Fields prefixed with ## are optional)
 # target:
 #   type: dynamodb
 #   table: <table name>
-#   # Optional - write to a custom endpoint:
-#   endpoint:
-#     # If writing to Scylla Alternator, prefix the hostname with 'http://'.
-#     host: <host>
-#     port: <port>
+#   ## endpoint:
+#   ##   # Specify the hostname without a protocol (the AWS SDK resolves it automatically)
+#   ##   host: <host>
+#   ##   port: <port>
 #
-#   # Optional - specify the region:
-#   # region: <region>
+#   ## region: <region>
 #
-#   # Optional - static credentials:
-#   credentials:
-#     accessKey: <user>
-#     secretKey: <pass>
-#     # Optional - assume role, see https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
-#     assumeRole:
-#       arn: <roleArn>
-#       # Optional - the session name to use. If not set, we use 'scylla-migrator'
-#       sessionName: <roleSessionName>
+#   ## credentials:
+#   ##   accessKey: <user>
+#   ##   secretKey: <pass>
+#   ##   # assume role, see https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html
+#   ##   assumeRole:
+#   ##     arn: <roleArn>
+#   ##     sessionName: <roleSessionName>
 #
 #   # throttling settings, set based on your write capacity units (or wanted capacity)
-#   writeThroughput: 1
+#   ## writeThroughput: 1
 #
 #   # The value of dynamodb.throughput.write.percent can be between 0.1 and 1.5, inclusively.
 #   # 0.5 represents the default write rate, meaning that the job will attempt to consume half of the write capacity of the table.
 #   # If you increase the value above 0.5, spark will increase the request rate; decreasing the value below 0.5 decreases the write request rate.
 #   # (The actual write rate will vary, depending on factors such as whether there is a uniform key distribution in the DynamoDB table.)
-#   throughputWritePercent: 1.0
+#   ## throughputWritePercent: 1.0
 #
-#   # When transferring DynamoDB sources to DynamoDB targets (such as other DynamoDB tables or Alternator tables),
-#   # the migrator supports transferring live changes occuring on the source table after transferring an initial
-#   # snapshot. This is done using DynamoDB streams and incurs additional charges due to the Kinesis streams created.
+#   # When transferring DynamoDB sources to DynamoDB targets, the migrator supports transferring live changes
+#   # occuring on the source table after transferring an initial snapshot. This is done using DynamoDB streams
+#   # and incurs additional charges due to the Kinesis streams created.
 #   # Enable this flag to transfer live changes after transferring an initial snapshot. The migrator will continue
 #   # replicating changes endlessly; it must be stopped manually.
 #   #
@@ -240,48 +276,56 @@ target:
 #   # migrator run.
 #   streamChanges: false
 #
-#   # Optional - explicitly set the billing mode when creating the target table.
-#   # Set to PROVISIONED or PAY_PER_REQUEST. If omitted, the mode is derived
-#   # from the source table or defaults to PAY_PER_REQUEST.
-#   billingMode: PAY_PER_REQUEST
+#   ## billingMode: PAY_PER_REQUEST
 #
-#   # When billingMode is set to PROVISIONED or unset this should be true
-#   # Table created with provisioned mode in Alternator should have the `--provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1` set
-#   # It configures the capacity accounting and removes the need for it (needed for Scylla version > 2024.2)
-#   # removeConsumedCapacity: true
+#   ## skipInitialSnapshotTransfer: false
+
+# Example for writing into a Scylla Alternator target:
+# (Fields prefixed with ## are optional)
+# target:
+#   type: alternator
+#   table: <table name>
+#   # Endpoint of the Alternator instance.
+#   # Unlike AWS DynamoDB, the protocol prefix ('http://' or 'https://') must be
+#   # included because the endpoint is a custom URL (not resolved by the AWS SDK).
+#   endpoint:
+#     host: http://<alternator-host>
+#     port: 8000
 #
-#   # Optional - when streamChanges is true, skip the initial snapshot transfer and only stream changes.
-#   # This setting is ignored if streamChanges is false.
-#   #skipInitialSnapshotTransfer: false
+#   ## region: <region>
 #
-#   # Optional - Alternator-specific settings (only used when endpoint is set):
-#   #alternator:
-#   #  # Preferred datacenter for DC-aware routing (falls back to all nodes if unavailable)
-#   #  datacenter: dc1
-#   #  # Preferred rack for rack-aware routing (requires datacenter, falls back to DC then all nodes)
-#   #  rack: rack1
-#   #  # Interval (ms) for refreshing the node list while the client is active (default: 1000)
-#   #  activeRefreshIntervalMs: 1000
-#   #  # Interval (ms) for refreshing the node list while the client is idle (default: 60000)
-#   #  idleRefreshIntervalMs: 60000
-#   #  # Enable GZIP compression of request bodies (default: false)
-#   #  compression: false
-#   #  # Optimize HTTP headers to reduce traffic overhead (default: false)
-#   #  optimizeHeaders: false
-#   #  # Maximum connections in the HTTP connection pool (default: 400)
-#   #  maxConnections: 400
-#   #  # Maximum idle time for pooled connections in ms (default: 600000)
-#   #  connectionMaxIdleTimeMs: 600000
-#   #  # Maximum lifetime for pooled connections in ms, 0 = unlimited (default: 0)
-#   #  connectionTimeToLiveMs: 0
-#   #  # Maximum time to wait when the pool is exhausted in ms (default: 10000)
-#   #  connectionAcquisitionTimeoutMs: 10000
-#   #  # Maximum time to wait for TCP handshake in ms (default: 15000)
-#   #  connectionTimeoutMs: 15000
-#   #  # Maximum items per BatchWriteItem request. DynamoDB limits this to 25,
-#   #  # but Alternator defaults the limit to 100
-#   #  # See https://docs.scylladb.com/manual/stable/alternator/compatibility.html#configurable-or-different-limits
-#   #  maxItemsPerBatch: 100
+#   ## credentials:
+#   ##   accessKey: <user>
+#   ##   secretKey: <pass>
+#
+#   # throttling settings, set based on your write capacity units (or wanted capacity)
+#   ## writeThroughput: 1
+#   ## throughputWritePercent: 1.0
+#
+#   # Stream changes from the source table after the initial snapshot transfer.
+#   streamChanges: false
+#
+#   ## billingMode: PAY_PER_REQUEST
+#
+#   # Remove consumed capacity headers from DynamoDB requests (defaults to true for Alternator).
+#   # Needed for Scylla version > 2024.2 to avoid unnecessary capacity accounting overhead.
+#   ## removeConsumedCapacity: true
+#
+#   ## skipInitialSnapshotTransfer: false
+#
+#   # Alternator-specific settings (all optional):
+#   ## datacenter: dc1
+#   ## rack: rack1  (requires datacenter)
+#   ## activeRefreshIntervalMs: 1000
+#   ## idleRefreshIntervalMs: 60000
+#   ## compression: false
+#   ## optimizeHeaders: false
+#   ## maxConnections: 400
+#   ## connectionMaxIdleTimeMs: 600000
+#   ## connectionTimeToLiveMs: 0
+#   ## connectionAcquisitionTimeoutMs: 10000
+#   ## connectionTimeoutMs: 15000
+#   ## maxItemsPerBatch: 100
 
 # Savepoints are configuration files (like this one), saved by the migrator as it
 # runs. Their purpose is to skip token ranges that have already been copied. This

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -52,7 +52,8 @@ Valid values for the source ``type`` are:
 
 - ``cassandra`` for a CQL-compatible source (Apache Cassandra or ScyllaDB).
 - ``parquet`` for a dataset stored using the Parquet format.
-- ``dynamodb`` for a DynamoDB-compatible source (AWS DynamoDB or ScyllaDB Alternator).
+- ``dynamodb`` for a DynamoDB source.
+- ``alternator`` for a ScyllaDB Alternator source.
 - ``dynamodb-s3-export`` for a DynamoDB table exported to S3.
 
 The following subsections detail the schema of each source type.
@@ -136,17 +137,16 @@ A source of type ``parquet`` can be used together with a target of type ``cassan
 DynamoDB Source
 ^^^^^^^^^^^^^^^
 
-A source of type ``dynamodb`` can be used together with a target of type ``dynamodb`` only.
+A source of type ``dynamodb`` can be used together with a target of type ``dynamodb``, ``alternator``, or ``dynamodb-s3-export``.
 
 .. code-block:: yaml
 
   source:
     type: dynamodb
-    # Name of the table to write. If it does not exist, it will be created on the fly.
+    # Name of the source table to read. The table must already exist.
     table: <table>
-    # Connect to a custom endpoint. Mandatory if writing to ScyllaDB Alternator.
+    # Optional - Connect to a custom endpoint such as DynamoDB Local or LocalStack.
     endpoint:
-      # If writing to ScyllaDB Alternator, prefix the hostname with 'http://'.
       host: <host>
       port: <port>
     # Optional - AWS availability region.
@@ -172,11 +172,57 @@ The properties ``scanSegments`` and ``maxMapTasks`` can have significant impact 
 
 Use ``maxMapTasks`` to cap the parallelism level used by the Spark executor when processing each segment.
 
+^^^^^^^^^^^^^^^^^
+Alternator Source
+^^^^^^^^^^^^^^^^^
+
+A source of type ``alternator`` can be used together with a target of type ``dynamodb`` or ``alternator``.
+
+.. code-block:: yaml
+
+  source:
+    type: alternator
+    table: <table>
+    endpoint:
+      # Alternator endpoints must include the protocol prefix.
+      host: http://<host>
+      port: <port>
+    # Optional - AWS availability region.
+    region: <region>
+    # Optional - Authentication credentials. See the section “AWS Authentication” for more details.
+    credentials:
+      accessKey: <access-key>
+      secretKey: <secret-key>
+    # Optional - Split factor for reading. The default is to split the source data into chunks
+    # of 128 MB that can be processed in parallel by the Spark executors.
+    scanSegments: 1
+    # Optional - Throttling settings, set based on your database read capacity units (or wanted capacity)
+    readThroughput: 1
+    # Optional - Can be between 0.1 and 1.5, inclusively.
+    throughputReadPercent: 1.0
+    # Optional - At most how many tasks per Spark executor? The default is to use the same as 'scanSegments'.
+    maxMapTasks: 1
+    # Optional - Remove consumed capacity headers from requests. Defaults to true for Alternator.
+    removeConsumedCapacity: true
+    # Optional - Alternator-specific routing / client tuning.
+    datacenter: dc1
+    rack: rack1
+    activeRefreshIntervalMs: 1000
+    idleRefreshIntervalMs: 60000
+    compression: false
+    optimizeHeaders: false
+    maxConnections: 400
+    connectionMaxIdleTimeMs: 600000
+    connectionTimeToLiveMs: 0
+    connectionAcquisitionTimeoutMs: 10000
+    connectionTimeoutMs: 15000
+    maxItemsPerBatch: 100
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 DynamoDB S3 Export Source
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A source of type ``dynamodb-s3-export`` can be used together with a target of type ``dynamodb`` only.
+A source of type ``dynamodb-s3-export`` can be used together with a target of type ``dynamodb`` or ``alternator``.
 
 .. code-block:: yaml
 
@@ -221,7 +267,8 @@ The ``target`` property describes the type of data to write. It must be an objec
 Valid values for the target ``type`` are:
 
 - ``cassandra`` for a CQL-compatible target (Apache Cassandra or ScyllaDB).
-- ``dynamodb`` for a DynamoDB-compatible target (DynamoDB or ScyllaDB Alternator).
+- ``dynamodb`` for a DynamoDB target.
+- ``alternator`` for a ScyllaDB Alternator target.
 
 The following subsections detail the schema of each target type.
 
@@ -305,7 +352,7 @@ DynamoDB Target
     # If you increase the value above 0.5, spark will increase the request rate; decreasing the value below 0.5 decreases the write request rate.
     # (The actual write rate will vary, depending on factors such as whether there is a uniform key distribution in the DynamoDB table.)
     throughputWritePercent: 1.0
-    # When transferring DynamoDB sources to DynamoDB targets (such as other DynamoDB tables or Alternator tables),
+    # When transferring DynamoDB sources to DynamoDB-like targets (DynamoDB or Alternator),
     # the migrator supports transferring live changes occurring on the source table after transferring an initial
     # snapshot.
     # Please see the documentation page “Stream Changes” for more details about this option.
@@ -313,6 +360,44 @@ DynamoDB Target
     # Optional - When streamChanges is true, skip the initial snapshot transfer and only stream changes.
     # This setting is ignored if streamChanges is false.
     skipInitialSnapshotTransfer: false
+
+^^^^^^^^^^^^^^^^^
+Alternator Target
+^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+  target:
+    type: alternator
+    # Name of the table to write. If it does not exist, it will be created on the fly.
+    table: <table>
+    # Alternator endpoints must include the protocol prefix.
+    endpoint:
+      host: http://<host>
+      port: <port>
+    # Optional - Throttling settings, set based on your database write capacity units (or wanted capacity).
+    writeThroughput: 1
+    # Optional - Can be between 0.1 and 1.5, inclusively.
+    throughputWritePercent: 1.0
+    # Please see the documentation page “Stream Changes” for more details about this option.
+    streamChanges: false
+    # Optional - When streamChanges is true, skip the initial snapshot transfer and only stream changes.
+    skipInitialSnapshotTransfer: false
+    # Optional - Remove consumed capacity headers from requests. Defaults to true for Alternator.
+    removeConsumedCapacity: true
+    # Optional - Alternator-specific routing / client tuning.
+    datacenter: dc1
+    rack: rack1
+    activeRefreshIntervalMs: 1000
+    idleRefreshIntervalMs: 60000
+    compression: false
+    optimizeHeaders: false
+    maxConnections: 400
+    connectionMaxIdleTimeMs: 600000
+    connectionTimeToLiveMs: 0
+    connectionAcquisitionTimeoutMs: 10000
+    connectionTimeoutMs: 15000
+    maxItemsPerBatch: 100
 
 -------
 Renames

--- a/docs/source/migrate-from-dynamodb.rst
+++ b/docs/source/migrate-from-dynamodb.rst
@@ -13,13 +13,13 @@ In file ``config.yaml``, make sure to keep only one ``source`` property and one 
 Configuring the Source
 ----------------------
 
-The data ``source`` can be a DynamoDB or Alternator table, or a DynamoDB S3 export.
+The data ``source`` can be a DynamoDB table, an Alternator table, or a DynamoDB S3 export.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Reading from DynamoDB or Alternator
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
+Reading from DynamoDB
+^^^^^^^^^^^^^^^^^^^^^
 
-In both cases, when reading from DynamoDB or Alternator, the type of source should be ``dynamodb`` in the configuration file. Here is a minimal ``source`` configuration to read a DynamoDB table:
+To read from DynamoDB, use the source type ``dynamodb``. Here is a minimal ``source`` configuration:
 
 .. code-block:: yaml
 
@@ -30,7 +30,7 @@ In both cases, when reading from DynamoDB or Alternator, the type of source shou
 
 Where ``<table>`` is the name of the table to read, and ``<region>`` is the AWS region where the DynamoDB instance is located.
 
-To read from the Alternator, you need to provide an ``endpoint`` instead of a ``region``:
+For custom AWS-compatible endpoints such as DynamoDB Local or LocalStack, you can also provide an ``endpoint``:
 
 .. code-block:: yaml
 
@@ -41,9 +41,30 @@ To read from the Alternator, you need to provide an ``endpoint`` instead of a ``
       host: http://<host>
       port: <port>
 
+Where ``<host>`` and ``<port>`` should be replaced with the host name and TCP port of your custom DynamoDB-compatible endpoint.
+
+^^^^^^^^^^^^^^^^^^^^^^^
+Reading from Alternator
+^^^^^^^^^^^^^^^^^^^^^^^
+
+To read from ScyllaDB Alternator, use the source type ``alternator`` and provide an ``endpoint``:
+
+.. code-block:: yaml
+
+  source:
+    type: alternator
+    table: <table>
+    endpoint:
+      host: http://<host>
+      port: <port>
+
 Where ``<host>`` and ``<port>`` should be replaced with the host name and TCP port of your Alternator instance.
 
-In practice, your source database (DynamoDB or Alternator) may require authentication. You can provide the AWS credentials with the ``credentials`` property:
+The ``endpoint.host`` value must include the protocol prefix (``http://`` or ``https://``) for Alternator.
+
+In practice, your source database may require authentication.
+
+For DynamoDB:
 
 .. code-block:: yaml
 
@@ -56,6 +77,20 @@ In practice, your source database (DynamoDB or Alternator) may require authentic
       secretKey: <secret-key>
 
 Where ``<access-key>`` and ``<secret-key>`` should be replaced with your actual AWS access key and secret key.
+
+For Alternator:
+
+.. code-block:: yaml
+
+  source:
+    type: alternator
+    table: <table>
+    endpoint:
+      host: http://<host>
+      port: <port>
+    credentials:
+      accessKey: <access-key>
+      secretKey: <secret-key>
 
 The Migrator also supports advanced AWS authentication options such as using `AssumeRole <https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html>`_. Please read the :ref:`configuration reference <aws-authentication>` for more details.
 
@@ -156,7 +191,13 @@ The Migrator also supports advanced AWS authentication options such as using `As
 Configuring the Destination
 ---------------------------
 
-The migration ``target`` can be DynamoDB or Alternator. In both cases, we use the configuration type ``dynamodb`` in the configuration. Here is a minimal ``target`` configuration to write to DynamoDB or Alternator:
+The migration ``target`` can be DynamoDB or Alternator.
+
+^^^^^^^^^^^^^^^^^^^
+Writing to DynamoDB
+^^^^^^^^^^^^^^^^^^^
+
+To write to DynamoDB, use the target type ``dynamodb``:
 
 .. code-block:: yaml
 
@@ -164,7 +205,7 @@ The migration ``target`` can be DynamoDB or Alternator. In both cases, we use th
     type: dynamodb
     # Name of the table to write. If it does not exist, it will be created on the fly.
     table: <table>
-    # When transferring DynamoDB sources to DynamoDB targets (such as other DynamoDB tables or Alternator tables),
+    # When transferring DynamoDB sources to DynamoDB-like targets (DynamoDB or Alternator),
     # the migrator supports transferring live changes occurring on the source table after transferring an initial
     # snapshot.
     # Please see the documentation page “Stream Changes” for more details about this option.
@@ -179,9 +220,8 @@ Additionally, you can also set the following optional properties:
   target:
     # ... same as above
 
-    # Connect to a custom endpoint. Mandatory if writing to ScyllaDB Alternator.
+    # Connect to a custom endpoint.
     endpoint:
-      # If writing to ScyllaDB Alternator, prefix the hostname with 'http://'.
       host: <host>
       port: <port>
 
@@ -208,5 +248,47 @@ Additionally, you can also set the following optional properties:
     skipInitialSnapshotTransfer: false
 
 Where ``<host>``, ``<port>``, ``<region>``, ``<access-key>``, and ``<secret-key>`` are replaced with your specific values.
+
+^^^^^^^^^^^^^^^^^^^^^
+Writing to Alternator
+^^^^^^^^^^^^^^^^^^^^^
+
+To write to ScyllaDB Alternator, use the target type ``alternator``:
+
+.. code-block:: yaml
+
+  target:
+    type: alternator
+    table: <table>
+    endpoint:
+      host: http://<host>
+      port: <port>
+    streamChanges: false
+
+The ``endpoint.host`` value must include the protocol prefix (``http://`` or ``https://``) for Alternator.
+
+In addition to the common DynamoDB-style properties shown above, Alternator targets also support:
+
+.. code-block:: yaml
+
+  target:
+    type: alternator
+    # ... same as above
+
+    # Remove consumed capacity headers from requests. Defaults to true for Alternator.
+    removeConsumedCapacity: true
+
+    # Optional Alternator-specific routing / client tuning:
+    datacenter: dc1
+    rack: rack1
+    activeRefreshIntervalMs: 1000
+    idleRefreshIntervalMs: 60000
+    compression: false
+    optimizeHeaders: false
+    maxConnections: 400
+    connectionMaxIdleTimeMs: 600000
+    connectionTimeToLiveMs: 0
+    connectionAcquisitionTimeoutMs: 10000
+    connectionTimeoutMs: 15000
 
 The Migrator also supports advanced AWS authentication options such as using `AssumeRole <https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html>`_. Please read the :ref:`configuration reference <aws-authentication>` for more details.

--- a/docs/source/stream-changes.rst
+++ b/docs/source/stream-changes.rst
@@ -2,11 +2,23 @@
 Stream Changes
 ==============
 
-Instead of terminating immediately after having copied a snapshot of the source table, the migrator can also keep running and endlessly replicate the changes applied to the source table as they arrive. This feature is only supported when :doc:`reading from DynamoDB and writing to ScyllaDB Alternator </migrate-from-dynamodb>`.
+Instead of terminating immediately after having copied a snapshot of the source table, the migrator can also keep running and endlessly replicate the changes applied to the source table as they arrive. This feature is supported when :doc:`reading from DynamoDB and writing to ScyllaDB Alternator or DynamoDB targets </migrate-from-dynamodb>`.
 
 It works by enabling, on the source table, a `DynamoDB Stream <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html>`_ that emits the changed items data each time an application creates, updates, or deletes data in the source table.
 
 Enable this feature by setting the property ``streamChanges`` to ``true`` in the target database configuration:
+
+.. code-block:: yaml
+
+  target:
+    type: alternator
+    # ...
+    # ... Full configuration not repeated here for the sake of brevity
+    # ...
+    # Enable the feature
+    streamChanges: true
+
+For a DynamoDB target, use ``type: dynamodb`` instead:
 
 .. code-block:: yaml
 
@@ -22,7 +34,7 @@ In this mode, the migrator has to be interrupted manually with ``Control`` + ``C
 
 Note that for the migration to be performed without loosing writes, the initial snapshot transfer must complete within 24 hours. Otherwise, some captured changes may be lost due to the retention period of the table’s stream.
 
-Optionally, you can skip the initial snapshot transfer and only replicate the changed items by setting the property ``skipInitialSnapshotTransfer`` to ``true``:
+Optionally, you can skip the initial snapshot transfer and only replicate the changed items by setting the property ``skipInitialSnapshotTransfer`` to ``true``. The target type can again be either ``alternator`` or ``dynamodb``:
 
 .. code-block:: yaml
 

--- a/docs/source/tutorials/dynamodb-to-scylladb-alternator/spark-data/config.yaml
+++ b/docs/source/tutorials/dynamodb-to-scylladb-alternator/spark-data/config.yaml
@@ -10,7 +10,7 @@ source:
   table: Example
 
 target:
-  type: dynamodb
+  type: alternator
   endpoint:
     host: http://scylla
     port: 8001

--- a/migrator/src/main/scala/com/scylladb/migrator/AwsUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/AwsUtils.scala
@@ -25,12 +25,15 @@ object AwsUtils {
   ): builder.type = {
 
     for (endpoint <- maybeEndpoint)
-      builder.endpointOverride(new URI(endpoint.renderEndpoint))
+      builder.endpointOverride(endpointUri(endpoint))
     maybeCredentialsProvider.foreach(builder.credentialsProvider)
     maybeRegion.map(Region.of).foreach(builder.region)
 
     builder
   }
+
+  private[migrator] def endpointUri(endpoint: DynamoDBEndpoint): URI =
+    new URI(endpoint.renderEndpoint)
 
   /** Compute the final AWS credentials to use to call any AWS API.
     *

--- a/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
@@ -1,7 +1,7 @@
 package com.scylladb.migrator
 
 import com.scylladb.alternator.AlternatorDynamoDbClient
-import com.scylladb.alternator.routing.{ ClusterScope, DatacenterScope, RackScope }
+import com.scylladb.alternator.routing.{ ClusterScope, DatacenterScope, RackScope, RoutingScope }
 import com.scylladb.alternator.RequestCompressionAlgorithm
 import com.scylladb.migrator.config.{
   AlternatorSettings,
@@ -19,7 +19,6 @@ import software.amazon.awssdk.auth.credentials.{
   AwsBasicCredentials,
   AwsCredentialsProvider,
   AwsSessionCredentials,
-  DefaultCredentialsProvider,
   StaticCredentialsProvider
 }
 import software.amazon.awssdk.regions.Region
@@ -58,7 +57,7 @@ import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient
 
 import java.net.URI
 import java.util.stream.Collectors
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Failure, Success, Try, Using }
 import scala.jdk.OptionConverters._
 
 object DynamoUtils {
@@ -82,6 +81,118 @@ object DynamoUtils {
     "scylla.migrator.alternator.connection_timeout_ms"
   private val AlternatorMaxItemsPerBatchConfig =
     "scylla.migrator.alternator.max_items_per_batch"
+  private val UseAlternatorClientConfig = "scylla.migrator.use_alternator_client"
+
+  /** Write all [[AlternatorSettings]] fields into a Hadoop configuration. */
+  private[migrator] def writeAlternatorSettingsToConf(
+    jobConf: JobConf,
+    settings: AlternatorSettings
+  ): Unit = {
+    setOptionalConf(jobConf, AlternatorDatacenterConfig, settings.datacenter)
+    setOptionalConf(jobConf, AlternatorRackConfig, settings.rack)
+    setOptionalConf(
+      jobConf,
+      AlternatorActiveRefreshConfig,
+      settings.activeRefreshIntervalMs.map(_.toString)
+    )
+    setOptionalConf(
+      jobConf,
+      AlternatorIdleRefreshConfig,
+      settings.idleRefreshIntervalMs.map(_.toString)
+    )
+    setOptionalConf(jobConf, AlternatorCompressionConfig, settings.compression.map(_.toString))
+    setOptionalConf(
+      jobConf,
+      AlternatorOptimizeHeadersConfig,
+      settings.optimizeHeaders.map(_.toString)
+    )
+    setOptionalConf(
+      jobConf,
+      AlternatorMaxConnectionsConfig,
+      settings.maxConnections.map(_.toString)
+    )
+    setOptionalConf(
+      jobConf,
+      AlternatorConnectionMaxIdleTimeMsConfig,
+      settings.connectionMaxIdleTimeMs.map(_.toString)
+    )
+    setOptionalConf(
+      jobConf,
+      AlternatorConnectionTimeToLiveMsConfig,
+      settings.connectionTimeToLiveMs.map(_.toString)
+    )
+    setOptionalConf(
+      jobConf,
+      AlternatorConnectionAcquisitionTimeoutMsConfig,
+      settings.connectionAcquisitionTimeoutMs.map(_.toString)
+    )
+    setOptionalConf(
+      jobConf,
+      AlternatorConnectionTimeoutMsConfig,
+      settings.connectionTimeoutMs.map(_.toString)
+    )
+    setOptionalConf(
+      jobConf,
+      AlternatorMaxItemsPerBatchConfig,
+      settings.maxItemsPerBatch.map(_.toString)
+    )
+    setOptionalConf(
+      jobConf,
+      DynamoDBConstants.MAX_ITEMS_PER_BATCH,
+      settings.maxItemsPerBatch.map(_.toString)
+    )
+  }
+
+  /** Read [[AlternatorSettings]] fields from a Hadoop configuration.
+    *
+    * These settings were already validated at config-parse time, so a parse failure here indicates
+    * corruption in the Hadoop config round-trip and should be treated as a fatal error.
+    */
+  private[migrator] def readAlternatorSettingsFromConf(conf: Configuration): AlternatorSettings = {
+    def parseLong(key: String): Option[Long] =
+      Option(conf.get(key)).map { s =>
+        Try(s.toLong).getOrElse(
+          throw new IllegalStateException(
+            s"Failed to parse Hadoop config '$key' value '$s' as Long"
+          )
+        )
+      }
+    def parseInt(key: String): Option[Int] =
+      Option(conf.get(key)).map { s =>
+        Try(s.toInt).getOrElse(
+          throw new IllegalStateException(
+            s"Failed to parse Hadoop config '$key' value '$s' as Int"
+          )
+        )
+      }
+    def parseBoolean(key: String): Option[Boolean] =
+      Option(conf.get(key)).map { s =>
+        Try(s.toBoolean).getOrElse(
+          throw new IllegalStateException(
+            s"Failed to parse Hadoop config '$key' value '$s' as Boolean"
+          )
+        )
+      }
+    AlternatorSettings(
+      datacenter                     = Option(conf.get(AlternatorDatacenterConfig)),
+      rack                           = Option(conf.get(AlternatorRackConfig)),
+      activeRefreshIntervalMs        = parseLong(AlternatorActiveRefreshConfig),
+      idleRefreshIntervalMs          = parseLong(AlternatorIdleRefreshConfig),
+      compression                    = parseBoolean(AlternatorCompressionConfig),
+      optimizeHeaders                = parseBoolean(AlternatorOptimizeHeadersConfig),
+      maxConnections                 = parseInt(AlternatorMaxConnectionsConfig),
+      connectionMaxIdleTimeMs        = parseLong(AlternatorConnectionMaxIdleTimeMsConfig),
+      connectionTimeToLiveMs         = parseLong(AlternatorConnectionTimeToLiveMsConfig),
+      connectionAcquisitionTimeoutMs = parseLong(AlternatorConnectionAcquisitionTimeoutMsConfig),
+      connectionTimeoutMs            = parseLong(AlternatorConnectionTimeoutMsConfig),
+      maxItemsPerBatch               = parseInt(AlternatorMaxItemsPerBatchConfig)
+    )
+  }
+
+  /** Build the interceptor list for removing `ConsumedCapacity` from DynamoDB responses. */
+  def removeConsumedCapacityInterceptors(remove: Boolean): Seq[ExecutionInterceptor] =
+    if (remove) Seq(new RemoveConsumedCapacityInterceptor)
+    else Nil
 
   class RemoveConsumedCapacityInterceptor extends ExecutionInterceptor {
     override def modifyRequest(ctx: Context.ModifyRequest, attrs: ExecutionAttributes): SdkRequest =
@@ -104,178 +215,189 @@ object DynamoUtils {
 
   def replicateTableDefinition(
     sourceDescription: TableDescription,
-    target: TargetSettings.DynamoDB
-  ): TableDescription = {
-    // If non-existent, replicate
-    val targetClient =
+    target: TargetSettings.DynamoDBLike
+  ): TableDescription =
+    Using.resource(
       buildDynamoClient(
         target.endpoint,
         target.finalCredentials.map(_.toProvider),
         target.region,
-        if (target.removeConsumedCapacity.getOrElse(true))
-          Seq(new RemoveConsumedCapacityInterceptor)
-        else Nil,
-        target.alternator
+        removeConsumedCapacityInterceptors(target.removeConsumedCapacity),
+        target.alternatorSettings
       )
+    ) { targetClient =>
+      log.info("Checking for table existence at destination")
+      val describeTargetTableRequest =
+        DescribeTableRequest.builder().tableName(target.table).build()
+      val targetDescription = Try(targetClient.describeTable(describeTargetTableRequest))
+      targetDescription match {
+        case Success(desc) =>
+          log.info(s"Table ${target.table} exists at destination")
+          desc.table()
 
-    log.info("Checking for table existence at destination")
-    val describeTargetTableRequest =
-      DescribeTableRequest.builder().tableName(target.table).build()
-    val targetDescription = Try(targetClient.describeTable(describeTargetTableRequest))
-    targetDescription match {
-      case Success(desc) =>
-        log.info(s"Table ${target.table} exists at destination")
-        desc.table()
+        case Failure(e: ResourceNotFoundException) =>
+          val requestBuilder = CreateTableRequest
+            .builder()
+            .tableName(target.table)
+            .keySchema(sourceDescription.keySchema)
+            .attributeDefinitions(sourceDescription.attributeDefinitions)
 
-      case Failure(e: ResourceNotFoundException) =>
-        val requestBuilder = CreateTableRequest
-          .builder()
-          .tableName(target.table)
-          .keySchema(sourceDescription.keySchema)
-          .attributeDefinitions(sourceDescription.attributeDefinitions)
+          target.billingMode match {
+            case Some(BillingMode.PROVISIONED)
+                if (sourceDescription.provisionedThroughput.readCapacityUnits == 0L ||
+                  sourceDescription.provisionedThroughput.writeCapacityUnits == 0L) =>
+              throw new RuntimeException(
+                "readCapacityUnits and writeCapacityUnits must be set for PROVISIONED billing mode"
+              )
 
-        target.billingMode match {
-          case Some(BillingMode.PROVISIONED)
-              if (sourceDescription.provisionedThroughput.readCapacityUnits == 0L ||
-                sourceDescription.provisionedThroughput.writeCapacityUnits == 0) =>
-            throw new RuntimeException(
-              "readCapacityUnits and writeCapacityUnits must be set for PROVISIONED billing mode"
-            )
-
-          case Some(BillingMode.PROVISIONED) | None
-              if (sourceDescription.provisionedThroughput.readCapacityUnits != 0L &&
-                sourceDescription.provisionedThroughput.writeCapacityUnits != 0) =>
-            log.info(
-              "BillingMode PROVISIONED will be used since writeCapacityUnits and readCapacityUnits are set"
-            )
-            requestBuilder.billingMode(BillingMode.PROVISIONED)
-            requestBuilder.provisionedThroughput(
-              ProvisionedThroughput
-                .builder()
-                .readCapacityUnits(sourceDescription.provisionedThroughput.readCapacityUnits)
-                .writeCapacityUnits(sourceDescription.provisionedThroughput.writeCapacityUnits)
-                .build()
-            )
-
-          // billing mode = PAY_PER_REQUEST or empty ( for backward compatibility )
-          case _ => requestBuilder.billingMode(BillingMode.PAY_PER_REQUEST)
-        }
-        if (sourceDescription.hasLocalSecondaryIndexes) {
-          requestBuilder.localSecondaryIndexes(
-            sourceDescription.localSecondaryIndexes.stream
-              .map(index =>
-                LocalSecondaryIndex
+            case Some(BillingMode.PROVISIONED) | None
+                if (sourceDescription.provisionedThroughput.readCapacityUnits != 0L &&
+                  sourceDescription.provisionedThroughput.writeCapacityUnits != 0L) =>
+              log.info(
+                "BillingMode PROVISIONED will be used since writeCapacityUnits and readCapacityUnits are set"
+              )
+              requestBuilder.billingMode(BillingMode.PROVISIONED)
+              requestBuilder.provisionedThroughput(
+                ProvisionedThroughput
                   .builder()
-                  .indexName(index.indexName())
-                  .keySchema(index.keySchema())
-                  .projection(index.projection())
+                  .readCapacityUnits(sourceDescription.provisionedThroughput.readCapacityUnits)
+                  .writeCapacityUnits(sourceDescription.provisionedThroughput.writeCapacityUnits)
                   .build()
               )
-              .collect(Collectors.toList[LocalSecondaryIndex])
-          )
-        }
-        if (sourceDescription.hasGlobalSecondaryIndexes) {
-          requestBuilder.globalSecondaryIndexes(
-            sourceDescription.globalSecondaryIndexes.stream
-              .map { index =>
-                val builder =
-                  GlobalSecondaryIndex
+
+            // billing mode = PAY_PER_REQUEST or empty ( for backward compatibility )
+            case _ => requestBuilder.billingMode(BillingMode.PAY_PER_REQUEST)
+          }
+          if (sourceDescription.hasLocalSecondaryIndexes) {
+            requestBuilder.localSecondaryIndexes(
+              sourceDescription.localSecondaryIndexes.stream
+                .map(index =>
+                  LocalSecondaryIndex
                     .builder()
                     .indexName(index.indexName())
                     .keySchema(index.keySchema())
                     .projection(index.projection())
-                if (target.billingMode.forall(_ == BillingMode.PROVISIONED))
-                  builder.provisionedThroughput(
-                    ProvisionedThroughput
-                      .builder()
-                      .readCapacityUnits(index.provisionedThroughput.readCapacityUnits)
-                      .writeCapacityUnits(index.provisionedThroughput.writeCapacityUnits)
-                      .build()
-                  )
-                builder.build()
-              }
-              .collect(Collectors.toList[GlobalSecondaryIndex])
-          )
-        }
-
-        log.info(
-          s"Table ${target.table} does not exist at destination - creating it according to definition:"
-        )
-        log.info(sourceDescription.toString)
-        targetClient.createTable(requestBuilder.build())
-        log.info(s"Table ${target.table} created.")
-
-        val waiterResponse =
-          targetClient.waiter().waitUntilTableExists(describeTargetTableRequest).matched
-        waiterResponse.response.toScala match {
-          case Some(describeTableResponse) => describeTableResponse.table
-          case None =>
-            throw new RuntimeException(
-              "Unable to replicate table definition",
-              waiterResponse.exception.get
+                    .build()
+                )
+                .collect(Collectors.toList[LocalSecondaryIndex])
             )
-        }
+          }
+          if (sourceDescription.hasGlobalSecondaryIndexes) {
+            requestBuilder.globalSecondaryIndexes(
+              sourceDescription.globalSecondaryIndexes.stream
+                .map { index =>
+                  val builder =
+                    GlobalSecondaryIndex
+                      .builder()
+                      .indexName(index.indexName())
+                      .keySchema(index.keySchema())
+                      .projection(index.projection())
+                  if (target.billingMode.forall(_ == BillingMode.PROVISIONED))
+                    builder.provisionedThroughput(
+                      ProvisionedThroughput
+                        .builder()
+                        .readCapacityUnits(index.provisionedThroughput.readCapacityUnits)
+                        .writeCapacityUnits(index.provisionedThroughput.writeCapacityUnits)
+                        .build()
+                    )
+                  builder.build()
+                }
+                .collect(Collectors.toList[GlobalSecondaryIndex])
+            )
+          }
 
-      case Failure(otherwise) =>
-        throw new RuntimeException("Failed to check for table existence", otherwise)
+          log.info(
+            s"Table ${target.table} does not exist at destination - creating it according to definition:"
+          )
+          log.info(sourceDescription.toString)
+          targetClient.createTable(requestBuilder.build())
+          log.info(s"Table ${target.table} created.")
+
+          val waiterResponse =
+            targetClient.waiter().waitUntilTableExists(describeTargetTableRequest).matched
+          waiterResponse.response.toScala match {
+            case Some(describeTableResponse) => describeTableResponse.table
+            case None =>
+              waiterResponse.exception.toScala match {
+                case Some(ex) =>
+                  throw new RuntimeException("Unable to replicate table definition", ex)
+                case None =>
+                  throw new RuntimeException(
+                    "Unable to replicate table definition: waiter returned neither response nor exception"
+                  )
+              }
+          }
+
+        case Failure(otherwise) =>
+          throw new RuntimeException("Failed to check for table existence", otherwise)
+      }
     }
-  }
 
-  def enableDynamoStream(source: SourceSettings.DynamoDB): Unit = {
-    val sourceClient =
+  def enableDynamoStream(source: SourceSettings.DynamoDB): Unit =
+    Using.resource(
       buildDynamoClient(
         source.endpoint,
         source.finalCredentials.map(_.toProvider),
         source.region,
-        if (source.removeConsumedCapacity.getOrElse(false))
-          Seq(new RemoveConsumedCapacityInterceptor)
-        else Nil,
-        source.alternator
+        removeConsumedCapacityInterceptors(source.removeConsumedCapacity),
+        source.alternatorSettings
       )
-    val sourceStreamsClient =
-      buildDynamoStreamsClient(
-        source.endpoint,
-        source.finalCredentials.map(_.toProvider),
-        source.region
-      )
-
-    sourceClient
-      .updateTable(
-        UpdateTableRequest
-          .builder()
-          .tableName(source.table)
-          .streamSpecification(
-            StreamSpecification
+    ) { sourceClient =>
+      Using.resource(
+        buildDynamoStreamsClient(
+          source.endpoint,
+          source.finalCredentials.map(_.toProvider),
+          source.region
+        )
+      ) { sourceStreamsClient =>
+        sourceClient
+          .updateTable(
+            UpdateTableRequest
               .builder()
-              .streamEnabled(true)
-              .streamViewType(StreamViewType.NEW_IMAGE)
+              .tableName(source.table)
+              .streamSpecification(
+                StreamSpecification
+                  .builder()
+                  .streamEnabled(true)
+                  .streamViewType(StreamViewType.NEW_IMAGE)
+                  .build()
+              )
               .build()
           )
-          .build()
-      )
 
-    var done = false
-    while (!done) {
-      val tableDesc =
-        sourceClient.describeTable(DescribeTableRequest.builder().tableName(source.table).build())
-      val latestStreamArn = tableDesc.table.latestStreamArn
-      val describeStream =
-        sourceStreamsClient.describeStream(
-          DescribeStreamRequest.builder().streamArn(latestStreamArn).build()
-        )
+        val maxRetries = 60 // 60 * 5s = 5 minutes
+        var retries = 0
+        var done = false
+        while (!done) {
+          val tableDesc =
+            sourceClient.describeTable(
+              DescribeTableRequest.builder().tableName(source.table).build()
+            )
+          val latestStreamArn = tableDesc.table.latestStreamArn
+          val describeStream =
+            sourceStreamsClient.describeStream(
+              DescribeStreamRequest.builder().streamArn(latestStreamArn).build()
+            )
 
-      val streamStatus = describeStream.streamDescription.streamStatus
-      if (streamStatus == StreamStatus.ENABLED) {
-        log.info("Stream enabled successfully")
-        done = true
-      } else {
-        log.info(
-          s"Stream not yet enabled (status ${streamStatus}); waiting for 5 seconds and retrying"
-        )
-        Thread.sleep(5000)
+          val streamStatus = describeStream.streamDescription.streamStatus
+          if (streamStatus == StreamStatus.ENABLED) {
+            log.info("Stream enabled successfully")
+            done = true
+          } else {
+            retries += 1
+            if (retries >= maxRetries)
+              throw new RuntimeException(
+                s"Timed out waiting for stream on table '${source.table}' to become ENABLED " +
+                  s"(last status: ${streamStatus}). Gave up after ${maxRetries} retries (${maxRetries * 5} seconds)."
+              )
+            log.info(
+              s"Stream not yet enabled (status ${streamStatus}); waiting for 5 seconds and retrying (attempt ${retries}/${maxRetries})"
+            )
+            Thread.sleep(5000)
+          }
+        }
       }
     }
-  }
 
   def buildDynamoClient(
     endpoint: Option[DynamoDBEndpoint],
@@ -285,11 +407,13 @@ object DynamoUtils {
     alternatorSettings: Option[AlternatorSettings] = None
   ): DynamoDbClient = {
     val baseBuilder: DynamoDbClientBuilder =
-      if (endpoint.isDefined) {
-        val altBuilder = AlternatorDynamoDbClient.builder()
-        applyAlternatorSettings(altBuilder, alternatorSettings)
-        altBuilder
-      } else DynamoDbClient.builder()
+      alternatorSettings match {
+        case Some(settings) =>
+          val altBuilder = AlternatorDynamoDbClient.builder()
+          applyAlternatorSettings(altBuilder, settings)
+          altBuilder
+        case None => DynamoDbClient.builder()
+      }
     val builder =
       AwsUtils.configureClientBuilder(baseBuilder, endpoint, region, creds)
     val conf = ClientOverrideConfiguration.builder()
@@ -299,37 +423,37 @@ object DynamoUtils {
 
   private def applyAlternatorSettings(
     altBuilder: AlternatorDynamoDbClient.AlternatorDynamoDbClientBuilder,
-    alternatorSettings: Option[AlternatorSettings]
-  ): Unit =
-    for (settings <- alternatorSettings) {
-      val routingScope = (settings.datacenter, settings.rack) match {
+    settings: AlternatorSettings
+  ): Unit = {
+    val routingScope: Option[RoutingScope] =
+      (settings.datacenter, settings.rack) match {
         case (Some(dc), Some(rack)) =>
-          RackScope.of(dc, rack, DatacenterScope.of(dc, ClusterScope.create()))
+          Some(RackScope.of(dc, rack, DatacenterScope.of(dc, ClusterScope.create())))
         case (Some(dc), None) =>
-          DatacenterScope.of(dc, ClusterScope.create())
-        case _ => null
+          Some(DatacenterScope.of(dc, ClusterScope.create()))
+        case _ => None
       }
-      if (routingScope != null)
-        altBuilder.withRoutingScope(routingScope)
-      for (interval <- settings.activeRefreshIntervalMs)
-        altBuilder.withActiveRefreshIntervalMs(interval)
-      for (interval <- settings.idleRefreshIntervalMs)
-        altBuilder.withIdleRefreshIntervalMs(interval)
-      if (settings.compression.getOrElse(false))
-        altBuilder.withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
-      if (settings.optimizeHeaders.getOrElse(false))
-        altBuilder.withOptimizeHeaders(true)
-      for (maxConns <- settings.maxConnections)
-        altBuilder.withMaxConnections(maxConns)
-      for (idleTime <- settings.connectionMaxIdleTimeMs)
-        altBuilder.withConnectionMaxIdleTimeMs(idleTime)
-      for (ttl <- settings.connectionTimeToLiveMs)
-        altBuilder.withConnectionTimeToLiveMs(ttl)
-      for (timeout <- settings.connectionAcquisitionTimeoutMs)
-        altBuilder.withConnectionAcquisitionTimeoutMs(timeout)
-      for (timeout <- settings.connectionTimeoutMs)
-        altBuilder.withConnectionTimeoutMs(timeout)
+    for (scope <- routingScope)
+      altBuilder.withRoutingScope(scope)
+    for (interval <- settings.activeRefreshIntervalMs)
+      altBuilder.withActiveRefreshIntervalMs(interval)
+    for (interval <- settings.idleRefreshIntervalMs)
+      altBuilder.withIdleRefreshIntervalMs(interval)
+    settings.compression.foreach { enabled =>
+      if (enabled) altBuilder.withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
     }
+    settings.optimizeHeaders.foreach(altBuilder.withOptimizeHeaders)
+    for (maxConns <- settings.maxConnections)
+      altBuilder.withMaxConnections(maxConns)
+    for (idleTime <- settings.connectionMaxIdleTimeMs)
+      altBuilder.withConnectionMaxIdleTimeMs(idleTime)
+    for (ttl <- settings.connectionTimeToLiveMs)
+      altBuilder.withConnectionTimeToLiveMs(ttl)
+    for (timeout <- settings.connectionAcquisitionTimeoutMs)
+      altBuilder.withConnectionAcquisitionTimeoutMs(timeout)
+    for (timeout <- settings.connectionTimeoutMs)
+      altBuilder.withConnectionTimeoutMs(timeout)
+  }
 
   def buildDynamoStreamsClient(
     endpoint: Option[DynamoDBEndpoint],
@@ -399,71 +523,20 @@ object DynamoUtils {
     // YARN environment. We disable it to be agnostic to the type of cluster.
     jobConf.set(DynamoDBConstants.YARN_RESOURCE_MANAGER_ENABLED, "false")
 
-    jobConf.set(
-      DynamoDBConstants.CUSTOM_CLIENT_BUILDER_TRANSFORMER,
-      classOf[AlternatorLoadBalancingEnabler].getName
-    )
+    if (alternatorSettings.isDefined)
+      jobConf.set(
+        DynamoDBConstants.CUSTOM_CLIENT_BUILDER_TRANSFORMER,
+        classOf[AlternatorLoadBalancingEnabler].getName
+      )
 
     jobConf.set(RemoveConsumedCapacityConfig, removeConsumedCapacity.toString)
+    jobConf.set(UseAlternatorClientConfig, alternatorSettings.isDefined.toString)
 
     jobConf.set("mapred.output.format.class", classOf[DynamoDBOutputFormat].getName)
     jobConf.set("mapred.input.format.class", classOf[DynamoDBInputFormat].getName)
 
-    for (settings <- alternatorSettings) {
-      setOptionalConf(jobConf, AlternatorDatacenterConfig, settings.datacenter)
-      setOptionalConf(jobConf, AlternatorRackConfig, settings.rack)
-      setOptionalConf(
-        jobConf,
-        AlternatorActiveRefreshConfig,
-        settings.activeRefreshIntervalMs.map(_.toString)
-      )
-      setOptionalConf(
-        jobConf,
-        AlternatorIdleRefreshConfig,
-        settings.idleRefreshIntervalMs.map(_.toString)
-      )
-      setOptionalConf(jobConf, AlternatorCompressionConfig, settings.compression.map(_.toString))
-      setOptionalConf(
-        jobConf,
-        AlternatorOptimizeHeadersConfig,
-        settings.optimizeHeaders.map(_.toString)
-      )
-      setOptionalConf(
-        jobConf,
-        AlternatorMaxConnectionsConfig,
-        settings.maxConnections.map(_.toString)
-      )
-      setOptionalConf(
-        jobConf,
-        AlternatorConnectionMaxIdleTimeMsConfig,
-        settings.connectionMaxIdleTimeMs.map(_.toString)
-      )
-      setOptionalConf(
-        jobConf,
-        AlternatorConnectionTimeToLiveMsConfig,
-        settings.connectionTimeToLiveMs.map(_.toString)
-      )
-      setOptionalConf(
-        jobConf,
-        AlternatorConnectionAcquisitionTimeoutMsConfig,
-        settings.connectionAcquisitionTimeoutMs.map(_.toString)
-      )
-      setOptionalConf(
-        jobConf,
-        AlternatorConnectionTimeoutMsConfig,
-        settings.connectionTimeoutMs.map(_.toString)
-      )
-      setOptionalConf(
-        jobConf,
-        AlternatorMaxItemsPerBatchConfig,
-        settings.maxItemsPerBatch.map(_.toString)
-      )
-      setOptionalConf(
-        jobConf,
-        DynamoDBConstants.MAX_ITEMS_PER_BATCH,
-        settings.maxItemsPerBatch.map(_.toString)
-      )
-    }
+    for (settings <- alternatorSettings)
+      writeAlternatorSettingsToConf(jobConf, settings)
   }
 
   /** @return
@@ -498,57 +571,42 @@ object DynamoUtils {
     private var conf: Configuration = null
 
     override def apply(builder: DynamoDbClientBuilder): DynamoDbClientBuilder = {
+      val useAlternator = conf.get(UseAlternatorClientConfig, "false").toBoolean
       val effectiveBuilder: DynamoDbClientBuilder =
-        Option(conf.get(DynamoDBConstants.ENDPOINT)) match {
-          case Some(customEndpoint) =>
-            val altBuilder = AlternatorDynamoDbClient.builder()
+        if (useAlternator) {
+          val altBuilder = AlternatorDynamoDbClient.builder()
+          for (customEndpoint <- Option(conf.get(DynamoDBConstants.ENDPOINT)))
             altBuilder.endpointOverride(URI.create(customEndpoint))
-            for (region <- Option(conf.get(DynamoDBConstants.REGION)))
-              altBuilder.region(Region.of(region))
-            (
-              Option(conf.get(DynamoDBConstants.DYNAMODB_ACCESS_KEY_CONF)),
-              Option(conf.get(DynamoDBConstants.DYNAMODB_SECRET_KEY_CONF))
-            ) match {
-              case (Some(accessKey), Some(secretKey)) =>
-                val awsCreds =
-                  Option(conf.get(DynamoDBConstants.DYNAMODB_SESSION_TOKEN_CONF)) match {
-                    case Some(token) =>
-                      AwsSessionCredentials.create(accessKey, secretKey, token)
-                    case None =>
-                      AwsBasicCredentials.create(accessKey, secretKey)
-                  }
-                altBuilder.credentialsProvider(StaticCredentialsProvider.create(awsCreds))
-              case _ => // No credentials configured - use anonymous (Alternator default)
-            }
-            applyAlternatorSettings(
-              altBuilder,
-              Some(
-                AlternatorSettings(
-                  datacenter = Option(conf.get(AlternatorDatacenterConfig)),
-                  rack       = Option(conf.get(AlternatorRackConfig)),
-                  activeRefreshIntervalMs =
-                    Option(conf.get(AlternatorActiveRefreshConfig)).map(_.toLong),
-                  idleRefreshIntervalMs =
-                    Option(conf.get(AlternatorIdleRefreshConfig)).map(_.toLong),
-                  compression = Option(conf.get(AlternatorCompressionConfig)).map(_.toBoolean),
-                  optimizeHeaders =
-                    Option(conf.get(AlternatorOptimizeHeadersConfig)).map(_.toBoolean),
-                  maxConnections = Option(conf.get(AlternatorMaxConnectionsConfig)).map(_.toInt),
-                  connectionMaxIdleTimeMs =
-                    Option(conf.get(AlternatorConnectionMaxIdleTimeMsConfig)).map(_.toLong),
-                  connectionTimeToLiveMs =
-                    Option(conf.get(AlternatorConnectionTimeToLiveMsConfig)).map(_.toLong),
-                  connectionAcquisitionTimeoutMs =
-                    Option(conf.get(AlternatorConnectionAcquisitionTimeoutMsConfig)).map(_.toLong),
-                  connectionTimeoutMs =
-                    Option(conf.get(AlternatorConnectionTimeoutMsConfig)).map(_.toLong),
-                  maxItemsPerBatch = Option(conf.get(AlternatorMaxItemsPerBatchConfig)).map(_.toInt)
-                )
+          for (region <- Option(conf.get(DynamoDBConstants.REGION)))
+            altBuilder.region(Region.of(region))
+          (
+            Option(conf.get(DynamoDBConstants.DYNAMODB_ACCESS_KEY_CONF)),
+            Option(conf.get(DynamoDBConstants.DYNAMODB_SECRET_KEY_CONF))
+          ) match {
+            case (Some(accessKey), Some(secretKey)) =>
+              val awsCreds =
+                Option(conf.get(DynamoDBConstants.DYNAMODB_SESSION_TOKEN_CONF)) match {
+                  case Some(token) =>
+                    AwsSessionCredentials.create(accessKey, secretKey, token)
+                  case None =>
+                    AwsBasicCredentials.create(accessKey, secretKey)
+                }
+              altBuilder.credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+            case (Some(_), None) | (None, Some(_)) =>
+              throw new IllegalStateException(
+                "Incomplete DynamoDB credentials in Hadoop config: both accessKey and secretKey must be set, or neither."
               )
+            case _ => // No credentials configured - use anonymous (Alternator default)
+          }
+          val settings = readAlternatorSettingsFromConf(conf)
+          val validationErrors = AlternatorSettings.validate(settings)
+          if (validationErrors.nonEmpty)
+            throw new IllegalStateException(
+              s"AlternatorSettings validation failed after Hadoop config round-trip: ${validationErrors.mkString("; ")}"
             )
-            altBuilder
-          case None => builder
-        }
+          applyAlternatorSettings(altBuilder, settings)
+          altBuilder
+        } else builder
       val overrideConf = ClientOverrideConfiguration.builder()
       if (conf.get(RemoveConsumedCapacityConfig, "false").toBoolean)
         overrideConf.addExecutionInterceptor(new RemoveConsumedCapacityInterceptor)

--- a/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
@@ -54,8 +54,8 @@ object Migrator {
         readers.Parquet.migrateToScylla(config, parquetSource, scyllaTarget)
       case (cqlSource: SourceSettings.Cassandra, parquetTarget: TargetSettings.Parquet) =>
         ScyllaMigrator.migrateToParquet(cqlSource, parquetTarget, config)
-      case (dynamoSource: SourceSettings.DynamoDB, alternatorTarget: TargetSettings.DynamoDB) =>
-        AlternatorMigrator.migrateFromDynamoDB(dynamoSource, alternatorTarget, config)
+      case (dynamoSource: SourceSettings.DynamoDBLike, dynamoTarget: TargetSettings.DynamoDBLike) =>
+        AlternatorMigrator.migrateFromDynamoDB(dynamoSource, dynamoTarget, config)
       case (
             dynamoSource: SourceSettings.DynamoDB,
             s3ExportTarget: TargetSettings.DynamoDBS3Export
@@ -63,9 +63,9 @@ object Migrator {
         AlternatorMigrator.migrateToS3Export(dynamoSource, s3ExportTarget, config)
       case (
             s3Source: SourceSettings.DynamoDBS3Export,
-            alternatorTarget: TargetSettings.DynamoDB
+            dynamoTarget: TargetSettings.DynamoDBLike
           ) =>
-        AlternatorMigrator.migrateFromS3Export(s3Source, alternatorTarget, config)
+        AlternatorMigrator.migrateFromS3Export(s3Source, dynamoTarget, config)
       case (source, target) =>
         sys.error(
           s"Unsupported combination of source and target: " +

--- a/migrator/src/main/scala/com/scylladb/migrator/Validator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Validator.scala
@@ -17,8 +17,8 @@ object Validator {
     (config.source, config.target) match {
       case (cassandraSource: SourceSettings.Cassandra, scyllaTarget: TargetSettings.Scylla) =>
         ScyllaValidator.runValidation(cassandraSource, scyllaTarget, config)
-      case (dynamoSource: SourceSettings.DynamoDB, alternatorTarget: TargetSettings.DynamoDB) =>
-        AlternatorValidator.runValidation(dynamoSource, alternatorTarget, config)
+      case (dynamoSource: SourceSettings.DynamoDBLike, dynamoTarget: TargetSettings.DynamoDBLike) =>
+        AlternatorValidator.runValidation(dynamoSource, dynamoTarget, config)
       case _ =>
         sys.error(
           "Unsupported combination of source and target " +

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
@@ -19,13 +19,23 @@ object AlternatorMigrator {
   private val log = LogManager.getLogger("com.scylladb.migrator.alternator")
 
   def migrateFromDynamoDB(
-    source: SourceSettings.DynamoDB,
-    target: TargetSettings.DynamoDB,
+    source: SourceSettings.DynamoDBLike,
+    target: TargetSettings.DynamoDBLike,
     migratorConfig: MigratorConfig
   )(implicit spark: SparkSession): Unit = {
     val (sourceRDD, sourceTableDesc) =
       readers.DynamoDB.readRDD(spark, source, migratorConfig.skipSegments)
-    val maybeStreamedSource = if (target.streamChanges) Some(source) else None
+    val maybeStreamedSource = source match {
+      case d: SourceSettings.DynamoDB if target.streamChanges => Some(d)
+      case _                                                  => None
+    }
+    if (target.streamChanges && maybeStreamedSource.isEmpty) {
+      throw new IllegalArgumentException(
+        "streamChanges is true on the target, but the source does not support DynamoDB Streams. " +
+          "This combination should have been rejected at config-parse time. " +
+          "Stream replication cannot proceed."
+      )
+    }
     migrate(sourceRDD, sourceTableDesc, maybeStreamedSource, target, migratorConfig)
   }
 
@@ -53,7 +63,7 @@ object AlternatorMigrator {
 
   def migrateFromS3Export(
     source: SourceSettings.DynamoDBS3Export,
-    target: TargetSettings.DynamoDB,
+    target: TargetSettings.DynamoDBLike,
     migratorConfig: MigratorConfig
   )(implicit spark: SparkSession): Unit = {
     val (sourceRDD, sourceTableDesc) = readers.DynamoDBS3Export.readRDD(source)(spark.sparkContext)
@@ -62,9 +72,6 @@ object AlternatorMigrator {
       sourceRDD.map { item =>
         (new Text(), new DynamoDBItemWritable(item.asJava))
       }
-    if (target.streamChanges) {
-      log.warn("'streamChanges: true' is not supported when the source is a DynamoDB S3 export.")
-    }
     migrate(normalizedRDD, sourceTableDesc, None, target, migratorConfig)
   }
 
@@ -85,7 +92,7 @@ object AlternatorMigrator {
     sourceRDD: RDD[(Text, DynamoDBItemWritable)],
     sourceTableDesc: TableDescription,
     maybeStreamedSource: Option[SourceSettings.DynamoDB],
-    target: TargetSettings.DynamoDB,
+    target: TargetSettings.DynamoDBLike,
     migratorConfig: MigratorConfig
   )(implicit spark: SparkSession): Unit = {
 
@@ -106,7 +113,7 @@ object AlternatorMigrator {
         )
       }
 
-      if (target.streamChanges && target.skipInitialSnapshotTransfer.contains(true)) {
+      if (maybeStreamedSource.isDefined && target.skipInitialSnapshotTransfer.contains(true)) {
         log.info("Skip transferring table snapshot")
       } else {
         Using.resource(DynamoDbSavepointsManager(migratorConfig, sourceRDD, spark.sparkContext)) {

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
@@ -17,8 +17,8 @@ object AlternatorValidator {
     *   A list of comparison failures (which is empty if the data are the same in both databases).
     */
   def runValidation(
-    sourceSettings: SourceSettings.DynamoDB,
-    targetSettings: TargetSettings.DynamoDB,
+    sourceSettings: SourceSettings.DynamoDBLike,
+    targetSettings: TargetSettings.DynamoDBLike,
     config: MigratorConfig
   )(implicit spark: SparkSession): List[RowComparisonFailure] = {
 
@@ -46,7 +46,8 @@ object AlternatorValidator {
       sourceSettings.readThroughput,
       sourceSettings.throughputReadPercent,
       skipSegments           = None,
-      removeConsumedCapacity = targetSettings.removeConsumedCapacity.getOrElse(true)
+      removeConsumedCapacity = targetSettings.removeConsumedCapacity,
+      alternatorSettings     = targetSettings.alternatorSettings
     )
 
     // Define some aliases to prevent the Spark engine to try to serialize the whole object graph

--- a/migrator/src/main/scala/com/scylladb/migrator/config/AlternatorSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/AlternatorSettings.scala
@@ -1,6 +1,6 @@
 package com.scylladb.migrator.config
 
-import io.circe.{ Decoder, Encoder }
+import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 
 case class AlternatorSettings(
@@ -20,5 +20,99 @@ case class AlternatorSettings(
 
 object AlternatorSettings {
   implicit val decoder: Decoder[AlternatorSettings] = deriveDecoder
-  implicit val encoder: Encoder[AlternatorSettings] = deriveEncoder
+  implicit val asObjectEncoder: Encoder.AsObject[AlternatorSettings] = deriveEncoder
+
+  /** Field names of AlternatorSettings, used by DynamoDB decoders to reject Alternator-only fields.
+    * Derived from the case class to stay in sync automatically.
+    */
+  val fieldNames: Set[String] = AlternatorSettings().productElementNames.toSet
+
+  private def hasProtocolPrefix(host: String): Boolean = {
+    val lower = host.toLowerCase(java.util.Locale.ROOT)
+    lower.startsWith("http://") || lower.startsWith("https://")
+  }
+
+  /** Guard the `type: dynamodb` / `type: dynamo` decoder branch.
+    *
+    * Rejects configs that contain Alternator-specific keys (for example a nested `alternator`
+    * block, `removeConsumedCapacity`, or any [[AlternatorSettings]] field) and suggests switching
+    * to `type: alternator`.
+    *
+    * @param cursor
+    *   JSON cursor positioned at the source/target object
+    * @param label
+    *   `"Source"` or `"Target"`, used in error messages
+    * @return
+    *   `Right(())` when valid, `Left(DecodingFailure)` otherwise
+    */
+  def guardDynamoDBType(
+    cursor: HCursor,
+    label: String
+  ): Either[DecodingFailure, Unit] = {
+    val guardErrors = List.newBuilder[String]
+    if (cursor.downField("alternator").focus.isDefined)
+      guardErrors +=
+        s"$label type 'dynamodb' contains a nested 'alternator' key. " +
+          "Please change the type to 'alternator' and promote the nested Alternator settings to top level."
+    if (cursor.downField("removeConsumedCapacity").focus.isDefined)
+      guardErrors +=
+        s"$label type 'dynamodb' does not support 'removeConsumedCapacity'. " +
+          "This setting is only applicable to type 'alternator'."
+    val presentKeys = cursor.keys.map(_.toSet).getOrElse(Set.empty)
+    val badKeys = presentKeys.intersect(fieldNames)
+    if (badKeys.nonEmpty)
+      guardErrors +=
+        s"$label type 'dynamodb' does not support Alternator-only fields: ${badKeys.toSeq.sorted
+            .mkString(", ")}. " +
+          "Please change the type to 'alternator' if you want to use these settings."
+    val allGuardErrors = guardErrors.result()
+    if (allGuardErrors.nonEmpty)
+      Left(DecodingFailure(allGuardErrors.mkString("; "), cursor.history))
+    else
+      Right(())
+  }
+
+  /** Validate common Alternator decoding concerns and return error messages if invalid. Checks:
+    * endpoint required, protocol prefix required, assumeRole not supported, plus all
+    * AlternatorSettings-level validations.
+    */
+  def validateDecoding(
+    endpoint: Option[DynamoDBEndpoint],
+    credentials: Option[AWSCredentials],
+    altSettings: AlternatorSettings
+  ): List[String] = {
+    val errors = List.newBuilder[String]
+    if (endpoint.isEmpty)
+      errors += "requires an 'endpoint' to be set."
+    if (endpoint.exists(e => !hasProtocolPrefix(e.host)))
+      errors += "endpoint host must include a protocol prefix ('http://' or 'https://')."
+    if (credentials.flatMap(_.assumeRole).isDefined)
+      errors += "does not support 'assumeRole' in credentials."
+    errors ++= validate(altSettings)
+    errors.result()
+  }
+
+  /** Validate Alternator-specific fields and return error messages if invalid. */
+  def validate(s: AlternatorSettings): List[String] = {
+    val errors = List.newBuilder[String]
+    if (s.rack.isDefined && s.datacenter.isEmpty)
+      errors += "'rack' is set without 'datacenter'. Please also set 'datacenter' when using 'rack'."
+    if (s.maxConnections.exists(_ <= 0))
+      errors += "'maxConnections' must be a positive integer."
+    if (s.activeRefreshIntervalMs.exists(_ <= 0))
+      errors += "'activeRefreshIntervalMs' must be a positive value."
+    if (s.idleRefreshIntervalMs.exists(_ <= 0))
+      errors += "'idleRefreshIntervalMs' must be a positive value."
+    if (s.connectionMaxIdleTimeMs.exists(_ < 0))
+      errors += "'connectionMaxIdleTimeMs' must not be negative."
+    if (s.connectionTimeToLiveMs.exists(_ < 0))
+      errors += "'connectionTimeToLiveMs' must not be negative."
+    if (s.connectionAcquisitionTimeoutMs.exists(_ < 0))
+      errors += "'connectionAcquisitionTimeoutMs' must not be negative."
+    if (s.connectionTimeoutMs.exists(_ < 0))
+      errors += "'connectionTimeoutMs' must not be negative."
+    if (s.maxItemsPerBatch.exists(_ <= 0))
+      errors += "'maxItemsPerBatch' must be a positive integer."
+    errors.result()
+  }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
@@ -7,6 +7,7 @@ import io.circe.syntax._
 import io.circe.yaml.parser
 import io.circe.yaml.syntax._
 import io.circe.{ Decoder, DecodingFailure, Encoder, Error, Json }
+import scala.util.Using
 
 case class MigratorConfig(
   source: SourceSettings,
@@ -48,11 +49,31 @@ object MigratorConfig {
     } yield result
   }
 
-  implicit val migratorConfigDecoder: Decoder[MigratorConfig] = deriveDecoder[MigratorConfig]
+  implicit val migratorConfigDecoder: Decoder[MigratorConfig] =
+    deriveDecoder[MigratorConfig].emap { config =>
+      (config.source, config.target) match {
+        case (_: SourceSettings.Alternator, t: TargetSettings.DynamoDBLike) if t.streamChanges =>
+          Left(
+            "'streamChanges: true' is not supported when the source is an Alternator table. " +
+              "Scylla Alternator does not support DynamoDB Streams."
+          )
+        case (_: SourceSettings.Alternator, _: TargetSettings.DynamoDBS3Export) =>
+          Left(
+            "A source of type 'alternator' is not supported with target type 'dynamodb-s3-export'. " +
+              "DynamoDB S3 export output is only supported when the source is AWS DynamoDB."
+          )
+        case (_: SourceSettings.DynamoDBS3Export, t: TargetSettings.DynamoDBLike)
+            if t.streamChanges =>
+          Left(
+            "'streamChanges: true' is not supported when the source is a DynamoDB S3 export."
+          )
+        case _ => Right(config)
+      }
+    }
   implicit val migratorConfigEncoder: Encoder[MigratorConfig] = deriveEncoder[MigratorConfig]
 
   def loadFrom(path: String): MigratorConfig = {
-    val configData = scala.io.Source.fromFile(path).mkString
+    val configData = Using.resource(scala.io.Source.fromFile(path))(_.mkString)
 
     parser
       .parse(configData)

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
@@ -7,8 +7,27 @@ import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import software.amazon.awssdk.services.dynamodb.model.BillingMode
 
+/** Endpoint for DynamoDB-protocol connections.
+  *
+  * The semantics of `host` differ by context:
+  *   - '''DynamoDB (AWS/custom endpoints):''' either a bare hostname, e.g.
+  *     `dynamodb.us-east-1.amazonaws.com`, or a full URL such as `http://localhost`
+  *   - '''Alternator (Scylla):''' must include protocol prefix, e.g. `http://10.0.0.1`
+  *
+  * Bare DynamoDB hosts are normalized to `http://` when passed to APIs that require an absolute
+  * URI. The protocol requirement for Alternator endpoints is validated at config parse time.
+  */
 case class DynamoDBEndpoint(host: String, port: Int) {
-  def renderEndpoint = s"${host}:${port}"
+  def renderEndpoint: String = {
+    val trimmedHost = host.stripSuffix("/")
+    val lowerHost = trimmedHost.toLowerCase(java.util.Locale.ROOT)
+    val endpointHost =
+      if (lowerHost.startsWith("http://") || lowerHost.startsWith("https://"))
+        trimmedHost
+      else
+        s"http://${trimmedHost}"
+    s"${endpointHost}:${port}"
+  }
 }
 
 object DynamoDBEndpoint {
@@ -33,6 +52,31 @@ object SourceSettings {
     where: Option[String],
     consistencyLevel: String
   ) extends SourceSettings
+
+  /** Common trait for DynamoDB-protocol sources (both AWS DynamoDB and Scylla Alternator). */
+  sealed trait DynamoDBLike extends SourceSettings {
+    def endpoint: Option[DynamoDBEndpoint]
+    def region: Option[String]
+    def credentials: Option[AWSCredentials]
+    def table: String
+    def scanSegments: Option[Int]
+    def readThroughput: Option[Int]
+    def throughputReadPercent: Option[Float]
+    def maxMapTasks: Option[Int]
+
+    /** Whether to strip `ConsumedCapacity` from DynamoDB responses.
+      *
+      *   - '''DynamoDB (AWS):''' defaults to `false` -- AWS uses consumed capacity for throttling
+      *     and billing feedback.
+      *   - '''Alternator (Scylla):''' defaults to `true` -- Scylla Alternator does not support
+      *     `ConsumedCapacity`, so leaving it enabled would produce unnecessary overhead or errors.
+      */
+    def removeConsumedCapacity: Boolean
+    def alternatorSettings: Option[AlternatorSettings]
+    lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
+      AwsUtils.computeFinalCredentials(credentials, endpoint, region)
+  }
+
   case class DynamoDB(
     endpoint: Option[DynamoDBEndpoint],
     region: Option[String],
@@ -41,13 +85,28 @@ object SourceSettings {
     scanSegments: Option[Int],
     readThroughput: Option[Int],
     throughputReadPercent: Option[Float],
-    maxMapTasks: Option[Int],
-    removeConsumedCapacity: Option[Boolean] = None,
-    alternator: Option[AlternatorSettings] = None
-  ) extends SourceSettings {
-    lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
-      AwsUtils.computeFinalCredentials(credentials, endpoint, region)
+    maxMapTasks: Option[Int]
+  ) extends DynamoDBLike {
+    val removeConsumedCapacity: Boolean = false
+    val alternatorSettings: Option[AlternatorSettings] = None
   }
+
+  case class Alternator(
+    alternatorEndpoint: DynamoDBEndpoint,
+    region: Option[String],
+    credentials: Option[AWSCredentials],
+    table: String,
+    scanSegments: Option[Int],
+    readThroughput: Option[Int],
+    throughputReadPercent: Option[Float],
+    maxMapTasks: Option[Int],
+    removeConsumedCapacity: Boolean = true,
+    alternatorConfig: AlternatorSettings = AlternatorSettings()
+  ) extends DynamoDBLike {
+    val endpoint: Option[DynamoDBEndpoint] = Some(alternatorEndpoint)
+    val alternatorSettings: Option[AlternatorSettings] = Some(alternatorConfig)
+  }
+
   case class Parquet(
     path: String,
     credentials: Option[AWSCredentials],
@@ -151,6 +210,21 @@ object SourceSettings {
     }
   }
 
+  private def validateDynamoDBLikeSource(s: DynamoDBLike): List[String] = {
+    val errors = List.newBuilder[String]
+    if (s.table.trim.isEmpty)
+      errors += "'table' must not be empty."
+    if (s.scanSegments.exists(_ <= 0))
+      errors += "'scanSegments' must be a positive integer."
+    if (s.readThroughput.exists(_ <= 0))
+      errors += "'readThroughput' must be a positive integer."
+    if (s.throughputReadPercent.exists(v => v < 0.1f || v > 1.5f))
+      errors += "'throughputReadPercent' must be between 0.1 and 1.5."
+    if (s.maxMapTasks.exists(_ <= 0))
+      errors += "'maxMapTasks' must be a positive integer."
+    errors.result()
+  }
+
   implicit val decoder: Decoder[SourceSettings] = Decoder.instance { cursor =>
     cursor.get[String]("type").flatMap {
       case "cassandra" | "scylla" =>
@@ -158,7 +232,100 @@ object SourceSettings {
       case "parquet" =>
         deriveDecoder[Parquet].apply(cursor)
       case "dynamo" | "dynamodb" =>
-        deriveDecoder[DynamoDB].apply(cursor)
+        AlternatorSettings.guardDynamoDBType(cursor, "Source").flatMap { _ =>
+          deriveDecoder[DynamoDB].apply(cursor).flatMap { d =>
+            val allErrors = validateDynamoDBLikeSource(d)
+            if (allErrors.nonEmpty)
+              Left(
+                DecodingFailure(
+                  s"Source type 'dynamodb': ${allErrors.mkString("; ")}",
+                  cursor.history
+                )
+              )
+            else Right(d)
+          }
+        }
+      case "alternator" =>
+        for {
+          _ <- Either.cond(
+                 cursor.downField("alternator").focus.isEmpty,
+                 (),
+                 DecodingFailure(
+                   "Source type 'alternator' does not use a nested 'alternator' block; " +
+                     "place Alternator settings at the top level.",
+                   cursor.history
+                 )
+               )
+          altSettings           <- AlternatorSettings.decoder(cursor)
+          maybeEndpoint         <- cursor.get[Option[DynamoDBEndpoint]]("endpoint")
+          region                <- cursor.get[Option[String]]("region")
+          credentials           <- cursor.get[Option[AWSCredentials]]("credentials")
+          table                 <- cursor.get[String]("table")
+          scanSegments          <- cursor.get[Option[Int]]("scanSegments")
+          readThroughput        <- cursor.get[Option[Int]]("readThroughput")
+          throughputReadPercent <- cursor.get[Option[Float]]("throughputReadPercent")
+          maxMapTasks           <- cursor.get[Option[Int]]("maxMapTasks")
+          // Default to true for Alternator (Scylla doesn't support ConsumedCapacity).
+          rcc <- cursor.getOrElse[Boolean]("removeConsumedCapacity")(true)
+          result <- {
+            val errors = List.newBuilder[String]
+            errors ++= AlternatorSettings.validateDecoding(
+              maybeEndpoint,
+              credentials,
+              altSettings
+            )
+            errors ++= validateDynamoDBLikeSource(
+              // Temporarily build with a dummy endpoint for shared validation.
+              // The endpoint-required check is already in validateDecoding above.
+              Alternator(
+                maybeEndpoint.getOrElse(DynamoDBEndpoint("http://placeholder", 0)),
+                region,
+                credentials,
+                table,
+                scanSegments,
+                readThroughput,
+                throughputReadPercent,
+                maxMapTasks,
+                rcc,
+                altSettings
+              )
+            )
+            val allErrors = errors.result()
+            if (allErrors.nonEmpty)
+              Left(
+                DecodingFailure(
+                  s"Source type 'alternator': ${allErrors.mkString("; ")}",
+                  cursor.history
+                )
+              )
+            else
+              maybeEndpoint match {
+                case Some(ep) =>
+                  Right(
+                    Alternator(
+                      ep,
+                      region,
+                      credentials,
+                      table,
+                      scanSegments,
+                      readThroughput,
+                      throughputReadPercent,
+                      maxMapTasks,
+                      rcc,
+                      altSettings
+                    )
+                  )
+                case None =>
+                  // Should not reach here: validateDecoding already rejects missing endpoint.
+                  Left(
+                    DecodingFailure(
+                      "Source type 'alternator' requires an 'endpoint' to be set.",
+                      cursor.history
+                    )
+                  )
+              }
+          }
+        } yield result
       case "dynamodb-s3-export" =>
         deriveDecoder[DynamoDBS3Export].apply(cursor)
       case otherwise =>
@@ -170,21 +337,37 @@ object SourceSettings {
     case s: Cassandra =>
       deriveEncoder[Cassandra]
         .encodeObject(s)
+        .filter { case (_, v) => !v.isNull }
         .add("type", Json.fromString("cassandra"))
         .asJson
     case s: DynamoDB =>
       deriveEncoder[DynamoDB]
         .encodeObject(s)
+        .filter { case (_, v) => !v.isNull }
         .add("type", Json.fromString("dynamodb"))
+        .asJson
+    case s: Alternator =>
+      val baseObj = deriveEncoder[Alternator]
+        .encodeObject(s)
+        .remove("alternatorConfig")
+        .remove("alternatorEndpoint")
+        .add("endpoint", Encoder[DynamoDBEndpoint].apply(s.alternatorEndpoint))
+      val altObj = AlternatorSettings.asObjectEncoder.encodeObject(s.alternatorConfig)
+      altObj.toList
+        .foldLeft(baseObj) { case (acc, (k, v)) => acc.add(k, v) }
+        .filter { case (_, v) => !v.isNull }
+        .add("type", Json.fromString("alternator"))
         .asJson
     case s: Parquet =>
       deriveEncoder[Parquet]
         .encodeObject(s)
+        .filter { case (_, v) => !v.isNull }
         .add("type", Json.fromString("parquet"))
         .asJson
     case s: DynamoDBS3Export =>
       deriveEncoder[DynamoDBS3Export]
         .encodeObject(s)
+        .filter { case (_, v) => !v.isNull }
         .add("type", Json.fromString("dynamodb-s3-export"))
         .asJson
   }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
@@ -26,6 +26,31 @@ object TargetSettings {
     dropNullPrimaryKeys: Option[Boolean] = None
   ) extends TargetSettings
 
+  /** Common trait for DynamoDB-protocol targets (both AWS DynamoDB and Scylla Alternator). */
+  sealed trait DynamoDBLike extends TargetSettings {
+    def endpoint: Option[DynamoDBEndpoint]
+    def region: Option[String]
+    def credentials: Option[AWSCredentials]
+    def table: String
+    def writeThroughput: Option[Int]
+    def throughputWritePercent: Option[Float]
+    def streamChanges: Boolean
+    def skipInitialSnapshotTransfer: Option[Boolean]
+
+    /** Whether to strip `ConsumedCapacity` from DynamoDB responses.
+      *
+      *   - '''DynamoDB (AWS):''' defaults to `false` -- AWS uses consumed capacity for throttling
+      *     and billing feedback.
+      *   - '''Alternator (Scylla):''' defaults to `true` -- Scylla Alternator does not support
+      *     `ConsumedCapacity`, so leaving it enabled would produce unnecessary overhead or errors.
+      */
+    def removeConsumedCapacity: Boolean
+    def billingMode: Option[BillingMode]
+    def alternatorSettings: Option[AlternatorSettings]
+    lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
+      AwsUtils.computeFinalCredentials(credentials, endpoint, region)
+  }
+
   case class DynamoDB(
     endpoint: Option[DynamoDBEndpoint],
     region: Option[String],
@@ -35,12 +60,27 @@ object TargetSettings {
     throughputWritePercent: Option[Float],
     streamChanges: Boolean,
     skipInitialSnapshotTransfer: Option[Boolean],
-    removeConsumedCapacity: Option[Boolean] = Some(true),
+    billingMode: Option[BillingMode] = None
+  ) extends DynamoDBLike {
+    val removeConsumedCapacity: Boolean = false
+    val alternatorSettings: Option[AlternatorSettings] = None
+  }
+
+  case class Alternator(
+    alternatorEndpoint: DynamoDBEndpoint,
+    region: Option[String],
+    credentials: Option[AWSCredentials],
+    table: String,
+    writeThroughput: Option[Int],
+    throughputWritePercent: Option[Float],
+    streamChanges: Boolean,
+    skipInitialSnapshotTransfer: Option[Boolean],
+    removeConsumedCapacity: Boolean = true,
     billingMode: Option[BillingMode] = None,
-    alternator: Option[AlternatorSettings] = None
-  ) extends TargetSettings {
-    lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
-      AwsUtils.computeFinalCredentials(credentials, endpoint, region)
+    alternatorConfig: AlternatorSettings = AlternatorSettings()
+  ) extends DynamoDBLike {
+    val endpoint: Option[DynamoDBEndpoint] = Some(alternatorEndpoint)
+    val alternatorSettings: Option[AlternatorSettings] = Some(alternatorConfig)
   }
 
   case class Parquet(
@@ -59,13 +99,121 @@ object TargetSettings {
     path: String
   ) extends TargetSettings
 
+  private def validateDynamoDBLikeTarget(t: DynamoDBLike): List[String] = {
+    val errors = List.newBuilder[String]
+    if (t.table.trim.isEmpty)
+      errors += "'table' must not be empty."
+    if (t.writeThroughput.exists(_ <= 0))
+      errors += "'writeThroughput' must be a positive integer."
+    if (t.throughputWritePercent.exists(v => v < 0.1f || v > 1.5f))
+      errors += "'throughputWritePercent' must be between 0.1 and 1.5."
+    errors.result()
+  }
+
   implicit val decoder: Decoder[TargetSettings] =
     Decoder.instance { cursor =>
       cursor.get[String]("type").flatMap {
         case "scylla" | "cassandra" =>
           deriveDecoder[Scylla].apply(cursor)
         case "dynamodb" | "dynamo" =>
-          deriveDecoder[DynamoDB].apply(cursor)
+          AlternatorSettings.guardDynamoDBType(cursor, "Target").flatMap { _ =>
+            deriveDecoder[DynamoDB].apply(cursor).flatMap { d =>
+              val allErrors = validateDynamoDBLikeTarget(d)
+              if (allErrors.nonEmpty)
+                Left(
+                  DecodingFailure(
+                    s"Target type 'dynamodb': ${allErrors.mkString("; ")}",
+                    cursor.history
+                  )
+                )
+              else Right(d)
+            }
+          }
+        case "alternator" =>
+          for {
+            _ <- Either.cond(
+                   cursor.downField("alternator").focus.isEmpty,
+                   (),
+                   DecodingFailure(
+                     "Target type 'alternator' does not use a nested 'alternator' block; " +
+                       "place Alternator settings at the top level.",
+                     cursor.history
+                   )
+                 )
+            altSettings            <- AlternatorSettings.decoder(cursor)
+            maybeEndpoint          <- cursor.get[Option[DynamoDBEndpoint]]("endpoint")
+            region                 <- cursor.get[Option[String]]("region")
+            credentials            <- cursor.get[Option[AWSCredentials]]("credentials")
+            table                  <- cursor.get[String]("table")
+            writeThroughput        <- cursor.get[Option[Int]]("writeThroughput")
+            throughputWritePercent <- cursor.get[Option[Float]]("throughputWritePercent")
+            streamChanges          <- cursor.get[Boolean]("streamChanges")
+            skipInitialSnapshotTransfer <-
+              cursor.get[Option[Boolean]]("skipInitialSnapshotTransfer")
+            // Default to true for Alternator (Scylla doesn't support ConsumedCapacity).
+            rcc         <- cursor.getOrElse[Boolean]("removeConsumedCapacity")(true)
+            billingMode <- cursor.get[Option[BillingMode]]("billingMode")
+            result <- {
+              val errors = List.newBuilder[String]
+              errors ++= AlternatorSettings.validateDecoding(
+                maybeEndpoint,
+                credentials,
+                altSettings
+              )
+              errors ++= validateDynamoDBLikeTarget(
+                // Temporarily build with a dummy endpoint for shared validation.
+                // The endpoint-required check is already in validateDecoding above.
+                Alternator(
+                  maybeEndpoint.getOrElse(DynamoDBEndpoint("http://placeholder", 0)),
+                  region,
+                  credentials,
+                  table,
+                  writeThroughput,
+                  throughputWritePercent,
+                  streamChanges,
+                  skipInitialSnapshotTransfer,
+                  rcc,
+                  billingMode,
+                  altSettings
+                )
+              )
+              val allErrors = errors.result()
+              if (allErrors.nonEmpty)
+                Left(
+                  DecodingFailure(
+                    s"Target type 'alternator': ${allErrors.mkString("; ")}",
+                    cursor.history
+                  )
+                )
+              else
+                maybeEndpoint match {
+                  case Some(ep) =>
+                    Right(
+                      Alternator(
+                        ep,
+                        region,
+                        credentials,
+                        table,
+                        writeThroughput,
+                        throughputWritePercent,
+                        streamChanges,
+                        skipInitialSnapshotTransfer,
+                        rcc,
+                        billingMode,
+                        altSettings
+                      )
+                    )
+                  case None =>
+                    // Should not reach here: validateDecoding already rejects missing endpoint.
+                    Left(
+                      DecodingFailure(
+                        "Target type 'alternator' requires an 'endpoint' to be set.",
+                        cursor.history
+                      )
+                    )
+                }
+            }
+          } yield result
         case "parquet" =>
           for {
             path        <- cursor.get[String]("path")
@@ -115,17 +263,43 @@ object TargetSettings {
   implicit val encoder: Encoder[TargetSettings] =
     Encoder.instance {
       case t: Scylla =>
-        deriveEncoder[Scylla].encodeObject(t).add("type", Json.fromString("scylla")).asJson
+        deriveEncoder[Scylla]
+          .encodeObject(t)
+          .filter { case (_, v) => !v.isNull }
+          .add("type", Json.fromString("scylla"))
+          .asJson
 
       case t: DynamoDB =>
-        deriveEncoder[DynamoDB].encodeObject(t).add("type", Json.fromString("dynamodb")).asJson
+        deriveEncoder[DynamoDB]
+          .encodeObject(t)
+          .filter { case (_, v) => !v.isNull }
+          .add("type", Json.fromString("dynamodb"))
+          .asJson
+
+      case t: Alternator =>
+        val baseObj = deriveEncoder[Alternator]
+          .encodeObject(t)
+          .remove("alternatorConfig")
+          .remove("alternatorEndpoint")
+          .add("endpoint", Encoder[DynamoDBEndpoint].apply(t.alternatorEndpoint))
+        val altObj = AlternatorSettings.asObjectEncoder.encodeObject(t.alternatorConfig)
+        altObj.toList
+          .foldLeft(baseObj) { case (acc, (k, v)) => acc.add(k, v) }
+          .filter { case (_, v) => !v.isNull }
+          .add("type", Json.fromString("alternator"))
+          .asJson
 
       case t: Parquet =>
-        deriveEncoder[Parquet].encodeObject(t).add("type", Json.fromString("parquet")).asJson
+        deriveEncoder[Parquet]
+          .encodeObject(t)
+          .filter { case (_, v) => !v.isNull }
+          .add("type", Json.fromString("parquet"))
+          .asJson
 
       case t: DynamoDBS3Export =>
         deriveEncoder[DynamoDBS3Export]
           .encodeObject(t)
+          .filter { case (_, v) => !v.isNull }
           .add("type", Json.fromString("dynamodb-s3-export"))
           .asJson
     }

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
@@ -10,6 +10,7 @@ import org.apache.hadoop.mapred.JobConf
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
+import scala.util.Using
 import software.amazon.awssdk.services.dynamodb.model.{
   DescribeTableRequest,
   DescribeTimeToLiveRequest,
@@ -24,7 +25,7 @@ object DynamoDB {
 
   def readRDD(
     spark: SparkSession,
-    source: SourceSettings.DynamoDB,
+    source: SourceSettings.DynamoDBLike,
     skipSegments: Option[Set[Int]]
   ): (RDD[(Text, DynamoDBItemWritable)], TableDescription) =
     readRDD(
@@ -38,11 +39,11 @@ object DynamoDB {
       source.readThroughput,
       source.throughputReadPercent,
       skipSegments,
-      source.removeConsumedCapacity.getOrElse(true),
-      source.alternator
+      source.removeConsumedCapacity,
+      source.alternatorSettings
     )
 
-  /** Overload of `readRDD` that does not depend on `SourceSettings.DynamoDB`
+  /** Overload of `readRDD` that does not depend on `SourceSettings.DynamoDBLike`
     */
   def readRDD(
     spark: SparkSession,
@@ -59,28 +60,28 @@ object DynamoDB {
     alternatorSettings: Option[AlternatorSettings] = None
   ): (RDD[(Text, DynamoDBItemWritable)], TableDescription) = {
 
-    val dynamoDbClient =
-      DynamoUtils.buildDynamoClient(
-        endpoint,
-        credentials.map(_.toProvider),
-        region,
-        if (removeConsumedCapacity)
-          Seq(new DynamoUtils.RemoveConsumedCapacityInterceptor)
-        else Nil,
-        alternatorSettings
-      )
-
-    val tableDescription =
-      dynamoDbClient
-        .describeTable(DescribeTableRequest.builder().tableName(table).build())
-        .table
-
-    val maybeTtlDescription =
-      Option(
-        dynamoDbClient
-          .describeTimeToLive(DescribeTimeToLiveRequest.builder().tableName(table).build())
-          .timeToLiveDescription
-      )
+    val (tableDescription, maybeTtlDescription) =
+      Using.resource(
+        DynamoUtils.buildDynamoClient(
+          endpoint,
+          credentials.map(_.toProvider),
+          region,
+          DynamoUtils.removeConsumedCapacityInterceptors(removeConsumedCapacity),
+          alternatorSettings
+        )
+      ) { dynamoDbClient =>
+        val td =
+          dynamoDbClient
+            .describeTable(DescribeTableRequest.builder().tableName(table).build())
+            .table
+        val ttl =
+          Option(
+            dynamoDbClient
+              .describeTimeToLive(DescribeTimeToLiveRequest.builder().tableName(table).build())
+              .timeToLiveDescription
+          )
+        (td, ttl)
+      }
 
     val jobConf =
       makeJobConf(

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
@@ -17,13 +17,14 @@ import software.amazon.awssdk.services.dynamodb.model.{
 
 import java.util
 import java.util.stream.Collectors
+import scala.util.Using
 
 object DynamoDB {
 
   val log = LogManager.getLogger("com.scylladb.migrator.writers.DynamoDB")
 
   def deleteRDD(
-    target: TargetSettings.DynamoDB,
+    target: TargetSettings.DynamoDBLike,
     targetTableDesc: TableDescription,
     rdd: RDD[util.Map[String, AttributeValue]]
   )(implicit spark: SparkSession): Unit = {
@@ -32,17 +33,15 @@ object DynamoDB {
 
     rdd.foreachPartition { partition =>
       if (partition.nonEmpty) {
-        val dynamoDB = DynamoUtils.buildDynamoClient(
-          target.endpoint,
-          target.finalCredentials.map(_.toProvider),
-          target.region,
-          if (target.removeConsumedCapacity.getOrElse(true))
-            Seq(new DynamoUtils.RemoveConsumedCapacityInterceptor)
-          else Nil,
-          target.alternator
-        )
-
-        try
+        Using.resource(
+          DynamoUtils.buildDynamoClient(
+            target.endpoint,
+            target.finalCredentials.map(_.toProvider),
+            target.region,
+            DynamoUtils.removeConsumedCapacityInterceptors(target.removeConsumedCapacity),
+            target.alternatorSettings
+          )
+        ) { dynamoDB =>
           partition.foreach { item =>
             val keyToDelete =
               new util.HashMap[String, AttributeValue]()
@@ -72,14 +71,13 @@ object DynamoDB {
               }
             }
           }
-        finally
-          dynamoDB.close()
+        }
       }
     }
   }
 
   def writeRDD(
-    target: TargetSettings.DynamoDB,
+    target: TargetSettings.DynamoDBLike,
     renamesMap: Map[String, String],
     rdd: RDD[(Text, DynamoDBItemWritable)],
     targetTableDesc: TableDescription
@@ -94,8 +92,8 @@ object DynamoDB {
       maybeScanSegments = None,
       maybeMaxMapTasks  = None,
       target.finalCredentials,
-      target.removeConsumedCapacity.getOrElse(true),
-      target.alternator
+      target.removeConsumedCapacity,
+      target.alternatorSettings
     )
     jobConf.set(DynamoDBConstants.OUTPUT_TABLE_NAME, target.table)
     val writeThroughput =

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.dynamodb.model.{
 import java.util
 import java.util.stream.Collectors
 import scala.jdk.CollectionConverters._
+import scala.util.Using
 
 object DynamoStreamReplication {
   val log = LogManager.getLogger("com.scylladb.migrator.writers.DynamoStreamReplication")
@@ -40,7 +41,7 @@ object DynamoStreamReplication {
 
   private[writers] def run(
     msgs: RDD[Option[DynamoItem]],
-    target: TargetSettings.DynamoDB,
+    target: TargetSettings.DynamoDBLike,
     renamesMap: Map[String, String],
     targetTableDesc: TableDescription
   )(implicit spark: SparkSession): Unit = {
@@ -52,17 +53,15 @@ object DynamoStreamReplication {
 
     rdd.foreachPartition { partition =>
       if (partition.nonEmpty) {
-        val client =
+        Using.resource(
           DynamoUtils.buildDynamoClient(
             target.endpoint,
             target.finalCredentials.map(_.toProvider),
             target.region,
-            if (target.removeConsumedCapacity.getOrElse(true))
-              Seq(new DynamoUtils.RemoveConsumedCapacityInterceptor)
-            else Nil,
-            target.alternator
+            DynamoUtils.removeConsumedCapacityInterceptors(target.removeConsumedCapacity),
+            target.alternatorSettings
           )
-        try
+        ) { client =>
           partition.foreach { item =>
             val isPut = item.get(operationTypeColumn) == putOperation
 
@@ -99,8 +98,7 @@ object DynamoStreamReplication {
               }
             }
           }
-        finally
-          client.close()
+        }
       }
     }
 
@@ -119,7 +117,7 @@ object DynamoStreamReplication {
     spark: SparkSession,
     streamingContext: StreamingContext,
     src: SourceSettings.DynamoDB,
-    target: TargetSettings.DynamoDB,
+    target: TargetSettings.DynamoDBLike,
     targetTableDesc: TableDescription,
     renamesMap: Map[String, String]
   ): Unit =

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -92,7 +92,7 @@ object Scylla {
   ): Boolean =
     target.dropNullPrimaryKeys.getOrElse {
       source match {
-        case _: SourceSettings.Cassandra | _: SourceSettings.DynamoDB |
+        case _: SourceSettings.Cassandra | _: SourceSettings.DynamoDBLike |
             _: SourceSettings.DynamoDBS3Export =>
           false
         case _ => true

--- a/tests/src/test/configurations/bench-e2e-dynamodb-to-alternator.yaml
+++ b/tests/src/test/configurations/bench-e2e-dynamodb-to-alternator.yaml
@@ -12,7 +12,7 @@ source:
   readThroughput: 25
 
 target:
-  type: dynamodb
+  type: alternator
   table: bench_e2e_ddb
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/bench-e2e-s3export-to-alternator.yaml
+++ b/tests/src/test/configurations/bench-e2e-s3export-to-alternator.yaml
@@ -20,7 +20,7 @@ source:
     billingMode: PAY_PER_REQUEST
 
 target:
-  type: dynamodb
+  type: alternator
   table: bench_e2e_ddb_s3_restore
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-s3-export-to-alternator-basic-provisioned.yaml
+++ b/tests/src/test/configurations/dynamodb-s3-export-to-alternator-basic-provisioned.yaml
@@ -23,7 +23,7 @@ source:
       writeCapacityUnits: 25
 
 target:
-  type: dynamodb
+  type: alternator
   table: BasicTest
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-s3-export-to-alternator-basic.yaml
+++ b/tests/src/test/configurations/dynamodb-s3-export-to-alternator-basic.yaml
@@ -20,7 +20,7 @@ source:
     billingMode: PAY_PER_REQUEST
 
 target:
-  type: dynamodb
+  type: alternator
   table: BasicTest
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-basic-provisioned.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-basic-provisioned.yaml
@@ -10,7 +10,7 @@ source:
     secretKey: dummy
 
 target:
-  type: dynamodb
+  type: alternator
   table: BasicTest
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-basic.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-basic.yaml
@@ -10,7 +10,7 @@ source:
     secretKey: dummy
 
 target:
-  type: dynamodb
+  type: alternator
   table: BasicTest
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-issue-103-provisioned.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-issue-103-provisioned.yaml
@@ -12,7 +12,7 @@ source:
   scanSegments: 10
 
 target:
-  type: dynamodb
+  type: alternator
   table: Issue103Items
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-issue-103.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-issue-103.yaml
@@ -12,7 +12,7 @@ source:
   scanSegments: 10
 
 target:
-  type: dynamodb
+  type: alternator
   table: Issue103Items
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-part1-provisioned.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-part1-provisioned.yaml
@@ -11,7 +11,7 @@ source:
   scanSegments: 3
 
 target:
-  type: dynamodb
+  type: alternator
   table: SkippedSegments
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-part1.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-part1.yaml
@@ -11,7 +11,7 @@ source:
   scanSegments: 3
 
 target:
-  type: dynamodb
+  type: alternator
   table: SkippedSegments
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-part2-provisioned.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-part2-provisioned.yaml
@@ -11,7 +11,7 @@ source:
   scanSegments: 3
 
 target:
-  type: dynamodb
+  type: alternator
   table: SkippedSegments
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-part2.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-part2.yaml
@@ -11,7 +11,7 @@ source:
   scanSegments: 3
 
 target:
-  type: dynamodb
+  type: alternator
   table: SkippedSegments
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-renames-provisioned.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-renames-provisioned.yaml
@@ -11,7 +11,7 @@ source:
   maxMapTasks: 1
 
 target:
-  type: dynamodb
+  type: alternator
   table: RenamedItems
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-renames.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-renames.yaml
@@ -11,7 +11,7 @@ source:
   maxMapTasks: 1
 
 target:
-  type: dynamodb
+  type: alternator
   table: RenamedItems
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-secondary-indexes-provisioned.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-secondary-indexes-provisioned.yaml
@@ -10,7 +10,7 @@ source:
     secretKey: dummy
 
 target:
-  type: dynamodb
+  type: alternator
   table: TableWithSecondaryIndexes
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-secondary-indexes.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-secondary-indexes.yaml
@@ -10,7 +10,7 @@ source:
     secretKey: dummy
 
 target:
-  type: dynamodb
+  type: alternator
   table: TableWithSecondaryIndexes
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-streaming-skip-snapshot.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-streaming-skip-snapshot.yaml
@@ -4,7 +4,7 @@ source:
   region: us-east-1
 
 target:
-  type: dynamodb
+  type: alternator
   table: StreamedItemsSkipSnapshotTest
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-streaming.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-streaming.yaml
@@ -4,7 +4,7 @@ source:
   region: us-east-1
 
 target:
-  type: dynamodb
+  type: alternator
   table: StreamedItemsTest
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-ttl-provisioned.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-ttl-provisioned.yaml
@@ -10,7 +10,7 @@ source:
     secretKey: dummy
 
 target:
-  type: dynamodb
+  type: alternator
   table: TtlTable
   region: dummy
   endpoint:

--- a/tests/src/test/configurations/dynamodb-to-alternator-ttl.yaml
+++ b/tests/src/test/configurations/dynamodb-to-alternator-ttl.yaml
@@ -10,7 +10,7 @@ source:
     secretKey: dummy
 
 target:
-  type: dynamodb
+  type: alternator
   table: TtlTable
   region: dummy
   endpoint:

--- a/tests/src/test/scala/com/scylladb/migrator/AwsUtilsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/AwsUtilsTest.scala
@@ -10,6 +10,21 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 class AwsUtilsTest extends munit.FunSuite {
 
+  test("protocol-less endpoint host is normalized to an absolute URI") {
+    val normalized = AwsUtils.endpointUri(DynamoDBEndpoint("my-dynamodb-host", 8000))
+    assertEquals(normalized.toString, "http://my-dynamodb-host:8000")
+  }
+
+  test("endpoint URI keeps protocol when already present") {
+    val normalized = AwsUtils.endpointUri(DynamoDBEndpoint("http://dynamodb", 8000))
+    assertEquals(normalized.toString, "http://dynamodb:8000")
+  }
+
+  test("endpoint URI keeps uppercase protocol when already present") {
+    val normalized = AwsUtils.endpointUri(DynamoDBEndpoint("HTTPS://dynamodb", 8000))
+    assertEquals(normalized.toString, "HTTPS://dynamodb:8000")
+  }
+
   // --- Section 1: configureClientBuilder ---
 
   test("Endpoint override is applied when provided") {

--- a/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
@@ -13,6 +13,7 @@ import org.apache.spark.sql.SparkSession
 
 import java.nio.file.Paths
 import java.util.concurrent.atomic.AtomicInteger
+import scala.util.control.NonFatal
 
 object SparkUtils {
 
@@ -31,7 +32,10 @@ object SparkUtils {
     def stop(): Unit = {
       spark.streams.active.foreach(_.stop())
       thread.join(30000)
-      if (thread.isAlive) thread.interrupt()
+      if (thread.isAlive) {
+        thread.interrupt()
+        thread.join(5000)
+      }
     }
   }
 
@@ -94,7 +98,7 @@ object SparkUtils {
         Migrator.migrate(config)(spark)
       catch {
         case _: InterruptedException => exitCode.set(143)
-        case e: Exception =>
+        case NonFatal(e) =>
           exitCode.set(1)
           e.printStackTrace()
       }
@@ -142,6 +146,8 @@ object SparkUtils {
         c.copy(host = "localhost", port = cqlHostPortMap.getOrElse(c.host, c.port))
       case d: SourceSettings.DynamoDB =>
         d.copy(endpoint = d.endpoint.map(remapEndpoint))
+      case a: SourceSettings.Alternator =>
+        a.copy(alternatorEndpoint = remapEndpoint(a.alternatorEndpoint))
       case p: SourceSettings.Parquet =>
         p.copy(
           path     = remapContainerPath(p.path),
@@ -155,6 +161,8 @@ object SparkUtils {
         s.copy(host = "localhost", port = cqlHostPortMap.getOrElse(s.host, s.port))
       case d: TargetSettings.DynamoDB =>
         d.copy(endpoint = d.endpoint.map(remapEndpoint))
+      case a: TargetSettings.Alternator =>
+        a.copy(alternatorEndpoint = remapEndpoint(a.alternatorEndpoint))
       case p: TargetSettings.Parquet =>
         p.copy(path = remapContainerPath(p.path))
       case s: TargetSettings.DynamoDBS3Export =>

--- a/tests/src/test/scala/com/scylladb/migrator/config/DynamoDBSourceSettingParserTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/DynamoDBSourceSettingParserTest.scala
@@ -7,6 +7,7 @@ import com.scylladb.migrator.config.SourceSettings.DynamoDBS3Export.{
   KeyType
 }
 import io.circe.{ yaml, DecodingFailure }
+import io.circe.syntax._
 
 class DynamoDBSourceSettingParserTest extends munit.FunSuite {
 
@@ -75,6 +76,675 @@ class DynamoDBSourceSettingParserTest extends munit.FunSuite {
     }
   }
 
+  test("'dynamo' type alias parses as DynamoDB source") {
+    val config =
+      """type: dynamo
+        |table: Dummy
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    result match {
+      case Right(_: SourceSettings.DynamoDB) => () // OK
+      case other =>
+        fail(s"Expected SourceSettings.DynamoDB, got: ${other}")
+    }
+  }
+
+  test("dynamodb source with nested alternator key fails fast") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |alternator:
+        |  datacenter: dc1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("nested 'alternator' key")),
+      s"Expected error message about nested alternator key, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator source with nested alternator block fails fast") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |alternator:
+        |  datacenter: dc1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("does not use a nested 'alternator' block")),
+      s"Expected error about nested alternator block, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("valid alternator source config") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |scanSegments: 4
+        |readThroughput: 100
+        |throughputReadPercent: 0.5
+        |maxMapTasks: 2
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |datacenter: dc1
+        |rack: rack1
+        |activeRefreshIntervalMs: 5000
+        |idleRefreshIntervalMs: 30000
+        |compression: true
+        |optimizeHeaders: true
+        |maxConnections: 50
+        |connectionMaxIdleTimeMs: 60000
+        |connectionTimeToLiveMs: 120000
+        |connectionAcquisitionTimeoutMs: 10000
+        |connectionTimeoutMs: 5000
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    result match {
+      case Right(alt: SourceSettings.Alternator) =>
+        assertEquals(alt.table, "MyTable")
+        assertEquals(alt.scanSegments, Some(4))
+        assertEquals(alt.readThroughput, Some(100))
+        assertEquals(alt.throughputReadPercent, Some(0.5f))
+        assertEquals(alt.maxMapTasks, Some(2))
+        assertEquals(alt.endpoint, Some(DynamoDBEndpoint("http://10.0.0.1", 8000)))
+        assertEquals(alt.alternatorConfig.datacenter, Some("dc1"))
+        assertEquals(alt.alternatorConfig.rack, Some("rack1"))
+        assertEquals(alt.alternatorConfig.activeRefreshIntervalMs, Some(5000L))
+        assertEquals(alt.alternatorConfig.idleRefreshIntervalMs, Some(30000L))
+        assertEquals(alt.alternatorConfig.compression, Some(true))
+        assertEquals(alt.alternatorConfig.optimizeHeaders, Some(true))
+        assertEquals(alt.alternatorConfig.maxConnections, Some(50))
+        assertEquals(alt.alternatorConfig.connectionMaxIdleTimeMs, Some(60000L))
+        assertEquals(alt.alternatorConfig.connectionTimeToLiveMs, Some(120000L))
+        assertEquals(alt.alternatorConfig.connectionAcquisitionTimeoutMs, Some(10000L))
+        assertEquals(alt.alternatorConfig.connectionTimeoutMs, Some(5000L))
+      case other =>
+        fail(s"Expected SourceSettings.Alternator, got: ${other}")
+    }
+  }
+
+  test("alternator source without endpoint fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("requires an 'endpoint'")),
+      s"Expected error about missing endpoint, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator source roundtrip encode then decode") {
+    val original = SourceSettings.Alternator(
+      alternatorEndpoint     = DynamoDBEndpoint("http://10.0.0.1", 8000),
+      region                 = Some("us-east-1"),
+      credentials            = Some(AWSCredentials("myKey", "mySecret", None)),
+      table                  = "RoundtripTable",
+      scanSegments           = Some(4),
+      readThroughput         = Some(100),
+      throughputReadPercent  = Some(0.5f),
+      maxMapTasks            = Some(2),
+      removeConsumedCapacity = false,
+      alternatorConfig = AlternatorSettings(
+        datacenter                     = Some("dc1"),
+        rack                           = Some("rack1"),
+        activeRefreshIntervalMs        = Some(5000L),
+        idleRefreshIntervalMs          = Some(30000L),
+        compression                    = Some(true),
+        optimizeHeaders                = Some(false),
+        maxConnections                 = Some(50),
+        connectionMaxIdleTimeMs        = Some(60000L),
+        connectionTimeToLiveMs         = Some(120000L),
+        connectionAcquisitionTimeoutMs = Some(10000L),
+        connectionTimeoutMs            = Some(5000L)
+      )
+    )
+
+    val json = (original: SourceSettings).asJson
+    val decoded = json.as[SourceSettings]
+
+    decoded match {
+      case Right(roundtripped: SourceSettings.Alternator) =>
+        assertEquals(roundtripped, original)
+      case other =>
+        fail(s"Roundtrip failed. Got: ${other}")
+    }
+  }
+
+  test("dynamodb source roundtrip encode then decode") {
+    val original = SourceSettings.DynamoDB(
+      endpoint              = Some(DynamoDBEndpoint("localhost", 8000)),
+      region                = Some("us-east-1"),
+      credentials           = None,
+      table                 = "TestTable",
+      scanSegments          = Some(4),
+      readThroughput        = Some(100),
+      throughputReadPercent = Some(0.5f),
+      maxMapTasks           = Some(2)
+    )
+    val json = (original: SourceSettings).asJson
+    val decoded = json.as[SourceSettings]
+    assertEquals(decoded, Right(original))
+  }
+
+  test("alternator source with rack but no datacenter fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |rack: rack1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("datacenter")),
+      s"Expected error about missing datacenter, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator source with zero maxConnections fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |maxConnections: 0
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("maxConnections")),
+      s"Expected error about maxConnections, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb source with removeConsumedCapacity fails") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |removeConsumedCapacity: true
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("removeConsumedCapacity")),
+      s"Expected error about removeConsumedCapacity, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator source with assumeRole fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |credentials:
+        |  accessKey: foo
+        |  secretKey: bar
+        |  assumeRole:
+        |    arn: arn:aws:iam::123456789012:role/MyRole
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("assumeRole")),
+      s"Expected error about assumeRole, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator source with multiple validation errors reports all") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |rack: rack1
+        |maxConnections: 0
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    val msg = result.swap.map(_.getMessage).getOrElse("")
+    assert(msg.contains("datacenter"), s"Expected error about datacenter, got: $msg")
+    assert(msg.contains("maxConnections"), s"Expected error about maxConnections, got: $msg")
+  }
+
+  test("alternator source without endpoint and with invalid settings reports all errors") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |rack: rack1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    val msg = result.swap.map(_.getMessage).getOrElse("")
+    assert(msg.contains("endpoint"), s"Expected error about endpoint, got: $msg")
+    assert(msg.contains("datacenter"), s"Expected error about datacenter, got: $msg")
+  }
+
+  test("alternator source defaults removeConsumedCapacity to true") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    result match {
+      case Right(alt: SourceSettings.Alternator) =>
+        assertEquals(alt.removeConsumedCapacity, true)
+      case other =>
+        fail(s"Expected SourceSettings.Alternator, got: ${other}")
+    }
+  }
+
+  test("dynamodb source with Alternator-only fields fails") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |datacenter: dc1
+        |compression: true
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    val msg = result.swap.map(_.getMessage).getOrElse("")
+    assert(
+      msg.contains("Alternator-only fields"),
+      s"Expected error about Alternator-only fields, got: $msg"
+    )
+    assert(msg.contains("datacenter"), s"Expected 'datacenter' in error, got: $msg")
+    assert(msg.contains("compression"), s"Expected 'compression' in error, got: $msg")
+  }
+
+  test("dynamodb source with single Alternator-only field fails") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |rack: rack1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("rack")),
+      s"Expected error mentioning 'rack', got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("'dynamo' alias with Alternator-only fields fails") {
+    val config =
+      """type: dynamo
+        |table: Dummy
+        |datacenter: dc1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("Alternator-only fields")),
+      s"Expected error about Alternator-only fields, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb source minimal roundtrip (all optionals None)") {
+    val original = SourceSettings.DynamoDB(
+      endpoint              = None,
+      region                = None,
+      credentials           = None,
+      table                 = "MinimalTable",
+      scanSegments          = None,
+      readThroughput        = None,
+      throughputReadPercent = None,
+      maxMapTasks           = None
+    )
+    val json = (original: SourceSettings).asJson
+    val decoded = json.as[SourceSettings]
+    assertEquals(decoded, Right(original))
+  }
+
+  test("alternator source minimal roundtrip (all optionals None)") {
+    val original = SourceSettings.Alternator(
+      alternatorEndpoint     = DynamoDBEndpoint("http://10.0.0.1", 8000),
+      region                 = None,
+      credentials            = None,
+      table                  = "MinimalTable",
+      scanSegments           = None,
+      readThroughput         = None,
+      throughputReadPercent  = None,
+      maxMapTasks            = None,
+      removeConsumedCapacity = true,
+      alternatorConfig       = AlternatorSettings()
+    )
+    val json = (original: SourceSettings).asJson
+    val decoded = json.as[SourceSettings]
+    assertEquals(decoded, Right(original))
+  }
+
+  test("AlternatorSettings field names do not overlap with base Alternator source field names") {
+    // Derive field names from the case class to stay in sync automatically.
+    // "alternatorConfig" and "alternatorEndpoint" are internal fields (not in YAML),
+    // replaced with "endpoint" and "type" (synthetic YAML fields).
+    val baseSourceKeys = SourceSettings
+      .Alternator(
+        alternatorEndpoint    = DynamoDBEndpoint("http://placeholder", 0),
+        region                = None,
+        credentials           = None,
+        table                 = "",
+        scanSegments          = None,
+        readThroughput        = None,
+        throughputReadPercent = None,
+        maxMapTasks           = None
+      )
+      .productElementNames
+      .toSet - "alternatorConfig" - "alternatorEndpoint" + "endpoint" + "type"
+    val overlap = AlternatorSettings.fieldNames.intersect(baseSourceKeys)
+    assert(
+      overlap.isEmpty,
+      s"AlternatorSettings field names must not overlap with base Alternator source field names, but found: ${overlap.mkString(", ")}"
+    )
+  }
+
+  test("AlternatorSettings Hadoop config round-trip") {
+    val original = AlternatorSettings(
+      datacenter                     = Some("dc1"),
+      rack                           = Some("rack1"),
+      activeRefreshIntervalMs        = Some(5000L),
+      idleRefreshIntervalMs          = Some(30000L),
+      compression                    = Some(true),
+      optimizeHeaders                = Some(false),
+      maxConnections                 = Some(50),
+      connectionMaxIdleTimeMs        = Some(60000L),
+      connectionTimeToLiveMs         = Some(120000L),
+      connectionAcquisitionTimeoutMs = Some(10000L),
+      connectionTimeoutMs            = Some(5000L)
+    )
+
+    val jobConf = new org.apache.hadoop.mapred.JobConf()
+    com.scylladb.migrator.DynamoUtils.writeAlternatorSettingsToConf(jobConf, original)
+    val roundTripped =
+      com.scylladb.migrator.DynamoUtils.readAlternatorSettingsFromConf(jobConf)
+
+    assertEquals(roundTripped, original)
+  }
+
+  test("AlternatorSettings Hadoop config round-trip with all fields empty") {
+    val original = AlternatorSettings()
+
+    val jobConf = new org.apache.hadoop.mapred.JobConf()
+    com.scylladb.migrator.DynamoUtils.writeAlternatorSettingsToConf(jobConf, original)
+    val roundTripped =
+      com.scylladb.migrator.DynamoUtils.readAlternatorSettingsFromConf(jobConf)
+
+    assertEquals(roundTripped, original)
+  }
+
+  test("alternator source with endpoint missing protocol prefix fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: 10.0.0.1
+        |  port: 8000
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("protocol prefix")),
+      s"Expected error about protocol prefix, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb source with protocol-prefix endpoint parses") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |endpoint:
+        |  host: http://scylla
+        |  port: 8000
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    result match {
+      case Right(d: SourceSettings.DynamoDB) =>
+        assertEquals(d.endpoint.map(_.host), Some("http://scylla"))
+      case other =>
+        fail(s"Expected SourceSettings.DynamoDB, got: ${other}")
+    }
+  }
+
+  test("dynamodb source with zero scanSegments fails") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |scanSegments: 0
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("scanSegments")),
+      s"Expected error about scanSegments, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb source with empty table fails") {
+    val config =
+      """type: dynamodb
+        |table: ""
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("'table'")),
+      s"Expected error about 'table', got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb source with whitespace-only table fails") {
+    val config =
+      """type: dynamodb
+        |table: "   "
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("'table'")),
+      s"Expected error about 'table', got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator source with negative readThroughput fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |readThroughput: -1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("readThroughput")),
+      s"Expected error about readThroughput, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator source with explicit removeConsumedCapacity false") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |removeConsumedCapacity: false
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    result match {
+      case Right(alt: SourceSettings.Alternator) =>
+        assertEquals(alt.removeConsumedCapacity, false)
+      case other =>
+        fail(s"Expected SourceSettings.Alternator, got: ${other}")
+    }
+  }
+
+  test("alternator source with throughputReadPercent above 1.5 fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |throughputReadPercent: 2.0
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("throughputReadPercent")),
+      s"Expected error about throughputReadPercent, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb source with bare hostname endpoint succeeds") {
+    val config =
+      """type: dynamodb
+        |table: MyTable
+        |endpoint:
+        |  host: my-dynamodb-host
+        |  port: 8000
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    result match {
+      case Right(d: SourceSettings.DynamoDB) =>
+        assertEquals(d.endpoint, Some(DynamoDBEndpoint("my-dynamodb-host", 8000)))
+      case other =>
+        fail(s"Expected SourceSettings.DynamoDB, got: ${other}")
+    }
+  }
+
+  test("unknown source type fails") {
+    val config =
+      """type: unknown
+        |table: Dummy
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("Unknown source type")),
+      s"Expected error about unknown source type, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
   private def parseSourceSettings(yamlContent: String): SourceSettings.DynamoDBS3Export =
     yaml.parser
       .parse(yamlContent)
@@ -83,5 +753,158 @@ class DynamoDBSourceSettingParserTest extends munit.FunSuite {
       case Right(source: SourceSettings.DynamoDBS3Export) => source
       case Right(other) => fail(s"Failed to parse source settings. Got ${other}.")
     }
+
+  test("alternator source with https endpoint parses successfully") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: https://my-alternator
+        |  port: 8000
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    result match {
+      case Right(alt: SourceSettings.Alternator) =>
+        assertEquals(alt.endpoint, Some(DynamoDBEndpoint("https://my-alternator", 8000)))
+      case other =>
+        fail(s"Expected SourceSettings.Alternator, got: ${other}")
+    }
+  }
+
+  test("alternator source with https endpoint roundtrip") {
+    val original = SourceSettings.Alternator(
+      alternatorEndpoint     = DynamoDBEndpoint("https://my-alternator", 8000),
+      region                 = None,
+      credentials            = None,
+      table                  = "HttpsTable",
+      scanSegments           = None,
+      readThroughput         = None,
+      throughputReadPercent  = None,
+      maxMapTasks            = None,
+      removeConsumedCapacity = true,
+      alternatorConfig       = AlternatorSettings()
+    )
+    val json = (original: SourceSettings).asJson
+    val decoded = json.as[SourceSettings]
+    assertEquals(decoded, Right(original))
+  }
+
+  test("source throughputReadPercent boundary 0.1 passes") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |throughputReadPercent: 0.1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isRight, s"Expected success but got: ${result}")
+  }
+
+  test("source throughputReadPercent boundary 1.5 passes") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |throughputReadPercent: 1.5
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isRight, s"Expected success but got: ${result}")
+  }
+
+  test("source throughputReadPercent boundary 0.09 fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |throughputReadPercent: 0.09
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("throughputReadPercent")),
+      s"Expected error about throughputReadPercent, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("source throughputReadPercent boundary 1.51 fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |throughputReadPercent: 1.51
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+
+    assert(result.isLeft, s"Expected failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("throughputReadPercent")),
+      s"Expected error about throughputReadPercent, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb-s3-export source roundtrip with all optional fields") {
+    val original = SourceSettings.DynamoDBS3Export(
+      bucket      = "my-bucket",
+      manifestKey = "exports/manifest.json",
+      tableDescription = SourceSettings.DynamoDBS3Export.TableDescription(
+        attributeDefinitions = Seq(
+          AttributeDefinition("id", AttributeType.S),
+          AttributeDefinition("sort", AttributeType.N)
+        ),
+        keySchema = Seq(
+          KeySchema("id", KeyType.Hash),
+          KeySchema("sort", KeyType.Range)
+        ),
+        billingMode = Some(software.amazon.awssdk.services.dynamodb.model.BillingMode.PROVISIONED),
+        provisionedThroughput = Some(
+          SourceSettings.DynamoDBS3Export.ProvisionedThroughputConfig(
+            readCapacityUnits  = 100L,
+            writeCapacityUnits = 50L
+          )
+        )
+      ),
+      endpoint           = Some(DynamoDBEndpoint("localhost", 8000)),
+      region             = Some("us-west-2"),
+      credentials        = Some(AWSCredentials("key", "secret", None)),
+      usePathStyleAccess = Some(true)
+    )
+
+    val json = (original: SourceSettings).asJson
+    val decoded = json.as[SourceSettings]
+
+    decoded match {
+      case Right(roundtripped: SourceSettings.DynamoDBS3Export) =>
+        assertEquals(roundtripped, original)
+      case other =>
+        fail(s"Roundtrip failed. Got: ${other}")
+    }
+  }
 
 }

--- a/tests/src/test/scala/com/scylladb/migrator/config/DynamoDBTargetSettingParserTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/DynamoDBTargetSettingParserTest.scala
@@ -1,6 +1,8 @@
 package com.scylladb.migrator.config
 
 import io.circe.yaml
+import io.circe.syntax._
+import software.amazon.awssdk.services.dynamodb.model.BillingMode
 
 class DynamoDBTargetSettingParserTest extends munit.FunSuite {
 
@@ -8,10 +10,8 @@ class DynamoDBTargetSettingParserTest extends munit.FunSuite {
     val config =
       """type: dynamodb
         |table: Dummy
-        |scanSegments: 1
-        |readThroughput: 1
-        |throughputReadPercent: 1.0
-        |maxMapTasks: 1
+        |writeThroughput: 1
+        |throughputWritePercent: 1.0
         |streamChanges: false
         |""".stripMargin
 
@@ -23,10 +23,8 @@ class DynamoDBTargetSettingParserTest extends munit.FunSuite {
     val config =
       """type: dynamodb
         |table: Dummy
-        |scanSegments: 1
-        |readThroughput: 1
-        |throughputReadPercent: 1.0
-        |maxMapTasks: 1
+        |writeThroughput: 1
+        |throughputWritePercent: 1.0
         |streamChanges: false
         |skipInitialSnapshotTransfer: true
         |""".stripMargin
@@ -35,7 +33,25 @@ class DynamoDBTargetSettingParserTest extends munit.FunSuite {
     assertEquals(parsedSettings.skipInitialSnapshotTransfer, Some(true))
   }
 
-  test("alternator maxItemsPerBatch is optional and defaults to None") {
+  test("'dynamo' type alias parses as DynamoDB target") {
+    val config =
+      """type: dynamo
+        |table: Dummy
+        |streamChanges: false
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    result match {
+      case Right(_: TargetSettings.DynamoDB) => () // OK
+      case other =>
+        fail(s"Expected TargetSettings.DynamoDB, got: ${other}")
+    }
+  }
+
+  test("dynamodb target with nested alternator key fails fast") {
     val config =
       """type: dynamodb
         |table: Dummy
@@ -44,36 +60,233 @@ class DynamoDBTargetSettingParserTest extends munit.FunSuite {
         |  datacenter: dc1
         |""".stripMargin
 
-    val parsedSettings = parseDynamoDBTargetSettings(config)
-    assert(parsedSettings.alternator.isDefined)
-    assertEquals(parsedSettings.alternator.get.maxItemsPerBatch, None)
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("nested 'alternator' key")),
+      s"Expected error message about nested alternator key, got: ${result.left.map(_.getMessage)}"
+    )
   }
 
-  test("alternator maxItemsPerBatch is parsed when set") {
+  test("alternator target with nested alternator block fails fast") {
     val config =
-      """type: dynamodb
-        |table: Dummy
+      """type: alternator
+        |table: MyTable
         |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
         |alternator:
-        |  maxItemsPerBatch: 100
+        |  datacenter: dc1
         |""".stripMargin
 
-    val parsedSettings = parseDynamoDBTargetSettings(config)
-    assertEquals(parsedSettings.alternator.get.maxItemsPerBatch, Some(100))
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("does not use a nested 'alternator' block")),
+      s"Expected error about nested alternator block, got: ${result.left.map(_.getMessage)}"
+    )
   }
 
-  test("removeConsumedCapacity decodes as None when omitted from YAML") {
+  test("valid alternator target config") {
     val config =
-      """type: dynamodb
-        |table: Dummy
+      """type: alternator
+        |table: MyTable
+        |writeThroughput: 200
+        |throughputWritePercent: 0.8
+        |streamChanges: true
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |datacenter: dc1
+        |rack: rack1
+        |activeRefreshIntervalMs: 5000
+        |idleRefreshIntervalMs: 30000
+        |compression: true
+        |optimizeHeaders: true
+        |maxConnections: 50
+        |connectionMaxIdleTimeMs: 60000
+        |connectionTimeToLiveMs: 120000
+        |connectionAcquisitionTimeoutMs: 10000
+        |connectionTimeoutMs: 5000
+        |maxItemsPerBatch: 100
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    result match {
+      case Right(alt: TargetSettings.Alternator) =>
+        assertEquals(alt.table, "MyTable")
+        assertEquals(alt.writeThroughput, Some(200))
+        assertEquals(alt.throughputWritePercent, Some(0.8f))
+        assertEquals(alt.streamChanges, true)
+        assertEquals(alt.endpoint, Some(DynamoDBEndpoint("http://10.0.0.1", 8000)))
+        assertEquals(alt.alternatorConfig.datacenter, Some("dc1"))
+        assertEquals(alt.alternatorConfig.rack, Some("rack1"))
+        assertEquals(alt.alternatorConfig.activeRefreshIntervalMs, Some(5000L))
+        assertEquals(alt.alternatorConfig.idleRefreshIntervalMs, Some(30000L))
+        assertEquals(alt.alternatorConfig.compression, Some(true))
+        assertEquals(alt.alternatorConfig.optimizeHeaders, Some(true))
+        assertEquals(alt.alternatorConfig.maxConnections, Some(50))
+        assertEquals(alt.alternatorConfig.connectionMaxIdleTimeMs, Some(60000L))
+        assertEquals(alt.alternatorConfig.connectionTimeToLiveMs, Some(120000L))
+        assertEquals(alt.alternatorConfig.connectionAcquisitionTimeoutMs, Some(10000L))
+        assertEquals(alt.alternatorConfig.connectionTimeoutMs, Some(5000L))
+        assertEquals(alt.alternatorConfig.maxItemsPerBatch, Some(100))
+      case other =>
+        fail(s"Expected TargetSettings.Alternator, got: ${other}")
+    }
+  }
+
+  test("alternator target without endpoint fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
         |streamChanges: false
         |""".stripMargin
 
-    val parsedSettings = parseDynamoDBTargetSettings(config)
-    assertEquals(parsedSettings.removeConsumedCapacity, None)
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("requires an 'endpoint'")),
+      s"Expected error about missing endpoint, got: ${result.left.map(_.getMessage)}"
+    )
   }
 
-  test("removeConsumedCapacity decodes as Some(true) when explicitly set") {
+  test("alternator target roundtrip encode then decode") {
+    val original = TargetSettings.Alternator(
+      alternatorEndpoint          = DynamoDBEndpoint("http://10.0.0.1", 8000),
+      region                      = Some("us-east-1"),
+      credentials                 = Some(AWSCredentials("myKey", "mySecret", None)),
+      table                       = "RoundtripTable",
+      writeThroughput             = Some(200),
+      throughputWritePercent      = Some(0.8f),
+      streamChanges               = true,
+      skipInitialSnapshotTransfer = Some(false),
+      removeConsumedCapacity      = false,
+      billingMode                 = Some(BillingMode.PROVISIONED),
+      alternatorConfig = AlternatorSettings(
+        datacenter                     = Some("dc1"),
+        rack                           = Some("rack1"),
+        activeRefreshIntervalMs        = Some(5000L),
+        idleRefreshIntervalMs          = Some(30000L),
+        compression                    = Some(true),
+        optimizeHeaders                = Some(false),
+        maxConnections                 = Some(50),
+        connectionMaxIdleTimeMs        = Some(60000L),
+        connectionTimeToLiveMs         = Some(120000L),
+        connectionAcquisitionTimeoutMs = Some(10000L),
+        connectionTimeoutMs            = Some(5000L),
+        maxItemsPerBatch               = Some(100)
+      )
+    )
+
+    val json = (original: TargetSettings).asJson
+    val decoded = json.as[TargetSettings]
+
+    decoded match {
+      case Right(roundtripped: TargetSettings.Alternator) =>
+        assertEquals(roundtripped, original)
+      case other =>
+        fail(s"Roundtrip failed. Got: ${other}")
+    }
+  }
+
+  test("dynamodb target roundtrip encode then decode") {
+    val original = TargetSettings.DynamoDB(
+      endpoint                    = Some(DynamoDBEndpoint("localhost", 8000)),
+      region                      = Some("us-east-1"),
+      credentials                 = None,
+      table                       = "TestTable",
+      writeThroughput             = Some(200),
+      throughputWritePercent      = Some(0.8f),
+      streamChanges               = false,
+      skipInitialSnapshotTransfer = None,
+      billingMode                 = Some(BillingMode.PAY_PER_REQUEST)
+    )
+    val json = (original: TargetSettings).asJson
+    val decoded = json.as[TargetSettings]
+    assertEquals(decoded, Right(original))
+  }
+
+  test("alternator target with rack but no datacenter fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |rack: rack1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("datacenter")),
+      s"Expected error about missing datacenter, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator target with negative connectionTimeoutMs fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |connectionTimeoutMs: -1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("connectionTimeoutMs")),
+      s"Expected error about connectionTimeoutMs, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator target with zero maxItemsPerBatch fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |maxItemsPerBatch: 0
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("maxItemsPerBatch")),
+      s"Expected error about maxItemsPerBatch, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb target with removeConsumedCapacity fails") {
     val config =
       """type: dynamodb
         |table: Dummy
@@ -81,20 +294,565 @@ class DynamoDBTargetSettingParserTest extends munit.FunSuite {
         |removeConsumedCapacity: true
         |""".stripMargin
 
-    val parsedSettings = parseDynamoDBTargetSettings(config)
-    assertEquals(parsedSettings.removeConsumedCapacity, Some(true))
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("removeConsumedCapacity")),
+      s"Expected error about removeConsumedCapacity, got: ${result.left.map(_.getMessage)}"
+    )
   }
 
-  test("removeConsumedCapacity decodes as Some(false) when explicitly disabled") {
+  test("alternator target with assumeRole fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |credentials:
+        |  accessKey: foo
+        |  secretKey: bar
+        |  assumeRole:
+        |    arn: arn:aws:iam::123456789012:role/MyRole
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("assumeRole")),
+      s"Expected error about assumeRole, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator target with multiple validation errors reports all") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |rack: rack1
+        |maxConnections: -5
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    val msg = result.swap.map(_.getMessage).getOrElse("")
+    assert(msg.contains("datacenter"), s"Expected error about datacenter, got: $msg")
+    assert(msg.contains("maxConnections"), s"Expected error about maxConnections, got: $msg")
+  }
+
+  test("alternator target without endpoint and with invalid settings reports all errors") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |rack: rack1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    val msg = result.swap.map(_.getMessage).getOrElse("")
+    assert(msg.contains("endpoint"), s"Expected error about endpoint, got: $msg")
+    assert(msg.contains("datacenter"), s"Expected error about datacenter, got: $msg")
+  }
+
+  test("alternator target defaults removeConsumedCapacity to true") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    result match {
+      case Right(alt: TargetSettings.Alternator) =>
+        assertEquals(alt.removeConsumedCapacity, true)
+      case other =>
+        fail(s"Expected TargetSettings.Alternator, got: ${other}")
+    }
+  }
+
+  test("dynamodb target with Alternator-only fields fails") {
     val config =
       """type: dynamodb
         |table: Dummy
         |streamChanges: false
+        |datacenter: dc1
+        |compression: true
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    val msg = result.swap.map(_.getMessage).getOrElse("")
+    assert(
+      msg.contains("Alternator-only fields"),
+      s"Expected error about Alternator-only fields, got: $msg"
+    )
+    assert(msg.contains("datacenter"), s"Expected 'datacenter' in error, got: $msg")
+    assert(msg.contains("compression"), s"Expected 'compression' in error, got: $msg")
+  }
+
+  test("dynamodb target with single Alternator-only field fails") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |streamChanges: false
+        |rack: rack1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("rack")),
+      s"Expected error mentioning 'rack', got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("'dynamo' alias with Alternator-only fields fails") {
+    val config =
+      """type: dynamo
+        |table: Dummy
+        |streamChanges: false
+        |datacenter: dc1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("Alternator-only fields")),
+      s"Expected error about Alternator-only fields, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb target minimal roundtrip (all optionals None)") {
+    val original = TargetSettings.DynamoDB(
+      endpoint                    = None,
+      region                      = None,
+      credentials                 = None,
+      table                       = "MinimalTable",
+      writeThroughput             = None,
+      throughputWritePercent      = None,
+      streamChanges               = false,
+      skipInitialSnapshotTransfer = None
+    )
+    val json = (original: TargetSettings).asJson
+    val decoded = json.as[TargetSettings]
+    assertEquals(decoded, Right(original))
+  }
+
+  test("alternator target minimal roundtrip (all optionals None)") {
+    val original = TargetSettings.Alternator(
+      alternatorEndpoint          = DynamoDBEndpoint("http://10.0.0.1", 8000),
+      region                      = None,
+      credentials                 = None,
+      table                       = "MinimalTable",
+      writeThroughput             = None,
+      throughputWritePercent      = None,
+      streamChanges               = false,
+      skipInitialSnapshotTransfer = None,
+      removeConsumedCapacity      = true,
+      billingMode                 = None,
+      alternatorConfig            = AlternatorSettings()
+    )
+    val json = (original: TargetSettings).asJson
+    val decoded = json.as[TargetSettings]
+    assertEquals(decoded, Right(original))
+  }
+
+  test("AlternatorSettings field names do not overlap with base Alternator target field names") {
+    // Derive field names from the case class to stay in sync automatically.
+    // "alternatorConfig" and "alternatorEndpoint" are internal fields (not in YAML),
+    // replaced with "endpoint" and "type" (synthetic YAML fields).
+    val baseTargetKeys = TargetSettings
+      .Alternator(
+        alternatorEndpoint          = DynamoDBEndpoint("http://placeholder", 0),
+        region                      = None,
+        credentials                 = None,
+        table                       = "",
+        writeThroughput             = None,
+        throughputWritePercent      = None,
+        streamChanges               = false,
+        skipInitialSnapshotTransfer = None
+      )
+      .productElementNames
+      .toSet - "alternatorConfig" - "alternatorEndpoint" + "endpoint" + "type"
+    val overlap = AlternatorSettings.fieldNames.intersect(baseTargetKeys)
+    assert(
+      overlap.isEmpty,
+      s"AlternatorSettings field names must not overlap with base Alternator target field names, but found: ${overlap.mkString(", ")}"
+    )
+  }
+
+  test("alternator target with endpoint missing protocol prefix fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: 10.0.0.1
+        |  port: 8000
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("protocol prefix")),
+      s"Expected error about protocol prefix, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb target with protocol-prefix endpoint parses") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |streamChanges: false
+        |endpoint:
+        |  host: http://scylla
+        |  port: 8000
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    result match {
+      case Right(d: TargetSettings.DynamoDB) =>
+        assertEquals(d.endpoint.map(_.host), Some("http://scylla"))
+      case other =>
+        fail(s"Expected TargetSettings.DynamoDB, got: ${other}")
+    }
+  }
+
+  test("dynamodb target with zero writeThroughput fails") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |streamChanges: false
+        |writeThroughput: 0
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("writeThroughput")),
+      s"Expected error about writeThroughput, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb target with empty table fails") {
+    val config =
+      """type: dynamodb
+        |table: ""
+        |streamChanges: false
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("'table'")),
+      s"Expected error about 'table', got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb target with whitespace-only table fails") {
+    val config =
+      """type: dynamodb
+        |table: "   "
+        |streamChanges: false
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("'table'")),
+      s"Expected error about 'table', got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator target with negative throughputWritePercent fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |throughputWritePercent: -0.5
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("throughputWritePercent")),
+      s"Expected error about throughputWritePercent, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator target with explicit removeConsumedCapacity false") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
         |removeConsumedCapacity: false
         |""".stripMargin
 
-    val parsedSettings = parseDynamoDBTargetSettings(config)
-    assertEquals(parsedSettings.removeConsumedCapacity, Some(false))
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    result match {
+      case Right(alt: TargetSettings.Alternator) =>
+        assertEquals(alt.removeConsumedCapacity, false)
+      case other =>
+        fail(s"Expected TargetSettings.Alternator, got: ${other}")
+    }
+  }
+
+  test("alternator target with throughputWritePercent above 1.5 fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |throughputWritePercent: 2.0
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("throughputWritePercent")),
+      s"Expected error about throughputWritePercent, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb target with bare hostname endpoint succeeds") {
+    val config =
+      """type: dynamodb
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: my-dynamodb-host
+        |  port: 8000
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    result match {
+      case Right(d: TargetSettings.DynamoDB) =>
+        assertEquals(d.endpoint, Some(DynamoDBEndpoint("my-dynamodb-host", 8000)))
+      case other =>
+        fail(s"Expected TargetSettings.DynamoDB, got: ${other}")
+    }
+  }
+
+  test("unknown target type fails") {
+    val config =
+      """type: unknown
+        |table: Dummy
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("Invalid target type")),
+      s"Expected error about invalid target type, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb target with missing streamChanges fails") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("streamChanges")),
+      s"Expected error about streamChanges, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator target with https endpoint parses successfully") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: https://my-alternator
+        |  port: 8000
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    result match {
+      case Right(alt: TargetSettings.Alternator) =>
+        assertEquals(alt.endpoint, Some(DynamoDBEndpoint("https://my-alternator", 8000)))
+      case other =>
+        fail(s"Expected TargetSettings.Alternator, got: ${other}")
+    }
+  }
+
+  test("alternator target with https endpoint roundtrip") {
+    val original = TargetSettings.Alternator(
+      alternatorEndpoint          = DynamoDBEndpoint("https://my-alternator", 8000),
+      region                      = None,
+      credentials                 = None,
+      table                       = "HttpsTable",
+      writeThroughput             = None,
+      throughputWritePercent      = None,
+      streamChanges               = false,
+      skipInitialSnapshotTransfer = None,
+      removeConsumedCapacity      = true,
+      billingMode                 = None,
+      alternatorConfig            = AlternatorSettings()
+    )
+    val json = (original: TargetSettings).asJson
+    val decoded = json.as[TargetSettings]
+    assertEquals(decoded, Right(original))
+  }
+
+  test("target throughputWritePercent boundary 0.1 passes") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |throughputWritePercent: 0.1
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isRight, s"Expected success but got: ${result}")
+  }
+
+  test("target throughputWritePercent boundary 1.5 passes") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |throughputWritePercent: 1.5
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isRight, s"Expected success but got: ${result}")
+  }
+
+  test("target throughputWritePercent boundary 0.09 fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |throughputWritePercent: 0.09
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("throughputWritePercent")),
+      s"Expected error about throughputWritePercent, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("target throughputWritePercent boundary 1.51 fails") {
+    val config =
+      """type: alternator
+        |table: MyTable
+        |streamChanges: false
+        |endpoint:
+        |  host: http://10.0.0.1
+        |  port: 8000
+        |throughputWritePercent: 1.51
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[TargetSettings])
+
+    assert(result.isLeft, s"Expected failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("throughputWritePercent")),
+      s"Expected error about throughputWritePercent, got: ${result.left.map(_.getMessage)}"
+    )
   }
 
   private def parseDynamoDBTargetSettings(yamlContent: String): TargetSettings.DynamoDB =

--- a/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigFixtureParsingTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigFixtureParsingTest.scala
@@ -1,0 +1,87 @@
+package com.scylladb.migrator.config
+
+import java.nio.file.{ Files, Path, Paths }
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+class MigratorConfigFixtureParsingTest extends munit.FunSuite {
+
+  private def listYamlFiles(dir: Path): Seq[Path] = {
+    val stream = Files.list(dir)
+    try
+      stream
+        .iterator()
+        .asScala
+        .toSeq
+        .filter(_.toString.endsWith(".yaml"))
+        .sortBy(_.getFileName.toString)
+    finally
+      stream.close()
+  }
+
+  private def parseFailure(file: Path): Option[String] =
+    Try(MigratorConfig.loadFrom(file.toString)).toEither.left.toOption.map { error =>
+      val path = file.toString
+      s"${path}: ${error.getMessage}"
+    }
+
+  test("parses all test fixture configurations") {
+    val configDir = Seq(
+      Paths.get("src", "test", "configurations"),
+      Paths.get("tests", "src", "test", "configurations")
+    ).find(path => Files.exists(path))
+      .getOrElse(
+        fail("Could not find test configuration directory")
+      )
+    val configurationFiles = listYamlFiles(configDir)
+    val failures = configurationFiles.flatMap(parseFailure)
+    assert(
+      failures.isEmpty,
+      s"Expected all test configurations to parse, but failed on: ${failures.mkString(", ")}"
+    )
+  }
+
+  private def resolveExistingPath(candidates: Seq[Path], description: String): Path =
+    candidates.find(path => Files.exists(path)).getOrElse(fail(s"Expected $description"))
+
+  test("parses curated shipped example configurations") {
+    val exampleFiles = Seq(
+      resolveExistingPath(
+        Seq(
+          Paths.get("ansible", "files", "config.dynamodb.yml"),
+          Paths.get("..", "ansible", "files", "config.dynamodb.yml")
+        ),
+        "ansible/files/config.dynamodb.yml"
+      ),
+      resolveExistingPath(
+        Seq(
+          Paths.get(
+            "docs",
+            "source",
+            "tutorials",
+            "dynamodb-to-scylladb-alternator",
+            "spark-data",
+            "config.yaml"
+          ),
+          Paths.get(
+            "..",
+            "docs",
+            "source",
+            "tutorials",
+            "dynamodb-to-scylladb-alternator",
+            "spark-data",
+            "config.yaml"
+          )
+        ),
+        "docs/source/tutorials/dynamodb-to-scylladb-alternator/spark-data/config.yaml"
+      )
+    )
+
+    val failures = exampleFiles.sortBy(_.toString).flatMap(parseFailure)
+
+    assert(
+      failures.isEmpty,
+      s"Expected shipped example configs to parse, but failed on: ${failures.mkString(", ")}"
+    )
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigTest.scala
@@ -1,0 +1,412 @@
+package com.scylladb.migrator.config
+
+import com.datastax.spark.connector.rdd.partitioner.dht.{ BigIntToken, LongToken }
+import io.circe.yaml
+
+class MigratorConfigTest extends munit.FunSuite {
+
+  test("full MigratorConfig with Alternator types round-trips through YAML") {
+    val config = MigratorConfig(
+      source = SourceSettings.Alternator(
+        alternatorEndpoint     = DynamoDBEndpoint("http://10.0.0.1", 8000),
+        region                 = Some("us-east-1"),
+        credentials            = None,
+        table                  = "SrcTable",
+        scanSegments           = Some(4),
+        readThroughput         = Some(100),
+        throughputReadPercent  = Some(0.5f),
+        maxMapTasks            = Some(2),
+        removeConsumedCapacity = true,
+        alternatorConfig = AlternatorSettings(
+          datacenter              = Some("dc1"),
+          rack                    = Some("rack1"),
+          activeRefreshIntervalMs = Some(5000L)
+        )
+      ),
+      target = TargetSettings.Alternator(
+        alternatorEndpoint          = DynamoDBEndpoint("http://10.0.0.2", 8000),
+        region                      = None,
+        credentials                 = None,
+        table                       = "DstTable",
+        writeThroughput             = Some(200),
+        throughputWritePercent      = Some(0.8f),
+        streamChanges               = false,
+        skipInitialSnapshotTransfer = None,
+        removeConsumedCapacity      = true,
+        billingMode                 = None,
+        alternatorConfig            = AlternatorSettings(datacenter = Some("dc2"))
+      ),
+      renames          = Some(List(Rename("oldCol", "newCol"))),
+      savepoints       = Savepoints(intervalSeconds = 300, path = "/tmp/savepoints"),
+      skipTokenRanges  = None,
+      skipSegments     = None,
+      skipParquetFiles = None,
+      validation       = None
+    )
+    val rendered = config.render
+    val parsed = yaml.parser.parse(rendered).flatMap(_.as[MigratorConfig])
+    assert(parsed.isRight, s"Round-trip failed: ${parsed}")
+    val roundTripped = parsed.toOption.get
+    assertEquals(roundTripped.source, config.source)
+    assertEquals(roundTripped.target, config.target)
+    assertEquals(roundTripped.renames, config.renames)
+    assertEquals(roundTripped.savepoints, config.savepoints)
+  }
+
+  test("alternator source with streamChanges true is rejected") {
+    val config =
+      """source:
+        |  type: alternator
+        |  table: Src
+        |  endpoint:
+        |    host: http://10.0.0.1
+        |    port: 8000
+        |target:
+        |  type: dynamodb
+        |  table: Dest
+        |  streamChanges: true
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[MigratorConfig])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("streamChanges")),
+      s"Expected error about streamChanges, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator source with alternator target and streamChanges true is rejected") {
+    val config =
+      """source:
+        |  type: alternator
+        |  table: Src
+        |  endpoint:
+        |    host: http://10.0.0.1
+        |    port: 8000
+        |target:
+        |  type: alternator
+        |  table: Dest
+        |  streamChanges: true
+        |  endpoint:
+        |    host: http://10.0.0.2
+        |    port: 8000
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[MigratorConfig])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("streamChanges")),
+      s"Expected error about streamChanges, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb-s3-export source with streamChanges true is rejected") {
+    val config =
+      """source:
+        |  type: dynamodb-s3-export
+        |  bucket: foobar
+        |  manifestKey: manifest.json
+        |  tableDescription:
+        |    attributeDefinitions:
+        |      - name: id
+        |        type: S
+        |    keySchema:
+        |      - name: id
+        |        type: HASH
+        |target:
+        |  type: alternator
+        |  table: Dest
+        |  streamChanges: true
+        |  endpoint:
+        |    host: http://10.0.0.1
+        |    port: 8000
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[MigratorConfig])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("streamChanges")),
+      s"Expected error about streamChanges, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("alternator source with streamChanges false is accepted") {
+    val config =
+      """source:
+        |  type: alternator
+        |  table: Src
+        |  endpoint:
+        |    host: http://10.0.0.1
+        |    port: 8000
+        |target:
+        |  type: dynamodb
+        |  table: Dest
+        |  streamChanges: false
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[MigratorConfig])
+
+    assert(result.isRight, s"Expected valid config but got: ${result}")
+  }
+
+  test("dynamodb source to alternator target parses successfully") {
+    val config =
+      """source:
+        |  type: dynamodb
+        |  table: Src
+        |target:
+        |  type: alternator
+        |  table: Dest
+        |  streamChanges: false
+        |  endpoint:
+        |    host: http://10.0.0.1
+        |    port: 8000
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[MigratorConfig])
+
+    assert(result.isRight, s"Expected valid config but got: ${result}")
+    val cfg = result.toOption.get
+    assert(cfg.source.isInstanceOf[SourceSettings.DynamoDB])
+    assert(cfg.target.isInstanceOf[TargetSettings.Alternator])
+  }
+
+  test("alternator source to alternator target parses successfully") {
+    val config =
+      """source:
+        |  type: alternator
+        |  table: Src
+        |  endpoint:
+        |    host: http://10.0.0.1
+        |    port: 8000
+        |target:
+        |  type: alternator
+        |  table: Dest
+        |  streamChanges: false
+        |  endpoint:
+        |    host: http://10.0.0.2
+        |    port: 8000
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[MigratorConfig])
+
+    assert(result.isRight, s"Expected valid config but got: ${result}")
+    val cfg = result.toOption.get
+    assert(cfg.source.isInstanceOf[SourceSettings.Alternator])
+    assert(cfg.target.isInstanceOf[TargetSettings.Alternator])
+  }
+
+  test("alternator source to dynamodb-s3-export target is rejected") {
+    val config =
+      """source:
+        |  type: alternator
+        |  table: Src
+        |  endpoint:
+        |    host: http://10.0.0.1
+        |    port: 8000
+        |target:
+        |  type: dynamodb-s3-export
+        |  path: /tmp/export
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[MigratorConfig])
+
+    assert(result.isLeft, s"Expected a decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("dynamodb-s3-export")),
+      s"Expected error about unsupported alternator -> dynamodb-s3-export, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("dynamodb source to alternator target with streaming parses successfully") {
+    val config =
+      """source:
+        |  type: dynamodb
+        |  table: Src
+        |target:
+        |  type: alternator
+        |  table: Dest
+        |  streamChanges: true
+        |  endpoint:
+        |    host: http://10.0.0.1
+        |    port: 8000
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[MigratorConfig])
+
+    assert(result.isRight, s"Expected valid config but got: ${result}")
+    val cfg = result.toOption.get
+    assert(cfg.source.isInstanceOf[SourceSettings.DynamoDB])
+    assert(cfg.target.isInstanceOf[TargetSettings.Alternator])
+    assert(cfg.target.asInstanceOf[TargetSettings.Alternator].streamChanges)
+  }
+
+  test("dynamodb-s3-export source with streamChanges false is accepted") {
+    val config =
+      """source:
+        |  type: dynamodb-s3-export
+        |  bucket: foobar
+        |  manifestKey: manifest.json
+        |  tableDescription:
+        |    attributeDefinitions:
+        |      - name: id
+        |        type: S
+        |    keySchema:
+        |      - name: id
+        |        type: HASH
+        |target:
+        |  type: alternator
+        |  table: Dest
+        |  streamChanges: false
+        |  endpoint:
+        |    host: http://10.0.0.1
+        |    port: 8000
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[MigratorConfig])
+
+    assert(result.isRight, s"Expected valid config but got: ${result}")
+  }
+
+  test("dynamodb source to dynamodb target parses successfully") {
+    val config =
+      """source:
+        |  type: dynamodb
+        |  table: Src
+        |target:
+        |  type: dynamodb
+        |  table: Dest
+        |  streamChanges: false
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[MigratorConfig])
+
+    assert(result.isRight, s"Expected valid config but got: ${result}")
+    val cfg = result.toOption.get
+    assert(cfg.source.isInstanceOf[SourceSettings.DynamoDB])
+    assert(cfg.target.isInstanceOf[TargetSettings.DynamoDB])
+  }
+
+  test("dynamodb source to dynamodb target with streaming parses successfully") {
+    val config =
+      """source:
+        |  type: dynamodb
+        |  table: Src
+        |target:
+        |  type: dynamodb
+        |  table: Dest
+        |  streamChanges: true
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+
+    val result = yaml.parser
+      .parse(config)
+      .flatMap(_.as[MigratorConfig])
+
+    assert(result.isRight, s"Expected valid config but got: ${result}")
+    val cfg = result.toOption.get
+    assert(cfg.source.isInstanceOf[SourceSettings.DynamoDB])
+    assert(cfg.target.isInstanceOf[TargetSettings.DynamoDB])
+    assert(cfg.target.asInstanceOf[TargetSettings.DynamoDB].streamChanges)
+  }
+
+  test("MigratorConfig roundtrip with skipTokenRanges containing LongToken and BigIntToken") {
+    val config = MigratorConfig(
+      source = SourceSettings.DynamoDB(
+        endpoint              = None,
+        region                = Some("us-east-1"),
+        credentials           = None,
+        table                 = "SrcTable",
+        scanSegments          = None,
+        readThroughput        = None,
+        throughputReadPercent = None,
+        maxMapTasks           = None
+      ),
+      target = TargetSettings.DynamoDB(
+        endpoint                    = None,
+        region                      = None,
+        credentials                 = None,
+        table                       = "DstTable",
+        writeThroughput             = None,
+        throughputWritePercent      = None,
+        streamChanges               = false,
+        skipInitialSnapshotTransfer = None
+      ),
+      renames    = None,
+      savepoints = Savepoints(intervalSeconds = 300, path = "/tmp/savepoints"),
+      skipTokenRanges = Some(
+        Set(
+          (LongToken(0L), LongToken(100L)),
+          (
+            BigIntToken(BigInt("123456789012345678901234567890")),
+            BigIntToken(BigInt("987654321098765432109876543210"))
+          )
+        )
+      ),
+      skipSegments     = Some(Set(1, 3, 5)),
+      skipParquetFiles = None,
+      validation       = None
+    )
+    val rendered = config.render
+    val parsed = yaml.parser.parse(rendered).flatMap(_.as[MigratorConfig])
+    assert(parsed.isRight, s"Round-trip failed: ${parsed}")
+    val roundTripped = parsed.toOption.get
+    assertEquals(roundTripped.skipTokenRanges, config.skipTokenRanges)
+    assertEquals(roundTripped.skipSegments, config.skipSegments)
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/writers/DynamoStreamReplicationIntegrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/writers/DynamoStreamReplicationIntegrationTest.scala
@@ -132,10 +132,10 @@ class DynamoStreamReplicationIntegrationTest extends MigratorSuiteWithDynamoDBLo
         .parallelize(streamEvents, 1)
         .asInstanceOf[RDD[Option[DynamoStreamReplication.DynamoItem]]]
 
-      val targetSettings = TargetSettings.DynamoDB(
+      val targetSettings = TargetSettings.Alternator(
         table                       = tableName,
         region                      = Some("eu-central-1"),
-        endpoint                    = Some(DynamoDBEndpoint("http://localhost", 8000)),
+        alternatorEndpoint          = DynamoDBEndpoint("http://localhost", 8000),
         credentials                 = Some(AWSCredentials("dummy", "dummy", None)),
         streamChanges               = false,
         skipInitialSnapshotTransfer = Some(true),


### PR DESCRIPTION
## Summary

- Introduce `type: alternator` as a distinct source/target type, separate from `type: dynamodb`
- Add `SourceSettings.DynamoDBLike` / `TargetSettings.DynamoDBLike` sealed traits for shared DynamoDB-protocol fields
- Add `SourceSettings.Alternator` / `TargetSettings.Alternator` case classes with alternator-specific settings (datacenter, rack, compression, etc.) as top-level config fields instead of nested under `alternator:`
- Client type selection now based on config type rather than endpoint presence: `type: alternator` → `AlternatorDynamoDbClient`, `type: dynamodb` → standard `DynamoDbClient`

## Breaking changes

- Configs targeting Scylla Alternator must change from `type: dynamodb` with nested `alternator:` settings to `type: alternator` with top-level settings
- The `alternator` field is removed from `type: dynamodb` source/target configs

## Test plan

- [x] Verify `sbt compile` passes (done locally)
- [x] Verify `sbt "tests / Test / compile"` passes (done locally)
- [x] Run DynamoDB-to-Alternator E2E tests
- [x] Run DynamoDB S3 export-to-Alternator E2E tests
- [x] Run streaming migration tests
- [x] Verify `type: dynamodb` still works for pure DynamoDB sources