### PR TITLE
Support migration of tables with counter columns

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -4,7 +4,7 @@ import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.{ Schema, TableDef }
 import com.datastax.spark.connector.rdd.ReadConf
 import com.datastax.spark.connector.rdd.partitioner.dht.Token
-import com.datastax.spark.connector.types.CassandraOption
+import com.datastax.spark.connector.types.{ CassandraOption, CounterType }
 import com.scylladb.migrator.Connectors
 import com.scylladb.migrator.config.{ CopyType, SourceSettings }
 import org.apache.logging.log4j.LogManager
@@ -28,6 +28,9 @@ object Cassandra {
     timestampColumns: Option[TimestampColumns]
   )
 
+  def hasCounterColumns(tableDef: TableDef): Boolean =
+    tableDef.columns.exists(_.columnType == CounterType)
+
   def determineCopyType(
     tableDef: TableDef,
     preserveTimesRequest: Boolean
@@ -38,7 +41,12 @@ object Cassandra {
           "TTL/Writetime preservation is unsupported for tables with collection types. Please check in your config the option 'preserveTimestamps' and set it to false to continue."
         )
       )
-    else if (preserveTimesRequest && tableDef.regularColumns.nonEmpty)
+    else if (hasCounterColumns(tableDef) && preserveTimesRequest) {
+      log.warn(
+        "Counter columns detected - disabling timestamp preservation (counters do not support USING TIMESTAMP)"
+      )
+      Right(CopyType.NoTimestampPreservation)
+    } else if (preserveTimesRequest && tableDef.regularColumns.nonEmpty)
       Right(CopyType.WithTimestampPreservation)
     else if (preserveTimesRequest && tableDef.regularColumns.isEmpty) {
       log.warn("No regular columns in the table - disabling timestamp preservation")

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -2,7 +2,8 @@ package com.scylladb.migrator.writers
 
 import com.datastax.spark.connector.writer._
 import com.datastax.spark.connector._
-import com.datastax.spark.connector.cql.Schema
+import com.datastax.spark.connector.cql.{ Schema, TableDef }
+import com.datastax.spark.connector.types.CounterType
 import com.scylladb.migrator.Connectors
 import com.scylladb.migrator.config.{ Rename, SourceSettings, TargetSettings }
 import com.scylladb.migrator.readers.TimestampColumns
@@ -98,6 +99,48 @@ object Scylla {
         case _ => true
       }
     }
+
+  /** Identify counter column indices in the DataFrame based on the target table definition. Returns
+    * indices of columns whose type is CounterType.
+    */
+  private[writers] def counterColumnIndices(
+    tableDef: TableDef,
+    renames: List[Rename],
+    dfSchema: StructType
+  ): Set[Int] = {
+    val renameMap = renames.map(r => r.to -> r.from).toMap
+    val counterNames = tableDef.columns
+      .filter(_.columnType == CounterType)
+      .map(_.columnName)
+      .toSet
+    val dfFieldNamesLower = dfSchema.fieldNames.zipWithIndex.map { case (name, idx) =>
+      name.toLowerCase(Locale.ROOT) -> idx
+    }.toMap
+    counterNames.flatMap { targetName =>
+      val sourceName = renameMap.getOrElse(targetName, targetName)
+      dfFieldNamesLower.get(sourceName.toLowerCase(Locale.ROOT))
+    }
+  }
+
+  /** Replace null counter values with 0L to avoid "Invalid null value for counter increment"
+    * errors. Rows where all counter columns are null are filtered out entirely.
+    */
+  private[writers] def fixNullCounterValues(
+    rdd: RDD[Row],
+    counterIndices: Set[Int]
+  ): RDD[Row] =
+    rdd
+      .filter { row =>
+        // Drop rows where all counter columns are null (nothing to increment)
+        counterIndices.exists(i => !row.isNullAt(i))
+      }
+      .map { row =>
+        val values = row.toSeq.zipWithIndex.map { case (value, idx) =>
+          if (counterIndices.contains(idx) && value == null) 0L
+          else value
+        }
+        Row.fromSeq(values)
+      }
 
   /** Columns that the Spark Cassandra Connector considers internal and filters from the write path
     * (see `TableWriter.InternalColumns`). If these columns are present in the source DataFrame, the
@@ -208,6 +251,9 @@ object Scylla {
           })
         }
 
+    val tableDef =
+      connector.withSessionDo(Schema.tableFromCassandra(_, target.keyspace, target.table))
+
     // Optionally filter out rows where any primary key column is null to prevent
     // infinite retries against the target database (see issue #262).
     // Auto-detected from the source type, or overridden via target `dropNullPrimaryKeys`.
@@ -215,8 +261,6 @@ object Scylla {
     log.info(s"Drop null primary key rows: ${dropNullPks}")
     val (finalRdd, nullPkRowsDropped) =
       if (dropNullPks) {
-        val tableDef =
-          connector.withSessionDo(Schema.tableFromCassandra(_, target.keyspace, target.table))
         val targetPkNames = tableDef.primaryKey.map(_.columnName).toSet
 
         val pkResolution = resolvePrimaryKeyColumns(targetPkNames, renames, cleanDf.schema)
@@ -239,7 +283,17 @@ object Scylla {
         (rdd, None)
       }
 
-    finalRdd
+    // Fix null counter values: replace nulls with 0 and drop all-null-counter rows
+    val counterIdxs = counterColumnIndices(tableDef, renames, cleanDf.schema)
+    val writeRdd =
+      if (counterIdxs.nonEmpty) {
+        log.info(
+          s"Counter columns detected at indices: ${counterIdxs.mkString(", ")}. Replacing null values with 0."
+        )
+        fixNullCounterValues(finalRdd, counterIdxs)
+      } else finalRdd
+
+    writeRdd
       .saveToCassandra(
         target.keyspace,
         target.table,

--- a/tests/src/test/configurations/cassandra-to-scylla-counters.yaml
+++ b/tests/src/test/configurations/cassandra-to-scylla-counters.yaml
@@ -1,0 +1,33 @@
+source:
+  type: cassandra
+  host: cassandra
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: countertest
+  consistencyLevel: LOCAL_QUORUM
+  preserveTimestamps: true
+  splitCount: 8
+  connections: 8
+  fetchSize: 1000
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: countertest
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/scala/com/scylladb/migrator/readers/CassandraCopyTypeTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/CassandraCopyTypeTest.scala
@@ -1,0 +1,75 @@
+package com.scylladb.migrator.readers
+
+import com.datastax.spark.connector.cql.{ ColumnDef, PartitionKeyColumn, RegularColumn, TableDef }
+import com.datastax.spark.connector.types.{ BigIntType, CounterType, ListType, TextType }
+import com.scylladb.migrator.config.CopyType
+
+class CassandraCopyTypeTest extends munit.FunSuite {
+
+  private def makeTableDef(regularColumns: Seq[ColumnDef]): TableDef =
+    TableDef(
+      "test_ks",
+      "test_table",
+      partitionKey      = Seq(ColumnDef("id", PartitionKeyColumn, TextType)),
+      clusteringColumns = Seq.empty,
+      regularColumns    = regularColumns
+    )
+
+  test("counter table with preserveTimestamps=true disables timestamp preservation") {
+    val tableDef = makeTableDef(
+      Seq(
+        ColumnDef("counter1", RegularColumn, CounterType),
+        ColumnDef("counter2", RegularColumn, CounterType)
+      )
+    )
+    val result = Cassandra.determineCopyType(tableDef, preserveTimesRequest = true)
+    assertEquals(result, Right(CopyType.NoTimestampPreservation))
+  }
+
+  test("counter table with preserveTimestamps=false returns NoTimestampPreservation") {
+    val tableDef = makeTableDef(
+      Seq(
+        ColumnDef("counter1", RegularColumn, CounterType)
+      )
+    )
+    val result = Cassandra.determineCopyType(tableDef, preserveTimesRequest = false)
+    assertEquals(result, Right(CopyType.NoTimestampPreservation))
+  }
+
+  test("non-counter table with preserveTimestamps=true returns WithTimestampPreservation") {
+    val tableDef = makeTableDef(
+      Seq(
+        ColumnDef("value", RegularColumn, BigIntType)
+      )
+    )
+    val result = Cassandra.determineCopyType(tableDef, preserveTimesRequest = true)
+    assertEquals(result, Right(CopyType.WithTimestampPreservation))
+  }
+
+  test("collection table with preserveTimestamps=true returns error") {
+    val tableDef = makeTableDef(
+      Seq(
+        ColumnDef("items", RegularColumn, ListType(TextType))
+      )
+    )
+    val result = Cassandra.determineCopyType(tableDef, preserveTimesRequest = true)
+    assert(result.isLeft)
+  }
+
+  test("hasCounterColumns detects counter columns") {
+    val withCounters = makeTableDef(
+      Seq(
+        ColumnDef("counter1", RegularColumn, CounterType),
+        ColumnDef("value", RegularColumn, BigIntType)
+      )
+    )
+    assert(Cassandra.hasCounterColumns(withCounters))
+
+    val withoutCounters = makeTableDef(
+      Seq(
+        ColumnDef("value", RegularColumn, BigIntType)
+      )
+    )
+    assert(!Cassandra.hasCounterColumns(withoutCounters))
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/CounterTableMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/CounterTableMigrationTest.scala
@@ -1,0 +1,89 @@
+package com.scylladb.migrator.scylla
+
+import com.datastax.oss.driver.api.core.`type`.DataTypes
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder
+import com.scylladb.migrator.Integration
+import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
+import org.junit.experimental.categories.Category
+
+import scala.jdk.CollectionConverters._
+import scala.util.chaining._
+
+/** Integration test for migrating tables with counter columns.
+  *
+  * Verifies that:
+  *   - Counter tables migrate successfully even with preserveTimestamps=true (timestamps are
+  *     auto-disabled for counters)
+  *   - Null counter values are handled without errors
+  *   - Non-null counter values are preserved correctly
+  */
+@Category(Array(classOf[Integration]))
+class CounterTableMigrationTest extends MigratorSuite(9043) {
+
+  private val configFile = "cassandra-to-scylla-counters.yaml"
+  private val tableName = "countertest"
+
+  private def createCounterTable(session: com.datastax.oss.driver.api.core.CqlSession): Unit = {
+    session.execute(SchemaBuilder.dropTable(keyspace, tableName).ifExists().build())
+    session.execute(
+      SchemaBuilder
+        .createTable(keyspace, tableName)
+        .withPartitionKey("id", DataTypes.TEXT)
+        .withClusteringColumn("category", DataTypes.TEXT)
+        .withColumn("counter_1", DataTypes.COUNTER)
+        .withColumn("counter_2", DataTypes.COUNTER)
+        .build()
+    )
+  }
+
+  val counterTable: FunFixture[String] = FunFixture(
+    setup = { _ =>
+      createCounterTable(sourceCassandra())
+      createCounterTable(targetScylla())
+      tableName
+    },
+    teardown = { _ =>
+      val drop = SchemaBuilder.dropTable(keyspace, tableName).build()
+      targetScylla().execute(drop)
+      sourceCassandra().execute(drop)
+      ()
+    }
+  )
+
+  counterTable.test("Counter table migration with mixed null and non-null values") { _ =>
+    // Insert counter values using UPDATE (the only way to modify counters)
+    // Row 1: both counters set
+    sourceCassandra().execute(
+      s"UPDATE $keyspace.$tableName SET counter_1 = counter_1 + 10, counter_2 = counter_2 + 20 WHERE id = 'row1' AND category = 'a'"
+    )
+
+    // Row 2: only counter_1 set (counter_2 remains null)
+    sourceCassandra().execute(
+      s"UPDATE $keyspace.$tableName SET counter_1 = counter_1 + 5 WHERE id = 'row2' AND category = 'b'"
+    )
+
+    successfullyPerformMigration(configFile)
+
+    val rows = targetScylla()
+      .execute(
+        QueryBuilder.selectFrom(keyspace, tableName).all().build()
+      )
+      .all()
+      .asScala
+      .sortBy(_.getString("id"))
+
+    // Row 1: both counters migrated
+    assertEquals(rows.size, 2)
+    val row1 = rows(0)
+    assertEquals(row1.getString("id"), "row1")
+    assertEquals(row1.getLong("counter_1"), 10L)
+    assertEquals(row1.getLong("counter_2"), 20L)
+
+    // Row 2: counter_1 migrated, counter_2 should be 0 (null counter replaced with 0)
+    val row2 = rows(1)
+    assertEquals(row2.getString("id"), "row2")
+    assertEquals(row2.getLong("counter_1"), 5L)
+    assertEquals(row2.getLong("counter_2"), 0L)
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #17

- Detect counter columns and automatically disable timestamp preservation (counters reject `USING TIMESTAMP`)
- Replace null counter values with 0 to avoid "Invalid null value for counter increment" errors
- Drop rows where all counter columns are null (nothing to increment)

## Changes
- `Cassandra.determineCopyType`: detect counter columns via `CounterType` and fall back to `NoTimestampPreservation`
- `Scylla.writeDataframe`: identify counter column indices in the target table, replace nulls with 0, filter all-null-counter rows
- Refactored `tableDef` fetch to happen once in the write path

## Test plan
- [x] 5 unit tests for `determineCopyType` and `hasCounterColumns` (pass)
- [ ] Integration test: counter table with mixed null/non-null values (`CounterTableMigrationTest`)