### PR TITLE
Add explicit permissions to release workflow for read-only GITHUB_TOKEN default

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: write` to the `publish` job in `.github/workflows/release.yaml`
- The `softprops/action-gh-release@v2` action needs `contents: write` to upload release artifacts to GitHub releases
- Without this, the release workflow will fail now that the repository default GITHUB_TOKEN is read-only

## Analysis of all workflows

| Workflow | Needs write? | Status |
|----------|-------------|--------|
| `release.yaml` | Yes (`contents: write` for `softprops/action-gh-release`) | **Fixed in this PR** |
| `tests-aws.yml` | Yes (`id-token: write`) | Already has explicit permissions |
| `docs-pages.yaml` | Yes (`pages: write`, `id-token: write`, `contents: write`) | Already has explicit permissions |
| `docs-pr.yaml` | No | Already has explicit `contents: read` |
| `docker-publish.yml` | No (uses `DOCKERHUB_TOKEN`, not `GITHUB_TOKEN`) | Fine with read-only default |
| `spark-image.yml` | No (uses `DOCKERHUB_TOKEN`) | Fine with read-only default |
| `spark-cache-cleanup.yml` | No (uses `DOCKERHUB_TOKEN`) | Fine with read-only default |
| `build.yml` | No | Fine with read-only default |
| `tests.yml` | No | Fine with read-only default |
| `tutorial-dynamodb.yaml` | No | Fine with read-only default |

## Test plan

- [ ] Create a release and verify that the assembly JAR is uploaded as a release artifact