### PR TITLE
Add flexible entrypoint for Docker image

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -18,9 +18,7 @@ FROM apache/spark:4.0.2-scala2.13-java17-r-ubuntu
 USER root
 
 COPY --from=build /app/migrator/target/scala-2.13/scylla-migrator-assembly.jar /jars/scylla-migrator-assembly.jar
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-ENTRYPOINT ["spark-submit", \
-    "--class", "com.scylladb.migrator.Migrator", \
-    "--master", "local[*]", \
-    "--conf", "spark.driver.host=localhost", \
-    "/jars/scylla-migrator-assembly.jar"]
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+exec /opt/spark/bin/spark-submit \
+  --class "${SPARK_CLASS:-com.scylladb.migrator.Migrator}" \
+  --master "${SPARK_MASTER:-local[*]}" \
+  "$@" \
+  /jars/scylla-migrator-assembly.jar


### PR DESCRIPTION
## Summary
Replace the hardcoded `ENTRYPOINT` in `Dockerfile.release` with a script that allows users to pass additional `spark-submit` flags.

Any `docker run` arguments are inserted as spark-submit flags:
```bash
docker run -v ./config.yaml:/config.yaml scylladb/scylla-migrator \
  --conf spark.scylla.config=/config.yaml \
  --conf spark.cassandra.auth.username=cassandra \
  --conf spark.cassandra.auth.password=cassandra
```

Override class (e.g. to run the Validator) or master via env vars:
```bash
docker run -e SPARK_CLASS=com.scylladb.migrator.Validator ...
docker run -e SPARK_MASTER=spark://host:7077 ...
```

## Test plan
- [x] Build image locally with `make docker-image`
- [x] Run with `--conf` flags and verify they reach spark-submit
- [x] Run with `SPARK_CLASS=com.scylladb.migrator.Validator` and verify class override
- [x] Run with `SPARK_MASTER=spark://host:7077` and verify master override