### PR TITLE
Extract ConsistencyLevel parsing into shared utility

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/ConsistencyLevelUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/ConsistencyLevelUtils.scala
@@ -1,0 +1,20 @@
+package com.scylladb.migrator
+
+import com.datastax.oss.driver.api.core.DefaultConsistencyLevel
+import com.datastax.oss.driver.api.core.ConsistencyLevel
+
+object ConsistencyLevelUtils {
+
+  /** Parse a consistency level string into a [[ConsistencyLevel]]. Throws
+    * [[IllegalArgumentException]] if the string is not a valid consistency level.
+    */
+  def parseConsistencyLevel(configured: String): ConsistencyLevel =
+    try DefaultConsistencyLevel.valueOf(configured)
+    catch {
+      case _: IllegalArgumentException =>
+        val validValues = DefaultConsistencyLevel.values().map(_.name()).mkString(", ")
+        throw new IllegalArgumentException(
+          s"Invalid consistency level '${configured}'. Valid values are: ${validValues}"
+        )
+    }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -13,7 +13,7 @@ import org.apache.spark.sql.cassandra.{ CassandraSQLRow, DataTypeConverter }
 import org.apache.spark.sql.types.{ IntegerType, LongType, StructField, StructType }
 import org.apache.spark.sql.{ DataFrame, Encoders, Row, SparkSession }
 import org.apache.spark.unsafe.types.UTF8String
-import com.datastax.oss.driver.api.core.ConsistencyLevel
+import com.scylladb.migrator.ConsistencyLevelUtils
 import com.scylladb.migrator.scylla.SourceDataFrame
 
 import scala.collection.immutable.ArraySeq
@@ -327,22 +327,10 @@ object Cassandra {
     skipExplosion: Boolean = false
   ): SourceDataFrame = {
     val connector = Connectors.sourceConnector(spark.sparkContext.getConf, source)
-    val consistencyLevel = source.consistencyLevel match {
-      case "LOCAL_QUORUM" => ConsistencyLevel.LOCAL_QUORUM
-      case "QUORUM"       => ConsistencyLevel.QUORUM
-      case "LOCAL_ONE"    => ConsistencyLevel.LOCAL_ONE
-      case "ONE"          => ConsistencyLevel.ONE
-      case _              => ConsistencyLevel.LOCAL_QUORUM
-    }
-    if (consistencyLevel.toString == source.consistencyLevel) {
-      log.info(
-        s"Using consistencyLevel [${consistencyLevel}] for SOURCE based on source config [${source.consistencyLevel}]"
-      )
-    } else {
-      log.info(
-        s"Using DEFAULT consistencyLevel [${consistencyLevel}] for SOURCE based on unrecognized source config [${source.consistencyLevel}]"
-      )
-    }
+    val consistencyLevel = ConsistencyLevelUtils.parseConsistencyLevel(source.consistencyLevel)
+    log.info(
+      s"Using consistencyLevel [${consistencyLevel}] for SOURCE based on source config [${source.consistencyLevel}]"
+    )
 
     val readConf = ReadConf
       .fromSparkConf(spark.sparkContext.getConf)

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala
@@ -13,7 +13,7 @@ import com.scylladb.migrator.config.{ MigratorConfig, SourceSettings, TargetSett
 import com.scylladb.migrator.validation.RowComparisonFailure
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.sql.SparkSession
-import com.datastax.oss.driver.api.core.ConsistencyLevel
+import com.scylladb.migrator.ConsistencyLevelUtils
 import com.datastax.spark.connector.rdd.ReadConf
 
 /** The C* to Scylla migration validator */
@@ -60,22 +60,11 @@ object ScyllaValidator {
         (sourceTableDef.partitionKey ++ sourceTableDef.clusteringColumns)
           .map(colDef => ColumnName(colDef.columnName, config.renamesMap.get(colDef.columnName)))
 
-      val consistencyLevel = sourceSettings.consistencyLevel match {
-        case "LOCAL_QUORUM" => ConsistencyLevel.LOCAL_QUORUM
-        case "QUORUM"       => ConsistencyLevel.QUORUM
-        case "LOCAL_ONE"    => ConsistencyLevel.LOCAL_ONE
-        case "ONE"          => ConsistencyLevel.ONE
-        case _              => ConsistencyLevel.LOCAL_QUORUM
-      }
-      if (consistencyLevel.toString == sourceSettings.consistencyLevel) {
-        log.info(
-          s"Using consistencyLevel [${consistencyLevel}] for VALIDATOR SOURCE based on validator source config [${sourceSettings.consistencyLevel}]"
-        )
-      } else {
-        log.info(
-          s"Using DEFAULT consistencyLevel [${consistencyLevel}] for VALIDATOR SOURCE based on unrecognized validator source config [${sourceSettings.consistencyLevel}]"
-        )
-      }
+      val consistencyLevel =
+        ConsistencyLevelUtils.parseConsistencyLevel(sourceSettings.consistencyLevel)
+      log.info(
+        s"Using consistencyLevel [${consistencyLevel}] for VALIDATOR SOURCE based on validator source config [${sourceSettings.consistencyLevel}]"
+      )
 
       spark.sparkContext
         .cassandraTable(sourceSettings.keyspace, sourceSettings.table)

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -11,7 +11,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{ DataFrame, Row, SparkSession }
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.LongAccumulator
-import com.datastax.oss.driver.api.core.ConsistencyLevel
+import com.scylladb.migrator.ConsistencyLevelUtils
 
 import scala.collection.immutable.ArraySeq
 import java.util.Locale
@@ -133,22 +133,10 @@ object Scylla {
 
     val connector = Connectors.targetConnector(spark.sparkContext.getConf, target)
 
-    val consistencyLevel = target.consistencyLevel match {
-      case "LOCAL_QUORUM" => ConsistencyLevel.LOCAL_QUORUM
-      case "QUORUM"       => ConsistencyLevel.QUORUM
-      case "LOCAL_ONE"    => ConsistencyLevel.LOCAL_ONE
-      case "ONE"          => ConsistencyLevel.ONE
-      case _              => ConsistencyLevel.LOCAL_QUORUM // Default for Target is LOCAL_QUORUM
-    }
-    if (consistencyLevel.toString == target.consistencyLevel) {
-      log.info(
-        s"Using consistencyLevel [${consistencyLevel}] for TARGET based on target config [${target.consistencyLevel}]"
-      )
-    } else {
-      log.info(
-        s"Using DEFAULT consistencyLevel [${consistencyLevel}] for TARGET based on unrecognized target config [${target.consistencyLevel}]"
-      )
-    }
+    val consistencyLevel = ConsistencyLevelUtils.parseConsistencyLevel(target.consistencyLevel)
+    log.info(
+      s"Using consistencyLevel [${consistencyLevel}] for TARGET based on target config [${target.consistencyLevel}]"
+    )
 
     val tempWriteConf = WriteConf
       .fromSparkConf(spark.sparkContext.getConf)


### PR DESCRIPTION
## Summary
- Extracts duplicated consistency level string-to-enum parsing from `Cassandra`, `Scylla`, and `ScyllaValidator` into a new `ConsistencyLevelUtils.parseConsistencyLevel` method
- Supports all valid `ConsistencyLevel` values instead of only 4 hardcoded ones
- Fails fast with a descriptive error on invalid input instead of silently defaulting to `LOCAL_QUORUM`

Closes: https://github.com/scylladb/scylla-migrator/issues/344
## Test plan
- [x] Verify existing integration tests pass with valid consistency levels
- [x] Verify an invalid consistency level in config now produces a clear `IllegalArgumentException` instead of silent fallback