### PR TITLE
feature: Add MySQL as migration and validation source for ScyllaDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ E2E_DDB_ROWS ?= 500000
 
 # ScyllaDB version and storage mode for DynamoDB/Alternator tests
 SCYLLA_VERSION ?= latest
+MYSQL_VERSION ?= 8.0.46
 TABLETS_MODE ?= vnodes
 
 ifeq ($(TABLETS_MODE),vnodes)
@@ -43,6 +44,7 @@ COMPOSE_SCYLLA_FILES := -f $(COMPOSE_SCYLLA)
 endif
 
 export SCYLLA_VERSION
+export MYSQL_VERSION
 
 ifeq ($(COVERAGE),true)
 SBT_COVERAGE_PREFIX := coverage
@@ -86,9 +88,22 @@ define wait-for-port
 	$(call attempt,curl -s "http://127.0.0.1:$(1)" > /dev/null)
 endef
 
+define wait-for-cql-compose
+	echo "Waiting for CQL to be ready in service $(2)"
+	$(call attempt,docker compose $(1) exec $(2) bash -c "cqlsh -e 'describe cluster'" > /dev/null)
+endef
+
 define wait-for-cql
-	echo "Waiting for CQL to be ready in service $(1)"
-	$(call attempt,docker compose -f $(COMPOSE_FILE) exec $(1) bash -c "cqlsh -e 'describe cluster'" > /dev/null)
+	$(call wait-for-cql-compose,-f $(COMPOSE_FILE),$(1))
+endef
+
+define wait-for-mysql-compose
+	echo "Waiting for MySQL to be ready in service $(2)"
+	$(call attempt,docker compose $(1) exec $(2) sh -lc "mysqladmin ping -h 127.0.0.1 -uroot -proot --silent" > /dev/null)
+endef
+
+define wait-for-mysql
+	$(call wait-for-mysql-compose,-f $(COMPOSE_FILE),$(1))
 endef
 
 lint: ## Check code formatting
@@ -134,12 +149,12 @@ spark-image: ## Pull or build the Spark Docker image
 start-services: ## Start all Docker Compose test services
 	$(Q)mkdir -p $(DOCKER_SPARK_BIND_DIRS) $(DOCKER_SCYLLA_BIND_DIRS)
 	$(Q)sudo chmod -R 777 $(DOCKER_SPARK_BIND_DIRS) $(DOCKER_SCYLLA_BIND_DIRS)
-	docker compose -f $(COMPOSE_FILE) up -d dynamodb cassandra cassandra2 cassandra3 cassandra5 scylla-source scylla s3
+	docker compose -f $(COMPOSE_FILE) up -d mysql dynamodb cassandra cassandra2 cassandra3 cassandra5 scylla-source scylla s3
 
 start-services-scylla: ## Start services needed for Scylla integration tests
 	$(Q)mkdir -p $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla ./tests/docker/scylla-source
 	$(Q)sudo chmod -R 777 $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla ./tests/docker/scylla-source
-	docker compose $(COMPOSE_SCYLLA_FILES) up -d cassandra scylla-source scylla
+	docker compose $(COMPOSE_SCYLLA_FILES) up -d mysql cassandra scylla-source scylla
 
 start-services-dynamodb: ## Start services for DynamoDB integration tests (SCYLLA_VERSION=..., TABLETS_MODE=...)
 	$(Q)mkdir -p $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla
@@ -160,26 +175,28 @@ wait-for-services: ## Wait for all test services to become ready
 	($(call wait-for-cql,scylla)) & p4=$$!
 	($(call wait-for-cql,cassandra)) & p5=$$!
 	($(call wait-for-cql,scylla-source)) & p6=$$!
-	wait $$p1; wait $$p2; wait $$p3; wait $$p4; wait $$p5; wait $$p6
+	($(call wait-for-mysql,mysql)) & p7=$$!
+	wait $$p1; wait $$p2; wait $$p3; wait $$p4; wait $$p5; wait $$p6; wait $$p7
 
 wait-for-services-scylla: ## Wait for Scylla test services to become ready
-	$(Q)($(call wait-for-cql,cassandra)) & p1=$$!
-	($(call wait-for-cql,scylla-source)) & p2=$$!
-	($(call wait-for-cql,scylla)) & p3=$$!
-	wait $$p1; wait $$p2; wait $$p3
+	$(Q)($(call wait-for-cql-compose,$(COMPOSE_SCYLLA_FILES),cassandra)) & p1=$$!
+	($(call wait-for-cql-compose,$(COMPOSE_SCYLLA_FILES),scylla-source)) & p2=$$!
+	($(call wait-for-cql-compose,$(COMPOSE_SCYLLA_FILES),scylla)) & p3=$$!
+	($(call wait-for-mysql-compose,$(COMPOSE_SCYLLA_FILES),mysql)) & p4=$$!
+	wait $$p1; wait $$p2; wait $$p3; wait $$p4
 
 wait-for-services-dynamodb: ## Wait for DynamoDB test services to become ready
 	$(Q)($(call wait-for-port,8000)) & p1=$$!
 	($(call wait-for-port,8001)) & p2=$$!
 	($(call wait-for-port,4566)) & p3=$$!
-	($(call wait-for-cql,scylla)) & p4=$$!
+	($(call wait-for-cql-compose,$(COMPOSE_DYNAMODB_FILES),scylla)) & p4=$$!
 	wait $$p1; wait $$p2; wait $$p3; wait $$p4
 
 wait-for-services-alternator: wait-for-services-dynamodb ## Alias for wait-for-services-dynamodb
 
 wait-for-services-aws: ## Wait for AWS test services to become ready
 	$(Q)($(call wait-for-port,8000)) & p1=$$!
-	($(call wait-for-cql,scylla)) & p2=$$!
+	($(call wait-for-cql-compose,$(COMPOSE_DYNAMODB_FILES),scylla)) & p2=$$!
 	wait $$p1; wait $$p2
 
 stop-services: ## Stop all Docker Compose test services
@@ -226,8 +243,8 @@ start-services-cassandra: ## Start services for a single Cassandra version (CASS
 	docker compose $(COMPOSE_SCYLLA_FILES) up -d $(_CASSANDRA_SERVICE) scylla
 
 wait-for-services-cassandra: ## Wait for a single Cassandra version to become ready (CASSANDRA_VERSION=...)
-	$(Q)($(call wait-for-cql,$(_CASSANDRA_SERVICE))) & p1=$$!
-	($(call wait-for-cql,scylla)) & p2=$$!
+	$(Q)($(call wait-for-cql-compose,$(COMPOSE_SCYLLA_FILES),$(_CASSANDRA_SERVICE))) & p1=$$!
+	($(call wait-for-cql-compose,$(COMPOSE_SCYLLA_FILES),scylla)) & p2=$$!
 	wait $$p1; wait $$p2
 
 test-integration-cassandra: ## Run integration tests for a single Cassandra version (CASSANDRA_VERSION=...)
@@ -239,8 +256,8 @@ test-unit: ## Run unit tests (no services required)
 test-integration: ## Run integration tests (requires services, excludes AWS, benchmarks, and E2E)
 	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.AWS,com.scylladb.migrator.E2E" $(SBT_COVERAGE_SUFFIX)
 
-test-integration-scylla: ## Run Scylla integration tests (Cassandra compat tests run in their own matrix job)
-	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.scylla.* -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.E2E,com.scylladb.migrator.CassandraCompat" $(SBT_COVERAGE_SUFFIX)
+test-integration-scylla: ## Run Scylla and reader integration tests (Cassandra compat tests run in their own matrix job)
+	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.scylla.* com.scylladb.migrator.readers.* -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.E2E,com.scylladb.migrator.CassandraCompat" $(SBT_COVERAGE_SUFFIX)
 
 test-integration-dynamodb: ## Run DynamoDB/Alternator integration tests (excludes AWS and E2E)
 	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.alternator.* com.scylladb.migrator.writers.* -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.AWS,com.scylladb.migrator.E2E" $(SBT_COVERAGE_SUFFIX)

--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,7 @@ lazy val migrator = (project in file("migrator"))
       "com.github.jnr" % "jnr-posix" % "3.1.19", // Needed by the Spark ScyllaDB connector
       "com.scylladb.alternator" % "emr-dynamodb-hadoop"  % "5.8.0",
       "com.scylladb.alternator" % "load-balancing"       % "2.0.3",
+      "com.mysql"              % "mysql-connector-j"     % "9.7.0",
       "io.circe"               %% "circe-generic"        % circeVersion,
       "io.circe"               %% "circe-parser"         % circeVersion,
       "io.circe"               %% "circe-yaml"           % "0.15.1",

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -44,6 +44,57 @@ source:
   # Optional condition to filter source table data that will be migrated
   # where: race_start_date = '2015-05-27' AND race_end_date = '2015-05-27'
 
+# Example for loading from MySQL:
+# source:
+#   type: mysql
+#   host: mysql-server
+#   port: 3306
+#   database: mydb
+#   table: mytable
+#   credentials:
+#     username: <user>
+#     password: <pass>
+#   # Number of rows to fetch per JDBC round-trip. Defaults to 1000 if omitted.
+#   # Use lower values (e.g. 100) for tables with large blobs, higher values
+#   # (e.g. 1000+) for small rows.
+#   fetchSize: 1000
+#   # Optional - columns forming the primary key, required for validation
+#   # primaryKey:
+#   #   - id
+#   # Optional - partition the read across multiple Spark tasks
+#   # partitionColumn: id
+#   # numPartitions: 8
+#   # lowerBound and upperBound must match the partition column's JDBC type.
+#   # For numeric columns use integer literals:
+#   # lowerBound: 0
+#   # upperBound: 1000000
+#   # For DATE columns use ISO date literals:
+#   # lowerBound: "2024-01-01"
+#   # upperBound: "2024-02-01"
+#   # For TIMESTAMP/DATETIME columns use timestamp literals:
+#   # lowerBound: "2024-01-01 00:00:00"
+#   # upperBound: "2024-01-02 00:00:00"
+#   # NOTE: Partitioned MySQL reads use multiple independent JDBC statements/connections.
+#   # They do not provide one global point-in-time snapshot across all Spark partitions.
+#   # If exact consistency matters, quiesce or otherwise freeze the source table first.
+#   # Optional - filter rows (treated as trusted SQL input, not sanitized)
+#   # where: "status = 'active'"
+#   # Optional - explicit zero-date handling. Defaults to EXCEPTION (fail fast).
+#   # Setting CONVERT_TO_NULL or ROUND changes source-data semantics and should only
+#   # be used when that behavior is intentional.
+#   # zeroDateTimeBehavior: CONVERT_TO_NULL
+#   # Optional - extra JDBC connection properties (e.g. SSL, timeouts)
+#   # connectionProperties:
+#   #   connectTimeout: "5000"
+#   #   socketTimeout: "30000"
+#   #
+#   # NOTE: Resume/savepoint support is not available for MySQL migrations.
+#   # Spark JDBC reads do not expose durable per-range progress for MySQL, and
+#   # partitioned reads use multiple independent JDBC statements instead of one
+#   # resumable snapshot. If a migration is interrupted, it must be restarted
+#   # from the beginning. For large tables, ensure your target schema uses upsert
+#   # semantics (e.g. ScyllaDB INSERT) so that re-running the migration is safe.
+
 # Example for loading from Parquet:
 # source:
 #   type: parquet
@@ -327,9 +378,15 @@ target:
 #   ## connectionTimeoutMs: 15000
 #   ## maxItemsPerBatch: 100
 
-# Savepoints are configuration files (like this one), saved by the migrator as it
-# runs. Their purpose is to skip token ranges that have already been copied. This
-# configuration only applies when copying from Cassandra/Scylla.
+# Optional savepoint configuration for resumable migrations. Savepoints are configuration
+# files (like this one), saved by the migrator as it runs. Their purpose is to skip data
+# that has already been copied on a restart. This configuration is used for
+# Cassandra/Scylla, DynamoDB, and Parquet sources.
+#
+# Omit this section for MySQL migrations. MySQL savepoints are not supported:
+# Spark JDBC reads do not expose durable per-range progress, and partitioned reads
+# use multiple independent JDBC statements instead of one resumable snapshot. If a
+# MySQL migration is interrupted, it must be restarted from the beginning.
 savepoints:
   # Where should savepoint configurations be stored? This is a path on the host running
   # the Spark driver - usually the Spark master.
@@ -371,3 +428,9 @@ savepoints:
 #   floatingPointTolerance: 0.001
 #   # What difference in ms should we allow between timestamps?
 #   timestampMsTolerance: 0
+#   # Optional - columns to hash for MySQL-to-ScyllaDB validation (use source-side names;
+#   # renames are applied automatically). This reduces Spark-side join/shuffle volume,
+#   # but the validator still reads the original payload columns before hashing.
+#   # hashColumns:
+#   #   - large_text_column
+#   #   - blob_column

--- a/docker-compose-scylla.yml
+++ b/docker-compose-scylla.yml
@@ -1,5 +1,18 @@
 services:
 
+  mysql:
+    image: mysql:${MYSQL_VERSION:-8.0.46}
+    command: --default-authentication-plugin=mysql_native_password --innodb-use-native-aio=0
+    environment:
+      MYSQL_DATABASE: testdb
+      MYSQL_USER: migrator
+      MYSQL_PASSWORD: migrator
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - "3308:3306"
+    expose:
+      - 3308
+
   cassandra:
     image: cassandra:4.1
     environment:
@@ -75,4 +88,3 @@ services:
       --memory 2048M
       --alternator-port 8000
       --alternator-write-isolation only_rmw_uses_lwt
-

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -1,5 +1,18 @@
 services:
 
+  mysql:
+    image: mysql:${MYSQL_VERSION:-8.0.46}
+    command: --default-authentication-plugin=mysql_native_password --innodb-use-native-aio=0
+    environment:
+      MYSQL_DATABASE: testdb
+      MYSQL_USER: migrator
+      MYSQL_PASSWORD: migrator
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - "3308:3306"
+    expose:
+      - 3308
+
   dynamodb:
     command: "-jar DynamoDBLocal.jar -sharedDb -inMemory"
     image: "amazon/dynamodb-local:2.5.3"

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -29,7 +29,8 @@ The configuration file requires the following top-level properties (ie, with no 
   # Optional - Columns to rename
   renames:
     # ...
-  # Savepoints configuration
+  # Savepoints configuration. Required for resumable migrations.
+  # Omit it for MySQL migrations; MySQL savepoints are not supported.
   savepoints:
     # ...
   # Validator configuration. Required only if the app is executed in validation mode.
@@ -418,7 +419,15 @@ The optional ``renames`` property lists the item columns to rename along the mig
 Savepoints
 ----------
 
-When migrating data from Apache Cassandra or DynamoDB, the migrator is able to :doc:`resume an interrupted migration </resume-interrupted-migration>`. To achieve this, it stores so-called “savepoints” along the process to remember which data items have already been migrated and should be skipped when the migration is restarted.
+For resumable sources, the migrator is able to :doc:`resume an interrupted migration </resume-interrupted-migration>`.
+To achieve this, it stores so-called “savepoints” along the process to remember which data items
+have already been migrated and should be skipped when the migration is restarted.
+
+This section must be omitted for MySQL migrations. MySQL savepoints are not supported: Spark JDBC
+reads do not expose durable per-range progress for MySQL, and partitioned reads use multiple
+independent JDBC statements instead of one resumable snapshot. If a MySQL migration is interrupted,
+it must be restarted from the beginning. For large tables, ensure the target schema uses idempotent
+writes so that re-running the migration is safe.
 
 .. code-block:: yaml
 
@@ -435,6 +444,11 @@ Validation
 
 The ``validation`` field and its properties are mandatory only when the application is executed in :doc:`validation mode </validate>`.
 
+When validating MySQL-to-ScyllaDB migrations, ensure that writes have stopped on both sides before
+starting the validator. The current implementation may issue multiple reads over time and therefore
+does not provide a single global point-in-time snapshot while the source or target table is still
+changing.
+
 .. code-block:: yaml
 
   validation:
@@ -450,6 +464,13 @@ The ``validation`` field and its properties are mandatory only when the applicat
     floatingPointTolerance: 0.001
     # What difference in ms should we allow between timestamps?
     timestampMsTolerance: 0
+    # Optional - columns to compare via a content hash for MySQL-to-ScyllaDB validation.
+    # Use source-side column names; renames are applied automatically.
+    # This reduces Spark-side join/shuffle volume, but the validator still reads the
+    # original payload columns from MySQL and ScyllaDB before hashing.
+    hashColumns:
+      - large_text_column
+      - blob_column
 
 .. _aws-authentication:
 

--- a/docs/source/validate.rst
+++ b/docs/source/validate.rst
@@ -6,6 +6,11 @@ In addition to the monitoring user interface provided by Spark, you can run anot
 
 Running this program consists of submitting the same Spark job as the migration, but with a different entry point.
 
+For MySQL-to-ScyllaDB validations, run the validator only after writes have stopped on both the
+MySQL source table and the ScyllaDB target table. The validator may scan both sides using multiple
+statements over time, so it does not provide a single global point-in-time snapshot while live
+writes are still happening.
+
 Before running the validator, adjust the corresponding configuration in the top-level ``validation`` property of the file ``config.yml``:
 
 .. code-block:: yaml

--- a/migrator/src/main/scala/com/scylladb/migrator/Connectors.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Connectors.scala
@@ -9,77 +9,154 @@ import com.datastax.spark.connector.cql.{
   NoAuthConf,
   PasswordAuthConf
 }
-import com.scylladb.migrator.config.{ Credentials, SourceSettings, TargetSettings }
+import com.scylladb.migrator.config.{ Credentials, SSLOptions, SourceSettings, TargetSettings }
 import org.apache.spark.SparkConf
 
 object Connectors {
-  def sourceConnector(sparkConf: SparkConf, sourceSettings: SourceSettings.Cassandra) =
+  private[migrator] case class SessionOptions(
+    host: String,
+    port: Int,
+    credentials: Option[Credentials],
+    sslOptions: Option[SSLOptions],
+    localDC: Option[String],
+    connections: Option[Int],
+    queryRetryCount: Int = -1
+  )
+
+  private val ConnectionHost = "spark.cassandra.connection.host"
+  private val ConnectionPort = "spark.cassandra.connection.port"
+  private val ConnectionLocalDC = "spark.cassandra.connection.localDC"
+  private val AuthUsername = "spark.cassandra.auth.username"
+  private val AuthPassword = "spark.cassandra.auth.password"
+  private val SslEnabled = "spark.cassandra.connection.ssl.enabled"
+  private val SslClientAuthEnabled = "spark.cassandra.connection.ssl.clientAuth.enabled"
+  private val SslTrustStorePath = "spark.cassandra.connection.ssl.trustStore.path"
+  private val SslTrustStorePassword = "spark.cassandra.connection.ssl.trustStore.password"
+  private val SslTrustStoreType = "spark.cassandra.connection.ssl.trustStore.type"
+  private val SslKeyStorePath = "spark.cassandra.connection.ssl.keyStore.path"
+  private val SslKeyStorePassword = "spark.cassandra.connection.ssl.keyStore.password"
+  private val SslKeyStoreType = "spark.cassandra.connection.ssl.keyStore.type"
+  private val SslProtocol = "spark.cassandra.connection.ssl.protocol"
+  private val SslEnabledAlgorithms = "spark.cassandra.connection.ssl.enabledAlgorithms"
+  private val LocalConnectionsPerExecutor = "spark.cassandra.connection.localConnectionsPerExecutor"
+  private val RemoteConnectionsPerExecutor =
+    "spark.cassandra.connection.remoteConnectionsPerExecutor"
+  private val QueryRetryCount = "spark.cassandra.query.retry.count"
+
+  private[migrator] def sourceSessionOptions(
+    sourceSettings: SourceSettings.Cassandra
+  ): SessionOptions =
+    SessionOptions(
+      host            = sourceSettings.host,
+      port            = sourceSettings.port,
+      credentials     = sourceSettings.credentials,
+      sslOptions      = sourceSettings.sslOptions,
+      localDC         = sourceSettings.localDC,
+      connections     = sourceSettings.connections,
+      queryRetryCount = -1
+    )
+
+  private[migrator] def targetSessionOptions(
+    targetSettings: TargetSettings.Scylla
+  ): SessionOptions =
+    SessionOptions(
+      host            = targetSettings.host,
+      port            = targetSettings.port,
+      credentials     = targetSettings.credentials,
+      sslOptions      = targetSettings.sslOptions,
+      localDC         = targetSettings.localDC,
+      connections     = targetSettings.connections,
+      queryRetryCount = -1
+    )
+
+  private[migrator] def sparkSessionOptions(options: SessionOptions): Map[String, String] = {
+    val base = Map(
+      ConnectionHost  -> options.host,
+      ConnectionPort  -> options.port.toString,
+      QueryRetryCount -> options.queryRetryCount.toString
+    )
+    val withCredentials = options.credentials.fold(base) { credentials =>
+      base ++ Map(
+        AuthUsername -> credentials.username,
+        AuthPassword -> credentials.password
+      )
+    }
+    val withLocalDc = options.localDC.fold(withCredentials) { dc =>
+      withCredentials + (ConnectionLocalDC -> dc)
+    }
+    val withSsl = options.sslOptions.fold(withLocalDc) { sslOptions =>
+      val requiredSslEntries = Map(
+        SslEnabled           -> sslOptions.enabled.toString,
+        SslClientAuthEnabled -> sslOptions.clientAuthEnabled.toString,
+        SslTrustStoreType ->
+          sslOptions.trustStoreType.getOrElse(SSLOptions.DefaultTrustStoreType),
+        SslKeyStoreType -> sslOptions.keyStoreType.getOrElse(SSLOptions.DefaultKeyStoreType),
+        SslProtocol     -> sslOptions.protocol.getOrElse(SSLOptions.DefaultProtocol),
+        SslEnabledAlgorithms ->
+          sslOptions.enabledAlgorithms.getOrElse(SSLOptions.DefaultEnabledAlgorithms).mkString(",")
+      )
+      val optionalSslEntries: Map[String, String] = List(
+        sslOptions.trustStorePath.map(SslTrustStorePath -> _),
+        sslOptions.trustStorePassword.map(SslTrustStorePassword -> _),
+        sslOptions.keyStorePath.map(SslKeyStorePath -> _),
+        sslOptions.keyStorePassword.map(SslKeyStorePassword -> _)
+      ).flatten.toMap
+      withLocalDc ++ requiredSslEntries ++ optionalSslEntries
+    }
+    options.connections.fold(withSsl) { connections =>
+      withSsl ++ Map(
+        LocalConnectionsPerExecutor  -> connections.toString,
+        RemoteConnectionsPerExecutor -> connections.toString
+      )
+    }
+  }
+
+  private def authConf(credentials: Option[Credentials]) =
+    credentials match {
+      case None                                  => NoAuthConf
+      case Some(Credentials(username, password)) => PasswordAuthConf(username, password)
+    }
+
+  private def cassandraSSLConf(sslOptions: Option[SSLOptions]) =
+    sslOptions match {
+      case None => CassandraConnectorConf.DefaultCassandraSSLConf
+      case Some(sslOptions) =>
+        CassandraConnectorConf.CassandraSSLConf(
+          enabled            = sslOptions.enabled,
+          clientAuthEnabled  = sslOptions.clientAuthEnabled,
+          trustStorePath     = sslOptions.trustStorePath,
+          trustStorePassword = sslOptions.trustStorePassword,
+          trustStoreType   = sslOptions.trustStoreType.getOrElse(SSLOptions.DefaultTrustStoreType),
+          protocol         = sslOptions.protocol.getOrElse(SSLOptions.DefaultProtocol),
+          keyStorePath     = sslOptions.keyStorePath,
+          keyStorePassword = sslOptions.keyStorePassword,
+          enabledAlgorithms =
+            sslOptions.enabledAlgorithms.getOrElse(SSLOptions.DefaultEnabledAlgorithms),
+          keyStoreType = sslOptions.keyStoreType.getOrElse(SSLOptions.DefaultKeyStoreType)
+        )
+    }
+
+  private def connector(
+    sparkConf: SparkConf,
+    options: SessionOptions
+  ) =
     new CassandraConnector(
       CassandraConnectorConf(sparkConf).copy(
         contactInfo = IpBasedContactInfo(
-          hosts = Set(new InetSocketAddress(sourceSettings.host, sourceSettings.port)),
-          authConf = sourceSettings.credentials match {
-            case None                                  => NoAuthConf
-            case Some(Credentials(username, password)) => PasswordAuthConf(username, password)
-          },
-          cassandraSSLConf = sourceSettings.sslOptions match {
-            case None => CassandraConnectorConf.DefaultCassandraSSLConf
-            case Some(sslOptions) =>
-              CassandraConnectorConf.CassandraSSLConf(
-                enabled            = sslOptions.enabled,
-                trustStorePath     = sslOptions.trustStorePath,
-                trustStorePassword = sslOptions.trustStorePassword,
-                trustStoreType     = sslOptions.trustStoreType.getOrElse("JKS"),
-                protocol           = sslOptions.protocol.getOrElse("TLS"),
-                enabledAlgorithms = sslOptions.enabledAlgorithms.getOrElse(
-                  Set("TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA")
-                ),
-                clientAuthEnabled = sslOptions.clientAuthEnabled,
-                keyStorePath      = sslOptions.keyStorePath,
-                keyStorePassword  = sslOptions.keyStorePassword,
-                keyStoreType      = sslOptions.keyStoreType.getOrElse("JKS")
-              )
-          }
+          hosts            = Set(new InetSocketAddress(options.host, options.port)),
+          authConf         = authConf(options.credentials),
+          cassandraSSLConf = cassandraSSLConf(options.sslOptions)
         ),
-        localDC                      = sourceSettings.localDC,
-        localConnectionsPerExecutor  = sourceSettings.connections,
-        remoteConnectionsPerExecutor = sourceSettings.connections,
-        queryRetryCount              = -1
+        localDC                      = options.localDC,
+        localConnectionsPerExecutor  = options.connections,
+        remoteConnectionsPerExecutor = options.connections,
+        queryRetryCount              = options.queryRetryCount
       )
     )
 
+  def sourceConnector(sparkConf: SparkConf, sourceSettings: SourceSettings.Cassandra) =
+    connector(sparkConf, sourceSessionOptions(sourceSettings))
+
   def targetConnector(sparkConf: SparkConf, targetSettings: TargetSettings.Scylla) =
-    new CassandraConnector(
-      CassandraConnectorConf(sparkConf).copy(
-        contactInfo = IpBasedContactInfo(
-          hosts = Set(new InetSocketAddress(targetSettings.host, targetSettings.port)),
-          authConf = targetSettings.credentials match {
-            case None                                  => NoAuthConf
-            case Some(Credentials(username, password)) => PasswordAuthConf(username, password)
-          },
-          cassandraSSLConf = targetSettings.sslOptions match {
-            case None => CassandraConnectorConf.DefaultCassandraSSLConf
-            case Some(sslOptions) =>
-              CassandraConnectorConf.CassandraSSLConf(
-                enabled            = sslOptions.enabled,
-                clientAuthEnabled  = sslOptions.clientAuthEnabled,
-                trustStorePath     = sslOptions.trustStorePath,
-                trustStorePassword = sslOptions.trustStorePassword,
-                trustStoreType     = sslOptions.trustStoreType.getOrElse("JKS"),
-                protocol           = sslOptions.protocol.getOrElse("TLS"),
-                keyStorePath       = sslOptions.keyStorePath,
-                keyStorePassword   = sslOptions.keyStorePassword,
-                enabledAlgorithms = sslOptions.enabledAlgorithms.getOrElse(
-                  Set("TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA")
-                ),
-                keyStoreType = sslOptions.keyStoreType.getOrElse("JKS")
-              )
-          }
-        ),
-        localDC                      = targetSettings.localDC,
-        localConnectionsPerExecutor  = targetSettings.connections,
-        remoteConnectionsPerExecutor = targetSettings.connections,
-        queryRetryCount              = -1
-      )
-    )
+    connector(sparkConf, targetSessionOptions(targetSettings))
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
@@ -29,7 +29,7 @@ object Migrator {
     val migratorConfig =
       MigratorConfig.loadFrom(spark.conf.get("spark.scylla.config"))
 
-    log.info(s"Loaded config: ${migratorConfig}")
+    log.info(s"Loaded config:\n${migratorConfig.renderRedacted}")
 
     try migrate(migratorConfig)
     finally spark.stop()
@@ -49,6 +49,17 @@ object Migrator {
           cqlSource.preserveTimestamps,
           config.getSkipTokenRangesOrEmptySet
         )
+        ScyllaMigrator.migrate(config, scyllaTarget, sourceDF)
+      case (mysqlSource: SourceSettings.MySQL, scyllaTarget: TargetSettings.Scylla) =>
+        log.info("Starting MySQL to ScyllaDB migration")
+        log.warn(
+          "MySQL source does not support savepoints; any configured savepoints settings are ignored. " +
+            "MySQL reads use Spark JDBC jobs that do not expose durable per-range progress, and " +
+            "partitioned reads use multiple independent JDBC statements instead of one resumable snapshot. " +
+            "If this migration is interrupted, it must be restarted from scratch. " +
+            "Ensure the target table supports idempotent writes."
+        )
+        val sourceDF = readers.MySQL.readDataframe(spark, mysqlSource)
         ScyllaMigrator.migrate(config, scyllaTarget, sourceDF)
       case (parquetSource: SourceSettings.Parquet, scyllaTarget: TargetSettings.Scylla) =>
         readers.Parquet.migrateToScylla(config, parquetSource, scyllaTarget)

--- a/migrator/src/main/scala/com/scylladb/migrator/Validator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Validator.scala
@@ -6,10 +6,13 @@ import com.scylladb.migrator.validation.RowComparisonFailure
 import org.apache.logging.log4j.{ Level, LogManager }
 import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.sql.SparkSession
-import com.scylladb.migrator.scylla.ScyllaValidator
+import com.scylladb.migrator.scylla.{ MySQLToScyllaValidator, ScyllaValidator }
 
 object Validator {
   val log = LogManager.getLogger("com.scylladb.migrator")
+
+  private[migrator] def loadedConfigLogMessage(config: MigratorConfig): String =
+    s"Loaded config:\n${config.renderRedacted}"
 
   def runValidation(
     config: MigratorConfig
@@ -19,6 +22,8 @@ object Validator {
         ScyllaValidator.runValidation(cassandraSource, scyllaTarget, config)
       case (dynamoSource: SourceSettings.DynamoDBLike, dynamoTarget: TargetSettings.DynamoDBLike) =>
         AlternatorValidator.runValidation(dynamoSource, dynamoTarget, config)
+      case (mysqlSource: SourceSettings.MySQL, scyllaTarget: TargetSettings.Scylla) =>
+        MySQLToScyllaValidator.runValidation(mysqlSource, scyllaTarget, config)
       case _ =>
         sys.error(
           "Unsupported combination of source and target " +
@@ -44,13 +49,37 @@ object Validator {
     val migratorConfig =
       MigratorConfig.loadFrom(spark.conf.get("spark.scylla.config"))
 
-    log.info(s"Loaded config: ${migratorConfig}")
+    log.info(loadedConfigLogMessage(migratorConfig))
 
     val failures = runValidation(migratorConfig)
 
     if (failures.isEmpty) log.info("No comparison failures found - enjoy your day!")
     else {
-      log.error("Found the following comparison failures:")
+      val missingCount =
+        failures.count(_.items.contains(RowComparisonFailure.Item.MissingTargetRow))
+      val extraCount =
+        failures.count(_.items.contains(RowComparisonFailure.Item.ExtraTargetRow))
+      val differingCount = failures.count(
+        _.items.exists(_.isInstanceOf[RowComparisonFailure.Item.DifferingFieldValues])
+      )
+      val mismatchedColumnCount =
+        failures.count(_.items.contains(RowComparisonFailure.Item.MismatchedColumnCount))
+      val mismatchedColumnNames =
+        failures.count(_.items.contains(RowComparisonFailure.Item.MismatchedColumnNames))
+
+      val breakdown = List(
+        if (missingCount > 0) Some(s"$missingCount missing target row(s)") else None,
+        if (extraCount > 0) Some(s"$extraCount extra target row(s)") else None,
+        if (differingCount > 0) Some(s"$differingCount differing field value(s)") else None,
+        if (mismatchedColumnCount > 0) Some(s"$mismatchedColumnCount mismatched column count(s)")
+        else None,
+        if (mismatchedColumnNames > 0) Some(s"$mismatchedColumnNames mismatched column name(s)")
+        else None
+      ).flatten.mkString(", ")
+
+      log.error(
+        s"Found ${failures.size} comparison failure(s) in sample: $breakdown"
+      )
       log.error(failures.mkString("\n"))
       System.exit(1)
     }

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
@@ -3,12 +3,15 @@ package com.scylladb.migrator.alternator
 import com.scylladb.migrator.config.{ MigratorConfig, SourceSettings, TargetSettings }
 import com.scylladb.migrator.validation.RowComparisonFailure
 import com.scylladb.migrator.readers
+import org.apache.logging.log4j.LogManager
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 
 import scala.jdk.CollectionConverters._
 
 object AlternatorValidator {
+
+  private val log = LogManager.getLogger("com.scylladb.migrator.alternator.AlternatorValidator")
 
   /** Checks that the target Alternator database contains the same data as the source DynamoDB
     * database.
@@ -55,6 +58,12 @@ object AlternatorValidator {
     val configValidation = config.validation.getOrElse(
       sys.error("Missing required property 'validation' in the configuration file.")
     )
+
+    configValidation.hashColumns.foreach { _ =>
+      log.warn(
+        "hashColumns is only supported for MySQL-to-ScyllaDB validation and will be ignored."
+      )
+    }
 
     val targetByKey: RDD[(List[DdbValue], collection.Map[String, DdbValue])] =
       target

--- a/migrator/src/main/scala/com/scylladb/migrator/config/HostValidation.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/HostValidation.scala
@@ -1,0 +1,50 @@
+package com.scylladb.migrator.config
+
+/** Shared validation utilities for validating hostnames and IP addresses. Extracted from
+  * [[com.scylladb.migrator.readers.MySQL]] and [[com.scylladb.migrator.config.SourceSettings]] to
+  * avoid duplication.
+  */
+object HostValidation {
+
+  /** Matches a hostname or IPv4 address: alphanumeric segments separated by dots or hyphens. Must
+    * start with an alphanumeric character to avoid matching dot-only or hyphen-only strings.
+    * Underscores are intentionally allowed for Docker/internal hostnames despite being technically
+    * invalid per RFC 952/1123.
+    *
+    * Note: this regex is deliberately permissive. Its primary purpose is to reject URL
+    * metacharacters (/, ?, #, &, @) that could break JDBC URL construction, not to enforce strict
+    * RFC 952/1123 hostname rules. Strings like "host..name" or "192.168.1." will pass but will be
+    * rejected by MySQL at connection time.
+    */
+  def isValidHostname(host: String): Boolean =
+    host.matches("""[a-zA-Z0-9][a-zA-Z0-9_.\-]*""")
+
+  /** Matches an IPv6 address, optionally wrapped in square brackets. Uses
+    * [[java.net.InetAddress.getByName]] for structural validation after a character-class
+    * pre-filter. The pre-filter ensures only hex digits, colons, and dots (for IPv4-mapped
+    * addresses) are present, which prevents `getByName` from performing DNS lookups.
+    */
+  def isValidIPv6Host(host: String): Boolean = {
+    val inner =
+      if (host.startsWith("[") && host.endsWith("]")) host.slice(1, host.length - 1)
+      else host
+    // Pre-filter: only allow characters that can appear in IPv6 addresses.
+    // This prevents InetAddress.getByName from triggering DNS lookups on hostnames.
+    if (
+      inner.isEmpty ||
+      !inner.matches("""[0-9a-fA-F:.]+""") ||
+      !inner.contains(':') ||
+      !inner.exists(c => c.isDigit || ('a' <= c.toLower && c.toLower <= 'f'))
+    )
+      return false
+    try {
+      val addr = java.net.InetAddress.getByName(inner)
+      // InetAddress.getByName parses IPv4-mapped IPv6 addresses (e.g., ::ffff:192.168.1.1) as
+      // Inet4Address. Since our pre-filter already confirmed the input contains a colon and
+      // only IPv6-legal characters, accept both Inet6Address and Inet4Address here.
+      addr.isInstanceOf[java.net.Inet6Address] || addr.isInstanceOf[java.net.Inet4Address]
+    } catch {
+      case _: Exception => false
+    }
+  }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
@@ -2,24 +2,26 @@ package com.scylladb.migrator.config
 
 import cats.implicits._
 import com.datastax.spark.connector.rdd.partitioner.dht.{ BigIntToken, LongToken, Token }
-import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 import io.circe.syntax._
 import io.circe.yaml.parser
 import io.circe.yaml.syntax._
-import io.circe.{ Decoder, DecodingFailure, Encoder, Error, Json }
+import io.circe.{ Decoder, DecodingFailure, Encoder, Error, Json, JsonObject }
 import scala.util.Using
 
 case class MigratorConfig(
   source: SourceSettings,
   target: TargetSettings,
   renames: Option[List[Rename]],
-  savepoints: Savepoints,
+  savepoints: Savepoints = Savepoints.Default,
   skipTokenRanges: Option[Set[(Token[_], Token[_])]],
   skipSegments: Option[Set[Int]],
   skipParquetFiles: Option[Set[String]],
   validation: Option[Validation]
 ) {
   def render: String = this.asJson.asYaml.spaces2
+  def renderRedacted: String = MigratorConfig.redactSecrets(this.asJson).asYaml.spaces2
 
   def getRenamesOrNil: List[Rename] = renames.getOrElse(Nil)
 
@@ -33,6 +35,9 @@ case class MigratorConfig(
 
 }
 object MigratorConfig {
+  private val RedactedValue = "<redacted>"
+  implicit val config: Configuration = Configuration.default.withDefaults
+
   implicit val tokenEncoder: Encoder[Token[_]] = Encoder.instance {
     case LongToken(value)   => Json.obj("type" := "long", "value" := value)
     case BigIntToken(value) => Json.obj("type" := "bigint", "value" := value)
@@ -50,27 +55,99 @@ object MigratorConfig {
   }
 
   implicit val migratorConfigDecoder: Decoder[MigratorConfig] =
-    deriveDecoder[MigratorConfig].emap { config =>
-      (config.source, config.target) match {
-        case (_: SourceSettings.Alternator, t: TargetSettings.DynamoDBLike) if t.streamChanges =>
+    Decoder.instance { cursor =>
+      deriveConfiguredDecoder[MigratorConfig].apply(cursor).flatMap { decoded =>
+        val savepointsProvided = cursor.downField("savepoints").success.isDefined
+        val savepointsRequired = decoded.source match {
+          case _: SourceSettings.MySQL => false
+          case _                       => true
+        }
+
+        if (!savepointsProvided && savepointsRequired)
           Left(
-            "'streamChanges: true' is not supported when the source is an Alternator table. " +
-              "Scylla Alternator does not support DynamoDB Streams."
+            DecodingFailure(
+              "Missing required field: savepoints. This field is optional only for MySQL migrations.",
+              cursor.history
+            )
           )
-        case (_: SourceSettings.Alternator, _: TargetSettings.DynamoDBS3Export) =>
-          Left(
-            "A source of type 'alternator' is not supported with target type 'dynamodb-s3-export'. " +
-              "DynamoDB S3 export output is only supported when the source is AWS DynamoDB."
-          )
-        case (_: SourceSettings.DynamoDBS3Export, t: TargetSettings.DynamoDBLike)
-            if t.streamChanges =>
-          Left(
-            "'streamChanges: true' is not supported when the source is a DynamoDB S3 export."
-          )
-        case _ => Right(config)
+        else {
+          (decoded.source, decoded.target) match {
+            case (_: SourceSettings.Alternator, t: TargetSettings.DynamoDBLike)
+                if t.streamChanges =>
+              Left(
+                DecodingFailure(
+                  "'streamChanges: true' is not supported when the source is an Alternator table. " +
+                    "Scylla Alternator does not support DynamoDB Streams.",
+                  cursor.history
+                )
+              )
+            case (_: SourceSettings.Alternator, _: TargetSettings.DynamoDBS3Export) =>
+              Left(
+                DecodingFailure(
+                  "A source of type 'alternator' is not supported with target type 'dynamodb-s3-export'. " +
+                    "DynamoDB S3 export output is only supported when the source is AWS DynamoDB.",
+                  cursor.history
+                )
+              )
+            case (_: SourceSettings.DynamoDBS3Export, t: TargetSettings.DynamoDBLike)
+                if t.streamChanges =>
+              Left(
+                DecodingFailure(
+                  "'streamChanges: true' is not supported when the source is a DynamoDB S3 export.",
+                  cursor.history
+                )
+              )
+            case _ => Right(decoded)
+          }
+        }
       }
     }
-  implicit val migratorConfigEncoder: Encoder[MigratorConfig] = deriveEncoder[MigratorConfig]
+  implicit val migratorConfigEncoder: Encoder[MigratorConfig] =
+    Encoder.instance { migratorConfig =>
+      val savepointsField = migratorConfig.source match {
+        case _: SourceSettings.MySQL => Nil
+        case _                       => List("savepoints" -> migratorConfig.savepoints.asJson)
+      }
+
+      Json.obj(
+        (
+          List(
+            "source"  -> migratorConfig.source.asJson,
+            "target"  -> migratorConfig.target.asJson,
+            "renames" -> migratorConfig.renames.asJson
+          ) ++ savepointsField ++ List(
+            "skipTokenRanges"  -> migratorConfig.skipTokenRanges.asJson,
+            "skipSegments"     -> migratorConfig.skipSegments.asJson,
+            "skipParquetFiles" -> migratorConfig.skipParquetFiles.asJson,
+            "validation"       -> migratorConfig.validation.asJson
+          )
+        ): _*
+      )
+    }
+
+  private def isMySQLSourceObject(obj: JsonObject): Boolean =
+    obj("type").flatMap(_.asString).contains("mysql")
+
+  private def shouldRedactValue(key: String, value: Json, obj: JsonObject): Boolean =
+    value.isString && (SensitiveKeys
+      .isSensitiveKey(key) || (key == "where" && isMySQLSourceObject(obj)))
+
+  private[config] def redactSecrets(json: Json): Json =
+    json.arrayOrObject(
+      json,
+      arr => Json.fromValues(arr.map(redactSecrets)),
+      obj =>
+        Json.fromJsonObject(
+          obj.toIterable.foldLeft(JsonObject.empty) { case (acc, (key, value)) =>
+            val updatedValue =
+              if (shouldRedactValue(key, value, obj))
+                Json.fromString(RedactedValue)
+              else
+                redactSecrets(value)
+            acc.add(key, updatedValue)
+          }
+        )
+    )
 
   def loadFrom(path: String): MigratorConfig = {
     val configData = Using.resource(scala.io.Source.fromFile(path))(_.mkString)

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SSLOptions.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SSLOptions.scala
@@ -19,4 +19,18 @@ case class SSLOptions(
 object SSLOptions {
   implicit val encoder: Encoder[SSLOptions] = deriveEncoder[SSLOptions]
   implicit val decoder: Decoder[SSLOptions] = deriveDecoder[SSLOptions]
+
+  /** Shared default values used by [[com.scylladb.migrator.Connectors]] and
+    * [[com.scylladb.migrator.scylla.ScyllaSparkConnectionOptions]].
+    */
+  val DefaultTrustStoreType: String = "JKS"
+  val DefaultKeyStoreType: String = "JKS"
+  val DefaultProtocol: String = "TLS"
+  // These two CBC cipher suites are intentionally narrower than the Spark Cassandra Connector
+  // defaults (which also include TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 and
+  // TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384). The narrower set maximises compatibility with older
+  // ScyllaDB/Cassandra deployments. Users whose clusters require GCM suites can override via the
+  // `enabledAlgorithms` config property.
+  val DefaultEnabledAlgorithms: Set[String] =
+    Set("TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA")
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/Savepoints.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/Savepoints.scala
@@ -23,6 +23,7 @@ import io.circe.generic.extras.semiauto._
 case class Savepoints(intervalSeconds: Int, path: String, enableParquetFileTracking: Boolean = true)
 
 object Savepoints {
+  val Default: Savepoints = Savepoints(intervalSeconds = 300, path = "/app/savepoints")
   implicit val config: Configuration = Configuration.default.withDefaults
   implicit val codec: Codec[Savepoints] = deriveConfiguredCodec[Savepoints]
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SensitiveKeys.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SensitiveKeys.scala
@@ -1,0 +1,23 @@
+package com.scylladb.migrator.config
+
+import java.util.Locale
+
+object SensitiveKeys {
+  val DefaultRedactionRegex: String =
+    "(?i)password|secret|token|credential|access[._-]?key|api[._-]?key|private[._-]?key"
+
+  private val SensitiveKeyMarkers =
+    Seq("password", "secret", "token", "credential", "accesskey", "apikey", "privatekey")
+
+  private def normalize(key: String): String =
+    key
+      .toLowerCase(Locale.ROOT)
+      .replace(".", "")
+      .replace("_", "")
+      .replace("-", "")
+
+  def isSensitiveKey(key: String): Boolean = {
+    val normalized = normalize(key)
+    SensitiveKeyMarkers.exists(normalized.contains)
+  }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
@@ -5,7 +5,18 @@ import com.scylladb.migrator.AwsUtils
 import io.circe.syntax._
 import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.{ deriveConfiguredDecoder => deriveExtrasDecoder }
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{
+  getZoneId,
+  stringToDate,
+  stringToTimestamp
+}
+import org.apache.spark.unsafe.types.UTF8String
 import software.amazon.awssdk.services.dynamodb.model.BillingMode
+
+import java.util.Locale
+import scala.util.Try
 
 /** Endpoint for DynamoDB-protocol connections.
   *
@@ -115,6 +126,213 @@ object SourceSettings {
   ) extends SourceSettings {
     lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
       AwsUtils.computeFinalCredentials(credentials, endpoint, region)
+  }
+
+  case class MySQL(
+    host: String,
+    port: Int,
+    database: String,
+    table: String,
+    credentials: Credentials,
+    primaryKey: Option[List[String]],
+    partitionColumn: Option[String],
+    numPartitions: Option[Int],
+    lowerBound: Option[MySQL.PartitionBound],
+    upperBound: Option[MySQL.PartitionBound],
+    zeroDateTimeBehavior: MySQL.ZeroDateTimeBehavior = MySQL.ZeroDateTimeBehavior.Exception,
+    fetchSize: Int = MySQL.DefaultFetchSize,
+    where: Option[String],
+    connectionProperties: Option[Map[String, String]]
+  ) extends SourceSettings
+
+  object MySQL {
+    val DefaultFetchSize: Int = 1000
+    private val UnquotedPartitionColumnPattern = "[a-zA-Z_][a-zA-Z0-9_]*".r
+    private val QuotedPartitionColumnPattern = "`(([^`\\n\\r]|``)+)`".r
+    private val NumericPartitionBoundPattern = "[-+]?\\d+".r
+    private val ConfigTemporalValidationZoneId = getZoneId("UTC")
+    private implicit val circeConfig: Configuration = Configuration.default.withDefaults
+    implicit val mysqlDecoder: Decoder[MySQL] = deriveExtrasDecoder[MySQL]
+
+    case class PartitionBound(value: String) extends AnyVal {
+      def isBlank: Boolean = value.trim.isEmpty
+      def isNumericLiteral: Boolean = NumericPartitionBoundPattern.matches(value)
+    }
+
+    object PartitionBound {
+      implicit val decoder: Decoder[PartitionBound] =
+        Decoder.decodeString
+          .map(PartitionBound(_))
+          .or(Decoder.decodeLong.map(value => PartitionBound(value.toString)))
+
+      implicit val encoder: Encoder[PartitionBound] = Encoder.instance { bound =>
+        if (bound.isNumericLiteral)
+          Try(bound.value.toLong).toOption
+            .map(Json.fromLong)
+            .getOrElse(Json.fromString(bound.value))
+        else
+          Json.fromString(bound.value)
+      }
+    }
+
+    sealed abstract class ZeroDateTimeBehavior(val jdbcValue: String)
+
+    object ZeroDateTimeBehavior {
+      case object Exception extends ZeroDateTimeBehavior("EXCEPTION")
+      case object ConvertToNull extends ZeroDateTimeBehavior("CONVERT_TO_NULL")
+      case object Round extends ZeroDateTimeBehavior("ROUND")
+
+      val values: List[ZeroDateTimeBehavior] = List(Exception, ConvertToNull, Round)
+      private val byJdbcValue: Map[String, ZeroDateTimeBehavior] =
+        values.map(value => value.jdbcValue -> value).toMap
+
+      implicit val decoder: Decoder[ZeroDateTimeBehavior] = Decoder.decodeString.emap { raw =>
+        byJdbcValue
+          .get(raw.trim.toUpperCase(Locale.ROOT))
+          .toRight(
+            s"zeroDateTimeBehavior must be one of ${values.map(_.jdbcValue).mkString(", ")}, got: '$raw'"
+          )
+      }
+
+      implicit val encoder: Encoder[ZeroDateTimeBehavior] =
+        Encoder.encodeString.contramap(_.jdbcValue)
+    }
+
+    private def parseNumericPartitionBound(
+      boundName: String,
+      bound: PartitionBound
+    ): Either[String, Long] =
+      if (!bound.isNumericLiteral)
+        Left(s"$boundName ('${bound.value}') must be a valid integer literal")
+      else
+        Try(bound.value.toLong).toEither.leftMap(_ =>
+          s"$boundName ('${bound.value}') must fit in a signed 64-bit integer"
+        )
+
+    private def parseDatePartitionBound(bound: PartitionBound): Option[Long] =
+      stringToDate(UTF8String.fromString(bound.value)).map(_.toLong)
+
+    private def parseTimestampPartitionBound(bound: PartitionBound): Option[Long] =
+      stringToTimestamp(UTF8String.fromString(bound.value), ConfigTemporalValidationZoneId)
+
+    private def validateBoundOrdering(
+      lowerBound: PartitionBound,
+      upperBound: PartitionBound
+    ): Option[String] =
+      if (lowerBound.isNumericLiteral && upperBound.isNumericLiteral)
+        (
+          parseNumericPartitionBound("lowerBound", lowerBound),
+          parseNumericPartitionBound("upperBound", upperBound)
+        ) match {
+          case (Right(parsedLower), Right(parsedUpper)) if parsedLower >= parsedUpper =>
+            Some(
+              s"lowerBound (${lowerBound.value}) must be less than upperBound (${upperBound.value})"
+            )
+          case (Left(error), _) =>
+            Some(error)
+          case (_, Left(error)) =>
+            Some(error)
+          case _ =>
+            None
+        }
+      else
+        (
+          parseTimestampPartitionBound(lowerBound),
+          parseTimestampPartitionBound(upperBound)
+        ) match {
+          case (Some(parsedLower), Some(parsedUpper)) if parsedLower >= parsedUpper =>
+            Some(
+              s"lowerBound (${lowerBound.value}) must be less than upperBound (${upperBound.value})"
+            )
+          case (Some(_), Some(_)) =>
+            None
+          case _ =>
+            (parseDatePartitionBound(lowerBound), parseDatePartitionBound(upperBound)) match {
+              case (Some(parsedLower), Some(parsedUpper)) if parsedLower >= parsedUpper =>
+                Some(
+                  s"lowerBound (${lowerBound.value}) must be less than upperBound (${upperBound.value})"
+                )
+              case _ =>
+                None
+            }
+        }
+
+    private def isValidPartitionColumn(column: String): Boolean =
+      UnquotedPartitionColumnPattern.matches(column) || QuotedPartitionColumnPattern.matches(column)
+
+    /** Shared validation logic used by both the config decoder and the reader. Returns a list of
+      * validation error messages (empty if valid).
+      */
+    def validate(mysql: MySQL): List[String] = {
+      val errors = List.newBuilder[String]
+      if (mysql.port < 1 || mysql.port > 65535)
+        errors += s"port must be between 1 and 65535, got: ${mysql.port}"
+      if (mysql.fetchSize <= 0)
+        errors += s"fetchSize must be > 0, got: ${mysql.fetchSize}"
+      if (mysql.fetchSize > com.scylladb.migrator.readers.MySQL.MaxFetchSize)
+        errors += s"fetchSize must be <= ${com.scylladb.migrator.readers.MySQL.MaxFetchSize}, got: ${mysql.fetchSize}"
+      mysql.numPartitions.foreach { n =>
+        if (n <= 0) errors += s"numPartitions must be > 0, got: $n"
+      }
+      mysql.primaryKey.foreach { pk =>
+        if (pk.isEmpty)
+          errors += "primaryKey must contain at least one column name when specified"
+        if (pk.exists(_.trim.isEmpty))
+          errors += "primaryKey must not contain empty or blank column names"
+        val duplicatePK = pk
+          .groupBy(_.toLowerCase(Locale.ROOT))
+          .values
+          .filter(_.size > 1)
+          .map(_.mkString("/"))
+          .toList
+        if (duplicatePK.nonEmpty)
+          errors += s"primaryKey contains duplicate column names: ${duplicatePK.mkString(", ")}"
+      }
+      mysql.lowerBound.foreach { bound =>
+        if (bound.isBlank) errors += "lowerBound must not be empty or blank when specified"
+      }
+      mysql.upperBound.foreach { bound =>
+        if (bound.isBlank) errors += "upperBound must not be empty or blank when specified"
+      }
+      (mysql.lowerBound, mysql.upperBound) match {
+        case (Some(lb), Some(ub)) =>
+          validateBoundOrdering(lb, ub).foreach(errors += _)
+        case _ => // ok
+      }
+      mysql.partitionColumn.foreach { column =>
+        if (!isValidPartitionColumn(column))
+          errors +=
+            s"partitionColumn '$column' contains invalid characters. " +
+              "Must be a valid SQL identifier matching [a-zA-Z_][a-zA-Z0-9_]* or a " +
+              "backtick-quoted identifier like `my column` (doubled backticks `` are allowed for escaping). " +
+              "This restriction exists as a defense against SQL injection in the JDBC partition column path."
+      }
+      (mysql.partitionColumn, mysql.numPartitions) match {
+        case (Some(_), None) =>
+          errors += "partitionColumn is set but numPartitions is missing. Both must be set together."
+        case (None, Some(_)) =>
+          errors += "numPartitions is set but partitionColumn is missing. Both must be set together."
+        case _ => // ok
+      }
+      (mysql.lowerBound, mysql.upperBound) match {
+        case (Some(_), _) | (_, Some(_))
+            if mysql.partitionColumn.isEmpty || mysql.numPartitions.isEmpty =>
+          errors += "lowerBound and upperBound can only be set when partitionColumn and numPartitions are both set."
+        case _ => // ok
+      }
+      (mysql.partitionColumn, mysql.numPartitions) match {
+        case (Some(_), Some(_)) =>
+          (mysql.lowerBound, mysql.upperBound) match {
+            case (Some(_), Some(_)) => // ok
+            case _ =>
+              errors += "Both lowerBound and upperBound must be set when using partitioned reads."
+          }
+        case _ => // ok
+      }
+      errors ++= com.scylladb.migrator.readers.MySQL
+        .validateConnectionPropertyValues(mysql.connectionProperties)
+      errors.result()
+    }
   }
 
   case class DynamoDBS3Export(
@@ -328,6 +546,148 @@ object SourceSettings {
         } yield result
       case "dynamodb-s3-export" =>
         deriveDecoder[DynamoDBS3Export].apply(cursor)
+      case "mysql" =>
+        MySQL.mysqlDecoder.apply(cursor).flatMap { mysql =>
+          def checkRemainingValidations(): Either[DecodingFailure, MySQL] =
+            if (mysql.database.trim.isEmpty)
+              Left(
+                DecodingFailure(
+                  "database must not be empty",
+                  cursor.history
+                )
+              )
+            else if (!mysql.database.matches("[a-zA-Z0-9_$\\-]+"))
+              Left(
+                DecodingFailure(
+                  s"Invalid database name '${mysql.database}'. " +
+                    "Must contain only alphanumeric characters, underscores, dollar signs, or hyphens. " +
+                    "URL-significant characters (/, ?, #, &) are not allowed.",
+                  cursor.history
+                )
+              )
+            else if (mysql.table.trim.isEmpty)
+              Left(
+                DecodingFailure(
+                  "table must not be empty",
+                  cursor.history
+                )
+              )
+            else if (!mysql.table.matches("[a-zA-Z0-9_$\\-]+"))
+              Left(
+                DecodingFailure(
+                  s"table '${mysql.table}' contains invalid characters. " +
+                    "Must match [a-zA-Z0-9_$$\\-]+ (alphanumeric, underscore, dollar sign, or hyphen).",
+                  cursor.history
+                )
+              )
+            else if (mysql.credentials.username.trim.isEmpty)
+              Left(
+                DecodingFailure(
+                  "username must not be empty",
+                  cursor.history
+                )
+              )
+            else if (mysql.credentials.password.isEmpty)
+              Left(
+                DecodingFailure(
+                  "password must not be empty",
+                  cursor.history
+                )
+              )
+            else if (mysql.credentials.password == "<redacted>")
+              Left(
+                DecodingFailure(
+                  "password is '<redacted>'. This appears to be a savepoint file with redacted credentials. " +
+                    "Use the original configuration file instead.",
+                  cursor.history
+                )
+              )
+            else if (mysql.where.exists(w => w.trim.isEmpty))
+              Left(
+                DecodingFailure(
+                  "WHERE clause must not be empty or blank when specified",
+                  cursor.history
+                )
+              )
+            else if (mysql.where.exists(_.exists(c => c.isControl)))
+              Left(
+                DecodingFailure(
+                  "WHERE clause contains control characters (newlines, null bytes, etc.) which are not allowed",
+                  cursor.history
+                )
+              )
+            else {
+              val dangerousKeys = mysql.connectionProperties
+                .getOrElse(Map.empty)
+                .keys
+                .filter(k =>
+                  com.scylladb.migrator.readers.MySQL.DangerousJdbcKeys
+                    .contains(k.toLowerCase(Locale.ROOT))
+                )
+                .toList
+              if (dangerousKeys.nonEmpty)
+                Left(
+                  DecodingFailure(
+                    s"connectionProperties contains blocked security-sensitive keys: ${dangerousKeys.mkString(", ")}. " +
+                      "These properties are blocked for security reasons.",
+                    cursor.history
+                  )
+                )
+              else {
+                val validationErrors = MySQL.validate(mysql)
+                if (validationErrors.nonEmpty)
+                  Left(
+                    DecodingFailure(
+                      validationErrors.mkString("; "),
+                      cursor.history
+                    )
+                  )
+                else
+                  Right(mysql)
+              }
+            }
+
+          if (mysql.host.trim.isEmpty)
+            Left(
+              DecodingFailure(
+                "host must not be empty",
+                cursor.history
+              )
+            )
+          else if (mysql.host.startsWith("[") && mysql.host.endsWith("]")) {
+            val inner = mysql.host.slice(1, mysql.host.length - 1)
+            // If it's wrapped in brackets but doesn't contain a colon, it's an IPv4 in brackets
+            if (!inner.contains(':'))
+              Left(
+                DecodingFailure(
+                  s"IPv4 addresses must not be wrapped in brackets. Use '$inner' instead of '${mysql.host}'",
+                  cursor.history
+                )
+              )
+            else if (!HostValidation.isValidIPv6Host(mysql.host))
+              Left(
+                DecodingFailure(
+                  s"Invalid host '${mysql.host}': must be a hostname, IPv4, or IPv6 address. " +
+                    "URL metacharacters (/, ?, #, &, @) are not allowed.",
+                  cursor.history
+                )
+              )
+            else
+              checkRemainingValidations()
+          } else if (
+            !HostValidation
+              .isValidHostname(mysql.host) && !HostValidation.isValidIPv6Host(mysql.host)
+          )
+            Left(
+              DecodingFailure(
+                s"Invalid host '${mysql.host}': must be a hostname, IPv4, or IPv6 address. " +
+                  "URL metacharacters (/, ?, #, &, @) are not allowed.",
+                cursor.history
+              )
+            )
+          else
+            checkRemainingValidations()
+        }
       case otherwise =>
         Left(DecodingFailure(s"Unknown source type: ${otherwise}", cursor.history))
     }
@@ -369,6 +729,11 @@ object SourceSettings {
         .encodeObject(s)
         .filter { case (_, v) => !v.isNull }
         .add("type", Json.fromString("dynamodb-s3-export"))
+        .asJson
+    case s: MySQL =>
+      deriveEncoder[MySQL]
+        .encodeObject(s)
+        .add("type", Json.fromString("mysql"))
         .asJson
   }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/Validation.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/Validation.scala
@@ -1,17 +1,87 @@
 package com.scylladb.migrator.config
 
-import io.circe.{ Decoder, Encoder }
-import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
+import io.circe.{ Decoder, DecodingFailure, Encoder }
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto._
 
+import java.util.Locale
+
+/** @param compareTimestamps
+  *   Whether to compare TTL and WRITETIME metadata (Cassandra only).
+  * @param ttlToleranceMillis
+  *   Tolerance for TTL comparisons.
+  * @param writetimeToleranceMillis
+  *   Tolerance for WRITETIME comparisons.
+  * @param failuresToFetch
+  *   Maximum number of row failures to collect before stopping.
+  * @param floatingPointTolerance
+  *   Tolerance for floating-point value comparisons.
+  * @param timestampMsTolerance
+  *   Tolerance in milliseconds for timestamp comparisons.
+  * @param hashColumns
+  *   When set, validation compares these columns via a single content-hash column instead of
+  *   joining their raw values. This reduces Spark-side join/shuffle volume, but the current
+  *   validator still reads the original payload columns from MySQL and ScyllaDB before hashing.
+  *   Only applies to MySQL-to-ScyllaDB validation. Use source-side column names here; renames are
+  *   applied automatically.
+  */
 case class Validation(
   compareTimestamps: Boolean,
   ttlToleranceMillis: Long,
   writetimeToleranceMillis: Long,
   failuresToFetch: Int,
   floatingPointTolerance: Double,
-  timestampMsTolerance: Long
+  timestampMsTolerance: Long,
+  hashColumns: Option[List[String]] = None
 )
 object Validation {
-  implicit val encoder: Encoder[Validation] = deriveEncoder[Validation]
-  implicit val decoder: Decoder[Validation] = deriveDecoder[Validation]
+  private implicit val circeConfig: Configuration = Configuration.default.withDefaults
+  implicit val encoder: Encoder[Validation] = deriveConfiguredEncoder[Validation]
+  implicit val decoder: Decoder[Validation] = Decoder.instance { cursor =>
+    deriveConfiguredDecoder[Validation].apply(cursor).flatMap { v =>
+      val hashColumns = v.hashColumns.getOrElse(Nil)
+      val duplicateHashColumns = hashColumns
+        .groupBy(_.toLowerCase(Locale.ROOT))
+        .values
+        .filter(_.size > 1)
+        .map(_.mkString("/"))
+        .toList
+      val validationErrors = List(
+        Option.when(v.failuresToFetch <= 0)(
+          s"failuresToFetch must be > 0, got: ${v.failuresToFetch}"
+        ),
+        Option.when(v.ttlToleranceMillis < 0)(
+          s"ttlToleranceMillis must be >= 0, got: ${v.ttlToleranceMillis}"
+        ),
+        Option.when(v.writetimeToleranceMillis < 0)(
+          s"writetimeToleranceMillis must be >= 0, got: ${v.writetimeToleranceMillis}"
+        ),
+        Option.when(v.timestampMsTolerance < 0)(
+          s"timestampMsTolerance must be >= 0, got: ${v.timestampMsTolerance}"
+        ),
+        Option.when(
+          v.floatingPointTolerance < 0 ||
+            v.floatingPointTolerance.isNaN ||
+            v.floatingPointTolerance.isInfinity
+        )(
+          s"floatingPointTolerance must be a finite value >= 0, got: ${v.floatingPointTolerance}"
+        ),
+        Option.when(hashColumns.exists(_.trim.isEmpty))(
+          "hashColumns must not contain empty or blank column names"
+        ),
+        Option.when(duplicateHashColumns.nonEmpty)(
+          s"hashColumns contains duplicate column names: ${duplicateHashColumns.mkString(", ")}"
+        )
+      ).flatten
+
+      if (validationErrors.isEmpty) Right(v)
+      else
+        Left(
+          DecodingFailure(
+            validationErrors.mkString("; "),
+            cursor.history
+          )
+        )
+    }
+  }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/MySQL.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/MySQL.scala
@@ -1,0 +1,928 @@
+package com.scylladb.migrator.readers
+
+import com.scylladb.migrator.config.{ HostValidation, SensitiveKeys, SourceSettings }
+import com.scylladb.migrator.scylla.SourceDataFrame
+import org.apache.logging.log4j.LogManager
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{
+  getZoneId,
+  stringToDate,
+  stringToTimestamp
+}
+import org.apache.spark.sql.{ DataFrame, DataFrameReader, SparkSession }
+import org.apache.spark.unsafe.types.UTF8String
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.sql.{ Connection, DriverManager, Types }
+import java.util.Locale
+import java.util.Properties
+
+import scala.util.{ Try, Using }
+
+object MySQL {
+  private val log = LogManager.getLogger("com.scylladb.migrator.readers.MySQL")
+
+  val DefaultMaxAllowedPacketBytes: Long = 256 * 1024 * 1024 // 256MB
+  val DefaultConnectTimeoutMs: Int = 30000 // 30 seconds
+  val DefaultSocketTimeoutMs: Int = 600000 // 10 minutes
+  val ContentHashColumn: String = "_content_hash"
+  val DefaultConnectionTimeZoneId: String = "UTC"
+
+  /** Maximum allowed fetchSize. Values above this risk OOM errors in the JDBC driver or Spark
+    * executors. The recommended range is 1000-10000 for most workloads.
+    */
+  val MaxFetchSize: Int = 100000
+
+  /** Threshold above which a warning is emitted about potential memory issues with large fetchSize
+    * values. This is the top of the recommended range.
+    */
+  val RecommendedMaxFetchSize: Int = 10000
+  private[readers] val DefaultSensitiveRedactionRegex = SensitiveKeys.DefaultRedactionRegex
+  private val DigitsOnly = """\d+""".r
+
+  private[readers] sealed trait PartitionColumnType {
+    def description: String
+  }
+
+  private[readers] object PartitionColumnType {
+    case object Numeric extends PartitionColumnType {
+      override val description: String = "numeric"
+    }
+    case object Date extends PartitionColumnType {
+      override val description: String = "DATE"
+    }
+    case object Timestamp extends PartitionColumnType {
+      override val description: String = "TIMESTAMP"
+    }
+  }
+
+  private[readers] case class PartitionColumnMetadata(
+    columnName: String,
+    jdbcTypeName: String,
+    columnType: PartitionColumnType
+  )
+
+  private[readers] def isSensitiveOptionKey(key: String): Boolean =
+    SensitiveKeys.isSensitiveKey(key)
+
+  private[readers] def redactionRegexCoversKeys(
+    regex: String,
+    keys: Seq[String]
+  ): Boolean = {
+    val pattern = regex.r.pattern
+    keys.forall(key => pattern.matcher(key).find())
+  }
+
+  private[readers] def ensureSensitiveReaderOptionsAreRedacted(
+    spark: SparkSession,
+    optionKeys: Seq[String],
+    context: String
+  ): Unit = {
+    val sensitiveKeys = optionKeys.distinct.filter(isSensitiveOptionKey)
+    if (sensitiveKeys.nonEmpty) {
+      val redactionRegex = spark.conf
+        .getOption("spark.redaction.regex")
+        .filter(_.trim.nonEmpty)
+        .getOrElse(DefaultSensitiveRedactionRegex)
+
+      require(
+        redactionRegexCoversKeys(redactionRegex, sensitiveKeys),
+        s"Refusing to create $context because spark.redaction.regex does not redact all sensitive option keys: ${sensitiveKeys.mkString(", ")}"
+      )
+    }
+  }
+
+  private def normalizedPartitionColumnName(column: String): String =
+    if (column.startsWith("`") && column.endsWith("`"))
+      column.substring(1, column.length - 1).replace("``", "`")
+    else
+      column
+
+  /** Escape metadata-pattern wildcard characters before calling `getColumns`. MySQL's metadata
+    * pattern matching treats `%` and `_` as wildcards, so literal table names containing those
+    * characters must be escaped or resolved metadata lookup may unexpectedly match sibling tables.
+    */
+  private[migrator] def escapeMetadataPattern(
+    pattern: String,
+    escape: String
+  ): String = {
+    val searchEscape = Option(escape).filter(_.nonEmpty).getOrElse("\\")
+    pattern
+      .replace(searchEscape, s"${searchEscape}${searchEscape}")
+      .replace("%", s"$searchEscape%")
+      .replace("_", s"${searchEscape}_")
+  }
+
+  private def classifyPartitionColumnType(
+    jdbcType: Int,
+    jdbcTypeName: String,
+    configuredColumn: String
+  ): PartitionColumnType =
+    jdbcType match {
+      case Types.TINYINT | Types.SMALLINT | Types.INTEGER | Types.BIGINT | Types.FLOAT |
+          Types.REAL | Types.DOUBLE | Types.NUMERIC | Types.DECIMAL =>
+        PartitionColumnType.Numeric
+      case Types.DATE =>
+        PartitionColumnType.Date
+      case Types.TIMESTAMP | Types.TIMESTAMP_WITH_TIMEZONE =>
+        PartitionColumnType.Timestamp
+      case _ =>
+        sys.error(
+          s"Partition column '$configuredColumn' has JDBC type '$jdbcTypeName', which Spark JDBC " +
+            "does not support for partitioned reads. Use a numeric, DATE, or TIMESTAMP column."
+        )
+    }
+
+  private def partitionColumnMetadata(
+    source: SourceSettings.MySQL,
+    configuredColumn: String
+  ): PartitionColumnMetadata = {
+    val requestedColumn = normalizedPartitionColumnName(configuredColumn)
+    withJdbcConnection(source) { connection =>
+      val catalog = Option(connection.getCatalog).getOrElse(source.database)
+      val tablePattern =
+        escapeMetadataPattern(
+          source.table,
+          Option(connection.getMetaData.getSearchStringEscape).getOrElse("\\")
+        )
+      Using.resource(connection.getMetaData.getColumns(catalog, null, tablePattern, "%")) {
+        resultSet =>
+          val columns = Iterator
+            .continually(resultSet.next())
+            .takeWhile(identity)
+            .map { _ =>
+              (
+                resultSet.getString("COLUMN_NAME"),
+                resultSet.getInt("DATA_TYPE"),
+                resultSet.getString("TYPE_NAME")
+              )
+            }
+            .toList
+
+          columns
+            .find(_._1.equalsIgnoreCase(requestedColumn))
+            .map { case (columnName, jdbcType, jdbcTypeName) =>
+              PartitionColumnMetadata(
+                columnName   = columnName,
+                jdbcTypeName = jdbcTypeName,
+                columnType   = classifyPartitionColumnType(jdbcType, jdbcTypeName, configuredColumn)
+              )
+            }
+            .getOrElse(
+              sys.error(
+                s"Partition column '$configuredColumn' was not found in MySQL table " +
+                  s"${source.database}.${source.table}. Available columns: " +
+                  s"${columns.map(_._1).mkString(", ")}. " +
+                  "Check the configured column name and quoting."
+              )
+            )
+      }
+    }
+  }
+
+  private[readers] def partitionedReadOptions(
+    configuredPartitionColumn: String,
+    partitionColumnInfo: PartitionColumnMetadata,
+    numPartitions: Int,
+    lowerBound: SourceSettings.MySQL.PartitionBound,
+    upperBound: SourceSettings.MySQL.PartitionBound
+  ): Seq[(String, String)] =
+    Seq(
+      "partitionColumn" -> partitionColumnInfo.columnName,
+      "numPartitions"   -> numPartitions.toString,
+      "lowerBound"      -> lowerBound.value,
+      "upperBound"      -> upperBound.value
+    )
+
+  private def parseNumericPartitionBound(
+    partitionColumn: String,
+    jdbcTypeName: String,
+    boundName: String,
+    bound: SourceSettings.MySQL.PartitionBound
+  ): Long =
+    Try(bound.value.toLong).getOrElse(
+      sys.error(
+        s"Partition column '$partitionColumn' has JDBC type '$jdbcTypeName', so $boundName " +
+          s"must be an integer literal. Got '${bound.value}'."
+      )
+    )
+
+  private def parseTemporalPartitionBound(
+    partitionColumn: String,
+    jdbcTypeName: String,
+    expectedLiteral: String,
+    boundName: String,
+    bound: SourceSettings.MySQL.PartitionBound,
+    parser: String => Option[Long]
+  ): Long =
+    parser(bound.value).getOrElse(
+      sys.error(
+        s"Partition column '$partitionColumn' has JDBC type '$jdbcTypeName', so $boundName " +
+          s"must be a $expectedLiteral literal. Got '${bound.value}'. " +
+          "Epoch-millisecond bounds are not supported for temporal JDBC partition columns."
+      )
+    )
+
+  private[readers] def validatePartitionBoundsForColumnType(
+    partitionColumn: String,
+    jdbcTypeName: String,
+    columnType: PartitionColumnType,
+    lowerBound: SourceSettings.MySQL.PartitionBound,
+    upperBound: SourceSettings.MySQL.PartitionBound,
+    timeZoneId: String
+  ): Unit = {
+    val lowerValue = columnType match {
+      case PartitionColumnType.Numeric =>
+        parseNumericPartitionBound(partitionColumn, jdbcTypeName, "lowerBound", lowerBound)
+      case PartitionColumnType.Date =>
+        parseTemporalPartitionBound(
+          partitionColumn = partitionColumn,
+          jdbcTypeName    = jdbcTypeName,
+          expectedLiteral = "DATE",
+          boundName       = "lowerBound",
+          bound           = lowerBound,
+          parser          = value => stringToDate(UTF8String.fromString(value)).map(_.toLong)
+        )
+      case PartitionColumnType.Timestamp =>
+        parseTemporalPartitionBound(
+          partitionColumn = partitionColumn,
+          jdbcTypeName    = jdbcTypeName,
+          expectedLiteral = "TIMESTAMP",
+          boundName       = "lowerBound",
+          bound           = lowerBound,
+          parser = value => stringToTimestamp(UTF8String.fromString(value), getZoneId(timeZoneId))
+        )
+    }
+
+    val upperValue = columnType match {
+      case PartitionColumnType.Numeric =>
+        parseNumericPartitionBound(partitionColumn, jdbcTypeName, "upperBound", upperBound)
+      case PartitionColumnType.Date =>
+        parseTemporalPartitionBound(
+          partitionColumn = partitionColumn,
+          jdbcTypeName    = jdbcTypeName,
+          expectedLiteral = "DATE",
+          boundName       = "upperBound",
+          bound           = upperBound,
+          parser          = value => stringToDate(UTF8String.fromString(value)).map(_.toLong)
+        )
+      case PartitionColumnType.Timestamp =>
+        parseTemporalPartitionBound(
+          partitionColumn = partitionColumn,
+          jdbcTypeName    = jdbcTypeName,
+          expectedLiteral = "TIMESTAMP",
+          boundName       = "upperBound",
+          bound           = upperBound,
+          parser = value => stringToTimestamp(UTF8String.fromString(value), getZoneId(timeZoneId))
+        )
+    }
+
+    if (lowerValue >= upperValue)
+      sys.error(
+        s"lowerBound ('${lowerBound.value}') must be less than upperBound ('${upperBound.value}') " +
+          s"for partition column '$partitionColumn' ($jdbcTypeName)."
+      )
+  }
+
+  /** Escape a SQL identifier for use in backtick-quoted MySQL syntax. Doubles any embedded backtick
+    * characters so that e.g. a table named `foo`` ` becomes `` `foo``` `` `.
+    */
+  private[readers] def escapeIdentifier(name: String): String = {
+    require(name.nonEmpty, "Identifier must not be empty")
+    s"`${name.replace("`", "``")}`"
+  }
+
+  /** Strip SQL block comments and single-line comments from a string. This prevents keyword
+    * obfuscation like `UNI&#47;**&#47;ON` (which MySQL treats as `UNION`) from bypassing the
+    * dangerous keyword regex.
+    */
+  private[readers] def stripSqlComments(sql: String): String =
+    sql
+      .replaceAll("""/\*.*?\*/""", "") // block comments /* ... */
+      .replaceAll("""--(?=[\s\p{Cntrl}])[^\r\n]*""", " ") // MySQL single-line comments -- ...
+
+  private def isMySqlLineCommentStart(sql: String, dashIndex: Int): Boolean =
+    dashIndex + 2 < sql.length &&
+      sql.charAt(dashIndex) == '-' &&
+      sql.charAt(dashIndex + 1) == '-' && {
+        val next = sql.charAt(dashIndex + 2)
+        next.isWhitespace || next.isControl
+      }
+
+  /** Replace the contents of quoted SQL strings and quoted identifiers with spaces so that
+    * subsequent keyword checks only inspect SQL structure and not literal data.
+    */
+  private[readers] def stripQuotedSqlText(sql: String): String = {
+    val out = new StringBuilder(sql.length)
+    var i = 0
+    var quoteChar: Option[Char] = None
+
+    while (i < sql.length) {
+      val c = sql.charAt(i)
+      quoteChar match {
+        case None =>
+          if (c == '\'' || c == '"' || c == '`') {
+            quoteChar = Some(c)
+            out.append(' ')
+            i += 1
+          } else {
+            out.append(c)
+            i += 1
+          }
+
+        case Some('\'') | Some('"') =>
+          val activeQuote = quoteChar.get
+          if (c == '\\' && i + 1 < sql.length) {
+            out.append("  ")
+            i += 2
+          } else if (c == activeQuote && i + 1 < sql.length && sql.charAt(i + 1) == activeQuote) {
+            out.append("  ")
+            i += 2
+          } else if (c == activeQuote) {
+            quoteChar = None
+            out.append(' ')
+            i += 1
+          } else {
+            out.append(' ')
+            i += 1
+          }
+
+        case Some('`') =>
+          if (c == '`' && i + 1 < sql.length && sql.charAt(i + 1) == '`') {
+            out.append("  ")
+            i += 2
+          } else if (c == '`') {
+            quoteChar = None
+            out.append(' ')
+            i += 1
+          } else {
+            out.append(' ')
+            i += 1
+          }
+
+        case Some(other) =>
+          throw new IllegalStateException(s"Unexpected quote character '$other'")
+      }
+    }
+
+    out.toString
+  }
+
+  /** Strip comments and quoted SQL text in one pass. Keeping comment and quote state together
+    * prevents quotes inside comments from hiding later executable comments or dangerous keywords.
+    * Backslash escapes are rejected because their behavior depends on MySQL sql_mode.
+    */
+  private[readers] def stripSqlCommentsAndQuotedText(sql: String): String = {
+    val out = new StringBuilder(sql.length)
+    var i = 0
+
+    def rejectExecutableComment(): Nothing =
+      sys.error(
+        "WHERE clause contains MySQL executable comments (`/*!...*/`), which are not allowed " +
+          "in WHERE filters."
+      )
+
+    def rejectUnterminated(kind: String): Nothing =
+      sys.error(s"WHERE clause contains unterminated $kind, which is not allowed in WHERE filters.")
+
+    def rejectBackslashEscape(): Nothing =
+      sys.error(
+        "WHERE clause contains backslash escapes, which are not allowed because MySQL " +
+          "NO_BACKSLASH_ESCAPES mode changes how quoted strings are parsed."
+      )
+
+    while (i < sql.length) {
+      val c = sql.charAt(i)
+      if (c == '\'' || c == '"' || c == '`') {
+        val quoteChar = c
+        out.append(' ')
+        i += 1
+
+        var closed = false
+        while (i < sql.length && !closed) {
+          val quoted = sql.charAt(i)
+          if (quoteChar != '`' && quoted == '\\') {
+            rejectBackslashEscape()
+          } else if (quoted == quoteChar && i + 1 < sql.length && sql.charAt(i + 1) == quoteChar) {
+            out.append("  ")
+            i += 2
+          } else if (quoted == quoteChar) {
+            out.append(' ')
+            i += 1
+            closed = true
+          } else {
+            out.append(' ')
+            i += 1
+          }
+        }
+
+        if (!closed)
+          rejectUnterminated("quoted SQL text")
+      } else if (c == '/' && i + 1 < sql.length && sql.charAt(i + 1) == '*') {
+        if (i + 2 < sql.length && sql.charAt(i + 2) == '!')
+          rejectExecutableComment()
+
+        i += 2
+        var closed = false
+        while (i + 1 < sql.length && !closed)
+          if (sql.charAt(i) == '*' && sql.charAt(i + 1) == '/') {
+            i += 2
+            closed = true
+          } else {
+            i += 1
+          }
+
+        if (!closed)
+          rejectUnterminated("SQL block comment")
+      } else if (isMySqlLineCommentStart(sql, i)) {
+        i += 2
+        while (i < sql.length && sql.charAt(i) != '\r' && sql.charAt(i) != '\n')
+          i += 1
+      } else {
+        out.append(c)
+        i += 1
+      }
+    }
+
+    out.toString
+  }
+
+  private def urlEncode(value: String): String =
+    URLEncoder.encode(value, StandardCharsets.UTF_8)
+
+  private def insecureUrlScheme(value: String): Option[String] = {
+    val normalized = value.trim.toLowerCase(Locale.ROOT)
+    if (normalized.startsWith("file://")) Some("file")
+    else if (normalized.startsWith("http://")) Some("http")
+    else None
+  }
+
+  private def caseInsensitivePropertyMatches(
+    props: Map[String, String],
+    propertyName: String
+  ): List[(String, String)] =
+    props.toList.filter { case (k, _) => k.equalsIgnoreCase(propertyName) }
+
+  private def parseJdbcNumericProperty(
+    props: Map[String, String],
+    propertyName: String,
+    minimum: Long,
+    maximum: Long,
+    defaultValue: Long,
+    expectation: String
+  ): Either[String, Long] =
+    caseInsensitivePropertyMatches(props, propertyName) match {
+      case Nil => Right(defaultValue)
+      case List((_, rawValue)) =>
+        rawValue match {
+          case DigitsOnly() =>
+            val parsed = scala.util.Try(rawValue.toLong).getOrElse(Long.MinValue)
+            if (parsed < minimum || parsed > maximum)
+              Left(
+                s"$propertyName must be $expectation, got: '$rawValue'"
+              )
+            else
+              Right(parsed)
+          case _ =>
+            Left(
+              s"$propertyName must be $expectation, got: '$rawValue'"
+            )
+        }
+      case matches =>
+        Left(
+          s"connectionProperties contains duplicate entries for '$propertyName' with different casing: " +
+            matches.map(_._1).mkString(", ")
+        )
+    }
+
+  private[migrator] def validateConnectionPropertyValues(
+    connectionProperties: Option[Map[String, String]]
+  ): List[String] = {
+    val userProps = connectionProperties.getOrElse(Map.empty)
+    List(
+      parseJdbcNumericProperty(
+        userProps,
+        propertyName = "maxAllowedPacket",
+        minimum      = 1L,
+        maximum      = Long.MaxValue,
+        defaultValue = DefaultMaxAllowedPacketBytes,
+        expectation  = "a positive integer number of bytes"
+      ),
+      parseJdbcNumericProperty(
+        userProps,
+        propertyName = "connectTimeout",
+        minimum      = 0L,
+        maximum      = Int.MaxValue.toLong,
+        defaultValue = DefaultConnectTimeoutMs.toLong,
+        expectation = s"a non-negative integer number of milliseconds between 0 and ${Int.MaxValue}"
+      ),
+      parseJdbcNumericProperty(
+        userProps,
+        propertyName = "socketTimeout",
+        minimum      = 0L,
+        maximum      = Int.MaxValue.toLong,
+        defaultValue = DefaultSocketTimeoutMs.toLong,
+        expectation = s"a non-negative integer number of milliseconds between 0 and ${Int.MaxValue}"
+      )
+    ).collect { case Left(error) => error }
+  }
+
+  private[migrator] def validateWhereClause(filter: String): Unit = {
+    if (filter.trim.isEmpty)
+      sys.error(
+        "WHERE clause is empty or blank. Remove the 'where' key or provide a valid filter."
+      )
+    if (filter.exists(c => c.isControl))
+      sys.error(
+        s"WHERE clause contains control characters (newlines, null bytes, etc.) which are not allowed. " +
+          s"Filter length: ${filter.length} characters"
+      )
+
+    val dangerousPattern =
+      """\b(drop|delete|truncate|alter|create|exec|execute|union|into|outfile|dumpfile|load_file|benchmark|sleep|grant|revoke)\b""".r
+    val filterForScan = stripSqlCommentsAndQuotedText(filter).toLowerCase(Locale.ROOT)
+    dangerousPattern.findFirstIn(filterForScan).foreach { keyword =>
+      sys.error(
+        "WHERE clause contains potentially dangerous SQL keyword(s): " +
+          s"matched '$keyword'. " +
+          "DDL/DML keywords (DROP, DELETE, TRUNCATE, ALTER, CREATE, EXEC, EXECUTE, UNION, " +
+          "INTO, OUTFILE, DUMPFILE, LOAD_FILE, BENCHMARK, SLEEP, GRANT, REVOKE) " +
+          "are not allowed in WHERE filters."
+      )
+    }
+  }
+
+  private[readers] def redactedWhereFilterLogMessage(filter: String): String =
+    s"Applying configured WHERE filter to MySQL read (content redacted, ${filter.length} characters)"
+
+  private[readers] def partitionedReadConsistencyWarning(
+    source: SourceSettings.MySQL
+  ): String =
+    s"Partitioned MySQL reads for ${source.database}.${source.table} use multiple independent " +
+      "JDBC statements/connections and do not provide a single global snapshot across partitions. " +
+      "Concurrent source writes can yield mixed-time results. For correctness-sensitive runs, " +
+      "quiesce or otherwise freeze the source table before starting the migration or validation."
+
+  def readDataframe(spark: SparkSession, source: SourceSettings.MySQL): SourceDataFrame = {
+    val df = readDataframeRaw(spark, source)
+    MySQLSchemaLogger.logSchemaInfo(df)
+    log.info(
+      s"Number of partitions: ${df.queryExecution.executedPlan.execute().getNumPartitions}"
+    )
+    sourceDataFrame(df)
+  }
+
+  private[readers] def sourceDataFrame(df: DataFrame): SourceDataFrame =
+    SourceDataFrame(df, timestampColumns = None, savepointsSupported = false)
+
+  private[readers] def buildJdbcUrl(
+    source: SourceSettings.MySQL,
+    connectionTimeZoneId: String = DefaultConnectionTimeZoneId
+  ): String = {
+    require(
+      source.database.matches("[a-zA-Z0-9_$\\-]+"),
+      s"Invalid database name '${source.database}'. " +
+        "Must contain only alphanumeric characters, underscores, dollar signs, or hyphens. " +
+        "URL-significant characters (/, ?, #, &) are not allowed."
+    )
+    require(
+      source.host.nonEmpty,
+      "host must not be empty"
+    )
+    require(
+      HostValidation.isValidHostname(source.host) || HostValidation.isValidIPv6Host(source.host),
+      s"Invalid host '${source.host}': must be a hostname, IPv4, or IPv6 address. " +
+        "URL metacharacters (/, ?, #, &, @) are not allowed."
+    )
+    val userProps = source.connectionProperties.getOrElse(Map.empty)
+    val maxPacket = parseJdbcNumericProperty(
+      userProps,
+      propertyName = "maxAllowedPacket",
+      minimum      = 1L,
+      maximum      = Long.MaxValue,
+      defaultValue = DefaultMaxAllowedPacketBytes,
+      expectation  = "a positive integer number of bytes"
+    ).fold(error => throw new IllegalArgumentException(error), _.toString)
+    val connectTimeout = parseJdbcNumericProperty(
+      userProps,
+      propertyName = "connectTimeout",
+      minimum      = 0L,
+      maximum      = Int.MaxValue.toLong,
+      defaultValue = DefaultConnectTimeoutMs.toLong,
+      expectation  = s"a non-negative integer number of milliseconds between 0 and ${Int.MaxValue}"
+    ).fold(error => throw new IllegalArgumentException(error), _.toString)
+    val socketTimeout = parseJdbcNumericProperty(
+      userProps,
+      propertyName = "socketTimeout",
+      minimum      = 0L,
+      maximum      = Int.MaxValue.toLong,
+      defaultValue = DefaultSocketTimeoutMs.toLong,
+      expectation  = s"a non-negative integer number of milliseconds between 0 and ${Int.MaxValue}"
+    ).fold(error => throw new IllegalArgumentException(error), _.toString)
+    val hostPart =
+      // Config validation already ensures IPv4 is not wrapped in brackets.
+      // Wrap IPv6 addresses (containing colons) in brackets if not already wrapped.
+      if (source.host.contains(':') && !source.host.startsWith("["))
+        s"[${source.host}]"
+      else
+        source.host
+    val queryParams = List(
+      "zeroDateTimeBehavior"             -> source.zeroDateTimeBehavior.jdbcValue,
+      "tinyInt1IsBit"                    -> "false",
+      "maxAllowedPacket"                 -> maxPacket,
+      "useCursorFetch"                   -> "true",
+      "connectTimeout"                   -> connectTimeout,
+      "socketTimeout"                    -> socketTimeout,
+      "connectionTimeZone"               -> connectionTimeZoneId,
+      "forceConnectionTimeZoneToSession" -> "true"
+    )
+    val query = queryParams
+      .map { case (key, value) => s"${urlEncode(key)}=${urlEncode(value)}" }
+      .mkString("&")
+
+    s"jdbc:mysql://$hostPart:${source.port}/${source.database}?$query"
+  }
+
+  /** Spark treats JDBC property map entries as data-source options before creating driver
+    * connection properties. Keep this denylist aligned with Spark JDBCOptions so user-supplied
+    * connectionProperties cannot override the validated read path or execute session SQL.
+    */
+  private val ReservedJdbcKeys =
+    Set(
+      "url",
+      "dbtable",
+      "query",
+      "driver",
+      "partitioncolumn",
+      "lowerbound",
+      "upperbound",
+      "numpartitions",
+      "querytimeout",
+      "fetchsize",
+      "truncate",
+      "cascadetruncate",
+      "createtableoptions",
+      "createtablecolumntypes",
+      "customschema",
+      "batchsize",
+      "isolationlevel",
+      "sessioninitstatement",
+      "pushdownpredicate",
+      "pushdownaggregate",
+      "pushdownlimit",
+      "pushdownoffset",
+      "pushdowntablesample",
+      "keytab",
+      "principal",
+      "tablecomment",
+      "refreshkrb5config",
+      "connectionprovider",
+      "preparequery",
+      "prefertimestampntz",
+      "hint",
+      "user",
+      "password"
+    )
+
+  /** JDBC properties that could be exploited to read local files, enable deserialization attacks,
+    * or otherwise compromise security. These are blocked even when supplied via
+    * connectionProperties.
+    *
+    * Note: TLS key-store properties (`trustcertificatekeystoreurl`, `clientcertificatekeystoreurl`,
+    * etc.) are intentionally NOT blocked here. They are standard MySQL Connector/J 9.x TLS
+    * configuration knobs required for verified TLS connections and do not introduce the
+    * local-file-read or deserialization attack vectors present in the properties listed below.
+    *
+    * This list was validated against MySQL Connector/J 8.x and 9.x documentation. It should be
+    * reviewed when upgrading to new major versions of the MySQL JDBC driver.
+    */
+  private[migrator] val DangerousJdbcKeys = Set(
+    "allowloadlocalinfile",
+    "allowurlinlocalinfile",
+    "allowloadlocalinfileinpath",
+    "autodeserialize",
+    "allowpublickeyretrieval",
+    "serverrsapublickeyfile",
+    "queryinterceptors",
+    "exceptioninterceptors",
+    "connectionlifecycleinterceptors",
+    "authenticationplugins",
+    "propertiestransform",
+    "socketfactory",
+    "autogeneratetestcasescript",
+    "statementinterceptors",
+    "connectionpropertiesloadbalancer",
+    "allowmultiqueries",
+    "profilereventhandler",
+    "clientinfoprovider",
+    "logger",
+    "sessionvariables"
+  )
+
+  /** JDBC properties that are already embedded in the JDBC URL by [[buildJdbcUrl]]. If specified
+    * via connectionProperties they would be silently ignored because MySQL Connector/J gives URL
+    * parameters precedence over Properties. Filter them with a warning.
+    */
+  private val UrlEmbeddedJdbcKeys =
+    Set(
+      "maxallowedpacket",
+      "usecursorfetch",
+      "zerodatetimebehavior",
+      "tinyint1isbit",
+      "connecttimeout",
+      "sockettimeout",
+      "connectiontimezone",
+      "forceconnectiontimezonetosession"
+    )
+
+  private[migrator] def safeConnectionProperties(
+    source: SourceSettings.MySQL
+  ): Map[String, String] =
+    source.connectionProperties.getOrElse(Map.empty).flatMap { case (k, v) =>
+      val lower = k.toLowerCase(Locale.ROOT)
+      if (ReservedJdbcKeys.contains(lower)) {
+        log.warn(
+          s"Ignoring reserved connectionProperty '$k' – this key is managed by the migrator"
+        )
+        None
+      } else if (DangerousJdbcKeys.contains(lower)) {
+        log.warn(
+          s"Ignoring dangerous connectionProperty '$k' – this property is blocked for security"
+        )
+        None
+      } else if (lower == "zerodatetimebehavior") {
+        log.warn(
+          s"Ignoring connectionProperty '$k' – use source.zeroDateTimeBehavior instead of connectionProperties"
+        )
+        None
+      } else if (UrlEmbeddedJdbcKeys.contains(lower)) {
+        log.warn(
+          s"Ignoring connectionProperty '$k' – this property is already set in the JDBC URL"
+        )
+        None
+      } else {
+        // Warn about potentially insecure TLS keystore URLs
+        if ((lower.contains("keystore") || lower.contains("cert")) && lower.contains("url")) {
+          insecureUrlScheme(v).foreach { scheme =>
+            log.warn(
+              s"SECURITY: connectionProperty '$k' uses a potentially insecure URL scheme '$scheme'. " +
+                "Verify this is from a trusted source."
+            )
+          }
+        }
+        Some(k -> v)
+      }
+    }
+
+  private[migrator] def jdbcConnectionProperties(source: SourceSettings.MySQL): Properties = {
+    val props = new Properties()
+    props.setProperty("user", source.credentials.username)
+    props.setProperty("password", source.credentials.password)
+    props.setProperty("driver", "com.mysql.cj.jdbc.Driver")
+    safeConnectionProperties(source).foreach { case (k, v) =>
+      props.setProperty(k, v)
+    }
+    props
+  }
+
+  private[migrator] def withJdbcConnection[A](source: SourceSettings.MySQL)(
+    f: Connection => A
+  ): A = {
+    Class.forName("com.mysql.cj.jdbc.Driver")
+    Using.resource(
+      DriverManager.getConnection(buildJdbcUrl(source), jdbcConnectionProperties(source))
+    )(
+      f
+    )
+  }
+
+  private[migrator] def jdbcReadProperties(source: SourceSettings.MySQL): Properties = {
+    val props = jdbcConnectionProperties(source)
+    props.setProperty("fetchsize", source.fetchSize.toString)
+    props
+  }
+
+  private def partitionedJdbcReader(
+    spark: SparkSession,
+    source: SourceSettings.MySQL,
+    jdbcUrl: String,
+    tableExpression: String
+  ): DataFrameReader = {
+    ensureSensitiveReaderOptionsAreRedacted(
+      spark,
+      Seq("user", "password", "driver") ++ safeConnectionProperties(source).keys.toSeq,
+      "partitioned MySQL JDBC reader"
+    )
+    val base = spark.read
+      .format("jdbc")
+      .option("url", jdbcUrl)
+      .option("dbtable", tableExpression)
+      .option("user", source.credentials.username)
+      .option("password", source.credentials.password)
+      .option("driver", "com.mysql.cj.jdbc.Driver")
+      .option("fetchsize", source.fetchSize)
+
+    safeConnectionProperties(source).foldLeft(base) { case (reader, (k, v)) =>
+      reader.option(k, v)
+    }
+  }
+
+  private def readDataframeRaw(
+    spark: SparkSession,
+    source: SourceSettings.MySQL
+  ): DataFrame = {
+    // Guard against programmatic misuse where the config decoder is bypassed.
+    val errors = SourceSettings.MySQL.validate(source)
+    require(errors.isEmpty, errors.mkString("; "))
+
+    log.info(s"Connecting to MySQL at ${source.host}:${source.port}/${source.database}")
+    log.info(s"Reading table: ${source.table}")
+    log.info(s"JDBC useCursorFetch=true, fetchSize=${source.fetchSize}")
+    if (source.zeroDateTimeBehavior != SourceSettings.MySQL.ZeroDateTimeBehavior.Exception)
+      log.warn(
+        s"MySQL zeroDateTimeBehavior=${source.zeroDateTimeBehavior.jdbcValue} is an explicit opt-in " +
+          "that changes how invalid zero dates are read. Continue only if that behavior is intentional."
+      )
+    if (source.fetchSize > RecommendedMaxFetchSize)
+      log.warn(
+        s"fetchSize (${source.fetchSize}) exceeds the recommended maximum of $RecommendedMaxFetchSize. " +
+          "For tables with large rows (TEXT/BLOB columns) this may cause excessive memory usage " +
+          "per JDBC connection. Consider lowering fetchSize to the 1000-10000 range."
+      )
+
+    val tableExpression = source.where match {
+      case Some(filter) if filter.trim.nonEmpty =>
+        validateWhereClause(filter)
+        // Note: the `where` value is treated as trusted input because the config author
+        // already has database credentials. No SQL sanitization is applied.
+        log.debug(
+          "The 'where' field is passed directly to MySQL as SQL without sanitization. " +
+            "Ensure the configuration file is not writable by untrusted principals."
+        )
+        log.info(redactedWhereFilterLogMessage(filter))
+        s"(SELECT * FROM ${escapeIdentifier(source.table)} WHERE $filter) AS filtered_table"
+      case Some(_) =>
+        sys.error(
+          "WHERE clause is empty or blank. Remove the 'where' key or provide a valid filter."
+        )
+      case None => escapeIdentifier(source.table)
+    }
+
+    val jdbcUrl =
+      buildJdbcUrl(source, connectionTimeZoneId = spark.sessionState.conf.sessionLocalTimeZone)
+    val readProperties = jdbcReadProperties(source)
+    ensureSensitiveReaderOptionsAreRedacted(
+      spark,
+      readProperties.stringPropertyNames().toArray(new Array[String](0)).toSeq,
+      "MySQL JDBC reader"
+    )
+
+    (source.partitionColumn, source.numPartitions) match {
+      case (Some(col), Some(n)) =>
+        (source.lowerBound, source.upperBound) match {
+          case (Some(lower), Some(upper)) =>
+            val partitionColumnInfo = partitionColumnMetadata(source, col)
+            validatePartitionBoundsForColumnType(
+              partitionColumn = partitionColumnInfo.columnName,
+              jdbcTypeName    = partitionColumnInfo.jdbcTypeName,
+              columnType      = partitionColumnInfo.columnType,
+              lowerBound      = lower,
+              upperBound      = upper,
+              timeZoneId      = spark.sessionState.conf.sessionLocalTimeZone
+            )
+            log.info(
+              s"Using partitioned read: column=$col, jdbcType=${partitionColumnInfo.jdbcTypeName}, " +
+                s"partitions=$n, lowerBound=${lower.value}, upperBound=${upper.value}"
+            )
+            log.warn(partitionedReadConsistencyWarning(source))
+            partitionedReadOptions(col, partitionColumnInfo, n, lower, upper)
+              .foldLeft(partitionedJdbcReader(spark, source, jdbcUrl, tableExpression)) {
+                case (reader, (key, value)) => reader.option(key, value)
+              }
+              .load()
+          case _ =>
+            sys.error(
+              s"Both lowerBound and upperBound must be set when using partitioned reads " +
+                s"(partitionColumn='$col', numPartitions=$n). " +
+                s"Please set lowerBound and upperBound to the MIN/MAX range of '$col' in the table."
+            )
+        }
+      case (Some(col), None) =>
+        sys.error(
+          s"partitionColumn '$col' specified but numPartitions is missing. " +
+            "Both partitionColumn and numPartitions must be set together for partitioned reads."
+        )
+      case (None, Some(n)) =>
+        sys.error(
+          s"numPartitions ($n) specified but partitionColumn is missing. " +
+            "Both partitionColumn and numPartitions must be set together for partitioned reads."
+        )
+      case _ =>
+        log.warn(
+          "No partitioning configured. This will read the entire table in a single partition. " +
+            "For large tables, set partitionColumn, numPartitions, lowerBound, and upperBound for parallel reads."
+        )
+        spark.read.jdbc(jdbcUrl, tableExpression, readProperties)
+    }
+  }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/MySQLSchemaLogger.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/MySQLSchemaLogger.scala
@@ -1,0 +1,56 @@
+package com.scylladb.migrator.readers
+
+import org.apache.logging.log4j.LogManager
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types._
+
+/** Handles MySQL-specific schema inspection to log how MySQL types map to CQL types via the Spark
+  * ScyllaDB connector. Currently no transformations are performed -- the connector handles type
+  * conversion at write time based on the target CQL schema. The methods below are intentionally
+  * no-ops that only log diagnostic information.
+  *
+  * MySQL type -> Spark JDBC type -> CQL type mapping:
+  *   - INT/BIGINT -> IntegerType/LongType -> int/bigint
+  *   - VARCHAR/TEXT -> StringType -> text
+  *   - DECIMAL -> DecimalType -> decimal
+  *   - DATETIME/TIMESTAMP -> TimestampType -> timestamp
+  *   - BLOB/BINARY -> BinaryType -> blob
+  *   - FLOAT/DOUBLE -> FloatType/DoubleType -> float/double
+  *   - DATE -> DateType -> date
+  *   - JSON/ENUM/SET -> StringType -> text
+  *   - UNSIGNED BIGINT -> DecimalType(precision>19, scale=0) -> varint
+  */
+object MySQLSchemaLogger {
+  private val log = LogManager.getLogger("com.scylladb.migrator.readers.MySQLSchemaLogger")
+
+  /** Log schema information for a MySQL DataFrame.
+    *
+    * No actual transformations are applied -- the Spark ScyllaDB connector handles type conversion.
+    * The main special case worth noting is unsigned BIGINT which comes as DecimalType(20, 0) and
+    * maps to CQL varint.
+    *
+    * @param df
+    *   The raw DataFrame from MySQL JDBC read
+    */
+  def logSchemaInfo(df: DataFrame): Unit = {
+    val schema = df.schema
+
+    schema.fields.foreach { field =>
+      field.dataType match {
+        case dt: DecimalType if dt.scale == 0 && dt.precision > 19 =>
+          log.info(
+            s"Column '${field.name}' has DecimalType(${dt.precision}, ${dt.scale}) - " +
+              "likely MySQL UNSIGNED BIGINT. Keeping as Decimal for ScyllaDB varint compatibility."
+          )
+        case _: DecimalType =>
+          log.debug(s"Column '${field.name}' is DecimalType - maps to CQL decimal")
+        case TimestampType =>
+          log.debug(s"Column '${field.name}' is TimestampType - maps to CQL timestamp")
+        case DateType =>
+          log.debug(s"Column '${field.name}' is DateType - maps to CQL date")
+        case _ =>
+          log.debug(s"Column '${field.name}' is ${field.dataType} - standard mapping")
+      }
+    }
+  }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidator.scala
@@ -1,0 +1,1216 @@
+package com.scylladb.migrator.scylla
+
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql.{ CassandraConnector, Schema, TableDef }
+import com.datastax.spark.connector.rdd.ReadConf
+import com.scylladb.migrator.Connectors
+import com.scylladb.migrator.config.{ MigratorConfig, Rename, SourceSettings, TargetSettings }
+import com.scylladb.migrator.readers
+import com.scylladb.migrator.readers.MySQL
+import com.scylladb.migrator.validation.RowComparisonFailure
+import org.apache.logging.log4j.LogManager
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.cassandra.{ CassandraSQLRow, DataTypeConverter }
+import org.apache.spark.sql.{ Column, DataFrame, Row, SparkSession }
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{ BinaryType, StringType, StructType }
+import org.apache.spark.storage.StorageLevel
+
+import java.sql.DatabaseMetaData
+import java.util.Locale
+import scala.collection.mutable.ListBuffer
+import scala.util.Using
+
+object MySQLToScyllaValidator {
+
+  private val log = LogManager.getLogger("com.scylladb.migrator.scylla.MySQLToScyllaValidator")
+  private[scylla] sealed trait ValidationCandidate
+  private[scylla] case class FinalValidationFailure(failure: RowComparisonFailure)
+      extends ValidationCandidate
+  private[scylla] case class MatchedRowValidationCandidate(
+    sourcePkValues: Vector[Any],
+    sourceRepr: String,
+    targetRepr: String,
+    directDifferingFields: List[String],
+    hashMismatch: Boolean
+  ) extends ValidationCandidate
+  private[scylla] case class HashRefinementFrames(
+    source: DataFrame,
+    target: DataFrame
+  )
+
+  private[scylla] def buildCaseInsensitiveRenameMap(
+    renames: List[Rename]
+  ): Map[String, String] =
+    renames
+      .groupBy(_.from.toLowerCase(Locale.ROOT))
+      .view
+      .map { case (sourceName, entries) =>
+        val targets = entries.map(_.to).distinct
+        if (targets.size > 1)
+          sys.error(
+            s"Renames contain conflicting case-insensitive mappings for source column '${sourceName}': " +
+              s"${targets.mkString(", ")}"
+          )
+        sourceName -> targets.head
+      }
+      .toMap
+
+  private[scylla] def escapeSparkColumnName(name: String): String =
+    s"`${name.replace("`", "``")}`"
+
+  private[scylla] def sparkColumn(name: String): Column =
+    col(escapeSparkColumnName(name))
+
+  private[scylla] def areDifferent(
+    left: Option[Any],
+    right: Option[Any],
+    timestampMsTolerance: Long,
+    floatingPointTolerance: Double
+  ): Boolean =
+    (left, right) match {
+      case (Some(l: Number), Some(r: Number)) =>
+        areNumbersDifferent(l, r, floatingPointTolerance)
+      case _ =>
+        RowComparisonFailure.areDifferent(
+          left,
+          right,
+          timestampMsTolerance,
+          floatingPointTolerance
+        )
+    }
+
+  private sealed trait FloatingPointSpecial
+  private case object NaNValue extends FloatingPointSpecial
+  private case class InfinityValue(sign: Int) extends FloatingPointSpecial
+
+  private def areNumbersDifferent(left: Number, right: Number, tolerance: Double): Boolean =
+    floatingPointSpecial(left)
+      .orElse(floatingPointSpecial(right))
+      .map { _ =>
+        (floatingPointSpecial(left), floatingPointSpecial(right)) match {
+          case (Some(NaNValue), Some(NaNValue)) => false
+          case (Some(InfinityValue(leftSign)), Some(InfinityValue(rightSign))) =>
+            leftSign != rightSign
+          case _ => true
+        }
+      }
+      .getOrElse {
+        (normalizedIntegralValue(left), normalizedIntegralValue(right)) match {
+          case (Some(l), Some(r)) => l != r
+          case _ =>
+            (normalizedDecimalValue(left), normalizedDecimalValue(right)) match {
+              case (Some(l), Some(r)) => areNumericalValuesDifferent(l, r, tolerance)
+              case _                  => left != right
+            }
+        }
+      }
+
+  private def floatingPointSpecial(value: Number): Option[FloatingPointSpecial] =
+    value match {
+      case d: java.lang.Double if d.isNaN      => Some(NaNValue)
+      case d: java.lang.Double if d.isInfinite => Some(InfinityValue(Math.signum(d).toInt))
+      case f: java.lang.Float if f.isNaN       => Some(NaNValue)
+      case f: java.lang.Float if f.isInfinite  => Some(InfinityValue(Math.signum(f).toInt))
+      case _                                   => None
+    }
+
+  private def normalizedIntegralValue(value: Number): Option[BigInt] =
+    value match {
+      case b: java.lang.Byte        => Some(BigInt(b.longValue))
+      case s: java.lang.Short       => Some(BigInt(s.longValue))
+      case i: java.lang.Integer     => Some(BigInt(i.longValue))
+      case l: java.lang.Long        => Some(BigInt(l.longValue))
+      case bi: java.math.BigInteger => Some(BigInt(bi))
+      case bi: BigInt               => Some(bi)
+      case bd: java.math.BigDecimal =>
+        val stripped = bd.stripTrailingZeros
+        if (stripped.scale <= 0) Some(BigInt(stripped.toBigIntegerExact)) else None
+      case bd: BigDecimal =>
+        val stripped = bd.bigDecimal.stripTrailingZeros
+        if (stripped.scale <= 0) Some(BigInt(stripped.toBigIntegerExact)) else None
+      case _ => None
+    }
+
+  private def normalizedDecimalValue(value: Number): Option[BigDecimal] =
+    value match {
+      case d: java.lang.Double if d.isNaN || d.isInfinite => None
+      case f: java.lang.Float if f.isNaN || f.isInfinite  => None
+      case b: java.lang.Byte                              => Some(BigDecimal(BigInt(b.longValue)))
+      case s: java.lang.Short                             => Some(BigDecimal(BigInt(s.longValue)))
+      case i: java.lang.Integer                           => Some(BigDecimal(BigInt(i.longValue)))
+      case l: java.lang.Long                              => Some(BigDecimal(BigInt(l.longValue)))
+      case bi: java.math.BigInteger                       => Some(BigDecimal(BigInt(bi)))
+      case bi: BigInt                                     => Some(BigDecimal(bi))
+      case bd: java.math.BigDecimal                       => Some(BigDecimal(bd))
+      case bd: BigDecimal                                 => Some(bd)
+      case f: java.lang.Float                             => Some(BigDecimal.decimal(f.doubleValue))
+      case d: java.lang.Double                            => Some(BigDecimal.decimal(d.doubleValue))
+      case _                                              => None
+    }
+
+  private def areNumericalValuesDifferent(
+    x: BigDecimal,
+    y: BigDecimal,
+    tolerance: BigDecimal
+  ): Boolean =
+    (x - y).abs > tolerance
+
+  private[scylla] def differingFieldNamesForRow(
+    joinedRow: Row,
+    fieldIndices: Seq[(String, Int, Int)],
+    timestampMsTolerance: Long,
+    floatingPointTolerance: Double
+  ): List[String] =
+    fieldIndices.flatMap { case (colName, srcIdx, tgtIdx) =>
+      val srcVal = if (joinedRow.isNullAt(srcIdx)) None else Some(joinedRow.get(srcIdx))
+      val tgtVal = if (joinedRow.isNullAt(tgtIdx)) None else Some(joinedRow.get(tgtIdx))
+      if (
+        areDifferent(
+          srcVal,
+          tgtVal,
+          timestampMsTolerance,
+          floatingPointTolerance
+        )
+      )
+        Some(colName)
+      else
+        None
+    }.toList
+
+  private[scylla] def compareFieldsBySchemaForRow(
+    joinedRow: Row,
+    directFieldIndices: Seq[(String, Int, Int)],
+    hashBackedFieldIndices: Seq[(String, Int, Int)],
+    contentHashFieldIndices: Option[(Int, Int)],
+    timestampMsTolerance: Long,
+    floatingPointTolerance: Double
+  ): List[String] = {
+    val directDifferences =
+      differingFieldNamesForRow(
+        joinedRow,
+        directFieldIndices,
+        timestampMsTolerance,
+        floatingPointTolerance
+      )
+
+    val hashBackedDifferences = contentHashFieldIndices match {
+      case Some((srcHashIdx, tgtHashIdx)) =>
+        val srcHash = if (joinedRow.isNullAt(srcHashIdx)) None else Some(joinedRow.get(srcHashIdx))
+        val tgtHash = if (joinedRow.isNullAt(tgtHashIdx)) None else Some(joinedRow.get(tgtHashIdx))
+        if (
+          areDifferent(
+            srcHash,
+            tgtHash,
+            timestampMsTolerance,
+            floatingPointTolerance
+          )
+        )
+          differingFieldNamesForRow(
+            joinedRow,
+            hashBackedFieldIndices,
+            timestampMsTolerance,
+            floatingPointTolerance
+          )
+        else
+          Nil
+      case None =>
+        differingFieldNamesForRow(
+          joinedRow,
+          hashBackedFieldIndices,
+          timestampMsTolerance,
+          floatingPointTolerance
+        )
+    }
+
+    directDifferences ++ hashBackedDifferences
+  }
+
+  private[scylla] def hasContentHashMismatch(
+    joinedRow: Row,
+    contentHashFieldIndices: Option[(Int, Int)],
+    timestampMsTolerance: Long,
+    floatingPointTolerance: Double
+  ): Boolean =
+    contentHashFieldIndices.exists { case (srcHashIdx, tgtHashIdx) =>
+      val srcHash = if (joinedRow.isNullAt(srcHashIdx)) None else Some(joinedRow.get(srcHashIdx))
+      val tgtHash = if (joinedRow.isNullAt(tgtHashIdx)) None else Some(joinedRow.get(tgtHashIdx))
+      areDifferent(
+        srcHash,
+        tgtHash,
+        timestampMsTolerance,
+        floatingPointTolerance
+      )
+    }
+
+  private[scylla] def materializeValidationCandidate(
+    candidate: ValidationCandidate,
+    hashBackedColumns: Seq[String],
+    refinedHashDifferences: Map[Vector[Any], List[String]]
+  ): Option[RowComparisonFailure] =
+    candidate match {
+      case FinalValidationFailure(failure) => Some(failure)
+      case matched: MatchedRowValidationCandidate =>
+        val hashDifferences =
+          if (!matched.hashMismatch) Nil
+          else
+            refinedHashDifferences.getOrElse(
+              normalizePrimaryKeyValues(matched.sourcePkValues),
+              List(
+                s"hashColumns(${hashBackedColumns.mkString(", ")}) " +
+                  "(content hash mismatch; values fetched by PK could not be resolved)"
+              )
+            )
+        val differingFields = matched.directDifferingFields ++ hashDifferences
+        if (differingFields.isEmpty) None
+        else
+          Some(
+            RowComparisonFailure(
+              matched.sourceRepr,
+              Some(matched.targetRepr),
+              List(RowComparisonFailure.Item.DifferingFieldValues(differingFields))
+            )
+          )
+    }
+
+  private[scylla] def collectFailureSample(
+    candidateFailuresRdd: RDD[ValidationCandidate],
+    rawSourceDF: DataFrame,
+    rawTargetDF: DataFrame,
+    primaryKey: Seq[String],
+    hashBackedColumns: Seq[String],
+    timestampMsTolerance: Long,
+    floatingPointTolerance: Double,
+    failuresToFetch: Int
+  )(implicit spark: SparkSession): List[RowComparisonFailure] =
+    if (failuresToFetch <= 0) Nil
+    else {
+      val failures = ListBuffer.empty[RowComparisonFailure]
+      val candidateIterator = candidateFailuresRdd.toLocalIterator
+      val refinementFrames =
+        Option
+          .when(hashBackedColumns.nonEmpty)(
+            createHashRefinementFrames(rawSourceDF, rawTargetDF, primaryKey, hashBackedColumns)
+          )
+
+      try
+        while (candidateIterator.hasNext && failures.size < failuresToFetch) {
+          val batchSize = math.max(failuresToFetch - failures.size, 1)
+          val batch = candidateIterator.take(batchSize).toList
+          val hashMismatchCandidates =
+            if (hashBackedColumns.nonEmpty)
+              batch.collect {
+                case candidate: MatchedRowValidationCandidate if candidate.hashMismatch =>
+                  candidate
+              }
+            else Nil
+
+          val refinedHashDifferences =
+            if (hashMismatchCandidates.nonEmpty)
+              resolveHashBackedDifferences(
+                refinementFrames.getOrElse(
+                  throw new IllegalStateException("Missing hash refinement frames")
+                ),
+                primaryKey,
+                hashMismatchCandidates.map(_.sourcePkValues),
+                hashBackedColumns,
+                timestampMsTolerance,
+                floatingPointTolerance
+              )
+            else Map.empty[Vector[Any], List[String]]
+
+          batch.iterator
+            .flatMap(
+              materializeValidationCandidate(_, hashBackedColumns, refinedHashDifferences)
+            )
+            .take(failuresToFetch - failures.size)
+            .foreach(failures += _)
+        }
+      finally
+        refinementFrames.foreach { frames =>
+          frames.source.unpersist(blocking = false)
+          frames.target.unpersist(blocking = false)
+        }
+
+      failures.toList
+    }
+
+  private[scylla] def resolveFieldName(fields: Array[String], name: String): String =
+    fields
+      .find(_.equalsIgnoreCase(name))
+      .getOrElse(
+        sys.error(
+          s"Column '$name' not found in schema. Available columns: ${fields.mkString(", ")}. " +
+            "This may indicate a missing rename entry or schema mismatch."
+        )
+      )
+
+  private[scylla] def differingFieldsBetweenRows(
+    sourceRow: Row,
+    sourceFields: Array[String],
+    targetRow: Row,
+    targetFields: Array[String],
+    columns: Seq[String],
+    timestampMsTolerance: Long,
+    floatingPointTolerance: Double
+  ): List[String] =
+    columns.flatMap { colName =>
+      val srcIdx = sourceFields.indexOf(resolveFieldName(sourceFields, colName))
+      val tgtIdx = targetFields.indexOf(resolveFieldName(targetFields, colName))
+      val srcVal = if (sourceRow.isNullAt(srcIdx)) None else Some(sourceRow.get(srcIdx))
+      val tgtVal = if (targetRow.isNullAt(tgtIdx)) None else Some(targetRow.get(tgtIdx))
+      if (
+        areDifferent(
+          srcVal,
+          tgtVal,
+          timestampMsTolerance,
+          floatingPointTolerance
+        )
+      )
+        Some(s"$colName (source=${truncateValue(srcVal)}, target=${truncateValue(tgtVal)})")
+      else None
+    }.toList
+
+  private[scylla] def validateTargetPrimaryKey(
+    configuredPrimaryKey: Seq[String],
+    actualTargetPrimaryKey: Seq[String]
+  ): Unit = {
+    val configuredLower = configuredPrimaryKey.map(_.toLowerCase(Locale.ROOT))
+    val actualLower = actualTargetPrimaryKey.map(_.toLowerCase(Locale.ROOT))
+    if (actualLower != configuredLower)
+      sys.error(
+        s"Configured primaryKey (after renames) does not match target table's actual PK. " +
+          s"Configured: ${configuredPrimaryKey.mkString(", ")}. " +
+          s"Actual target PK: ${actualTargetPrimaryKey.mkString(", ")}. " +
+          "Validation cannot safely proceed with a mismatched join key."
+      )
+  }
+
+  private[scylla] def validateSourcePrimaryKey(
+    configuredPrimaryKey: Seq[String],
+    actualSourcePrimaryKey: Seq[String]
+  ): Unit = {
+    val configuredLower = configuredPrimaryKey.map(_.toLowerCase(Locale.ROOT))
+    val actualLower = actualSourcePrimaryKey.map(_.toLowerCase(Locale.ROOT))
+    if (actualLower != configuredLower)
+      sys.error(
+        s"Configured primaryKey does not match the MySQL table's actual PK. " +
+          s"Configured: ${configuredPrimaryKey.mkString(", ")}. " +
+          s"Actual source PK: ${actualSourcePrimaryKey.mkString(", ")}. " +
+          "Validation cannot safely proceed with a mismatched join key."
+      )
+  }
+
+  private[scylla] def sourcePrimaryKeyFromMetadata(
+    metaData: DatabaseMetaData,
+    catalog: String,
+    tableName: String
+  ): Seq[String] =
+    Using.resource(
+      // getPrimaryKeys expects the literal table name, not a metadata pattern. Escaping `_`/`%`
+      // here breaks primary-key discovery on MySQL Connector/J, including for ordinary table
+      // names such as `users_numeric`.
+      metaData.getPrimaryKeys(catalog, null, tableName)
+    ) { resultSet =>
+      Iterator
+        .continually(resultSet.next())
+        .takeWhile(identity)
+        .map(_ => resultSet.getShort("KEY_SEQ").toInt -> resultSet.getString("COLUMN_NAME"))
+        .toList
+        .sortBy(_._1)
+        .map(_._2)
+    }
+
+  private[scylla] def sourcePrimaryKeyFromMetadata(
+    sourceSettings: SourceSettings.MySQL
+  ): Seq[String] =
+    readers.MySQL.withJdbcConnection(sourceSettings) { connection =>
+      val catalog = Option(connection.getCatalog).getOrElse(sourceSettings.database)
+      sourcePrimaryKeyFromMetadata(connection.getMetaData, catalog, sourceSettings.table)
+    }
+
+  private[scylla] def validateSourceColumnsPresentInTarget(
+    sourceColumns: Seq[String],
+    targetColumns: Seq[String]
+  ): Unit = {
+    val targetColumnsLower = targetColumns.map(_.toLowerCase(Locale.ROOT)).toSet
+    val missingInTarget =
+      sourceColumns.filterNot(c => targetColumnsLower.contains(c.toLowerCase(Locale.ROOT)))
+    if (missingInTarget.nonEmpty)
+      sys.error(
+        s"Source columns not found in target after renames: ${missingInTarget.mkString(", ")}. " +
+          "Validation would silently skip these columns, so the run has been aborted. " +
+          "If this is unexpected, check your target schema or 'renames' configuration."
+      )
+  }
+
+  private[scylla] def targetOnlyColumns(
+    sourceColumns: Seq[String],
+    targetColumns: Seq[String]
+  ): Seq[String] = {
+    val sourceColumnsLower = sourceColumns.map(_.toLowerCase(Locale.ROOT)).toSet
+    targetColumns.filterNot(c => sourceColumnsLower.contains(c.toLowerCase(Locale.ROOT)))
+  }
+
+  private[scylla] def normalizePrimaryKeyComponent(value: Any): Any = value match {
+    case bytes: Array[Byte] => bytes.toIndexedSeq
+    case other              => other
+  }
+
+  private[scylla] def normalizePrimaryKeyValues(values: Seq[Any]): Vector[Any] =
+    values.iterator.map(normalizePrimaryKeyComponent).toVector
+
+  private[scylla] def selectColumnsForHashRefinement(
+    df: DataFrame,
+    primaryKey: Seq[String],
+    hashBackedColumns: Seq[String]
+  ): DataFrame = {
+    val requiredColumns =
+      (primaryKey ++ hashBackedColumns).distinct.map(resolveFieldName(df.schema.fieldNames, _))
+    df.select(requiredColumns.map(sparkColumn): _*)
+  }
+
+  private[scylla] def createHashRefinementFrames(
+    rawSourceDF: DataFrame,
+    rawTargetDF: DataFrame,
+    primaryKey: Seq[String],
+    hashBackedColumns: Seq[String]
+  ): HashRefinementFrames =
+    HashRefinementFrames(
+      selectColumnsForHashRefinement(rawSourceDF, primaryKey, hashBackedColumns)
+        .persist(StorageLevel.MEMORY_AND_DISK),
+      selectColumnsForHashRefinement(rawTargetDF, primaryKey, hashBackedColumns)
+        .persist(StorageLevel.MEMORY_AND_DISK)
+    )
+
+  private[scylla] def selectAndAliasColumns(
+    df: DataFrame,
+    requestedColumns: Seq[String]
+  ): DataFrame = {
+    val schemaFields = df.schema.fieldNames
+    df.select(
+      requestedColumns.toIndexedSeq.map { columnName =>
+        sparkColumn(resolveFieldName(schemaFields, columnName)).as(columnName)
+      }: _*
+    )
+  }
+
+  private[scylla] def validateHashColumnsPresentOnBothSides(
+    requestedHashColumns: Seq[String],
+    sourceColumns: Seq[String],
+    targetColumns: Seq[String]
+  ): Unit = {
+    val sourceColumnsLower = sourceColumns.map(_.toLowerCase(Locale.ROOT)).toSet
+    val targetColumnsLower = targetColumns.map(_.toLowerCase(Locale.ROOT)).toSet
+    val missingInSource =
+      requestedHashColumns.filterNot(c => sourceColumnsLower.contains(c.toLowerCase(Locale.ROOT)))
+    val missingInTarget =
+      requestedHashColumns.filterNot(c => targetColumnsLower.contains(c.toLowerCase(Locale.ROOT)))
+
+    if (missingInSource.nonEmpty || missingInTarget.nonEmpty) {
+      val details = List(
+        if (missingInSource.nonEmpty)
+          Some(s"missing in source: ${missingInSource.mkString(", ")}")
+        else None,
+        if (missingInTarget.nonEmpty)
+          Some(s"missing in target: ${missingInTarget.mkString(", ")}")
+        else None
+      ).flatten.mkString("; ")
+
+      sys.error(
+        s"Configured hashColumns must exist on both source and target after renames, but found $details"
+      )
+    }
+  }
+
+  private def resolveTargetColumns(
+    targetTableDef: TableDef,
+    columns: Seq[String]
+  ): Seq[String] = {
+    val targetFields = targetTableDef.columns.map(_.columnName).toArray
+    columns.map(resolveFieldName(targetFields, _))
+  }
+
+  private def buildTargetSchema(
+    targetTableDef: TableDef,
+    selectedColumns: Seq[String]
+  ): StructType =
+    StructType(
+      selectedColumns.map { columnName =>
+        DataTypeConverter.toStructField(targetTableDef.columnByName(columnName))
+      }
+    )
+
+  private def targetReadConf(
+    spark: SparkSession,
+    targetSettings: TargetSettings.Scylla
+  ): ReadConf = {
+    val consistencyLevel =
+      com.scylladb.migrator.ConsistencyLevelUtils.parseConsistencyLevel(
+        targetSettings.consistencyLevel
+      )
+    log.info(
+      s"Using consistencyLevel [${consistencyLevel}] for VALIDATOR TARGET based on target config [${targetSettings.consistencyLevel}]"
+    )
+    ReadConf
+      .fromSparkConf(spark.sparkContext.getConf)
+      .copy(consistencyLevel = consistencyLevel)
+  }
+
+  private[scylla] def liveWriteWarning(
+    sourceSettings: SourceSettings.MySQL,
+    targetSettings: TargetSettings.Scylla
+  ): String =
+    s"MySQL-to-ScyllaDB validation is not point-in-time safe while either side is receiving " +
+      s"writes. The validator may scan ${sourceSettings.database}.${sourceSettings.table} and " +
+      s"${targetSettings.keyspace}.${targetSettings.table} using multiple statements over time, " +
+      "which can produce false mismatches or miss real ones. Run validation only after source " +
+      "and target writes have quiesced."
+
+  private def readTargetRows(
+    spark: SparkSession,
+    targetConnector: CassandraConnector,
+    targetTableDef: TableDef,
+    targetSettings: TargetSettings.Scylla,
+    selectedColumns: Seq[String]
+  ): DataFrame = {
+    val resolvedSelectedColumns = resolveTargetColumns(targetTableDef, selectedColumns)
+    val schema = buildTargetSchema(targetTableDef, resolvedSelectedColumns)
+    val selectColumns = resolvedSelectedColumns.map(ColumnName(_))
+    val rows: RDD[Row] = spark.sparkContext
+      .cassandraTable[CassandraSQLRow](targetSettings.keyspace, targetSettings.table)
+      .withConnector(targetConnector)
+      .withReadConf(targetReadConf(spark, targetSettings))
+      .select(selectColumns: _*)
+      .map(row => Row.fromSeq(row.toSeq.map(readers.Cassandra.convertValue)))
+    spark.createDataFrame(rows, schema)
+  }
+
+  private def lookupTargetRowsForSourceKeys(
+    spark: SparkSession,
+    sourceDF: DataFrame,
+    targetConnector: CassandraConnector,
+    targetTableDef: TableDef,
+    targetSettings: TargetSettings.Scylla,
+    primaryKeyColumns: Seq[String],
+    selectedColumns: Seq[String]
+  ): DataFrame = {
+    val sourceSchemaFields = sourceDF.schema.fieldNames
+    val resolvedSourcePK = primaryKeyColumns.map(resolveFieldName(sourceSchemaFields, _))
+    val resolvedTargetPK = resolveTargetColumns(targetTableDef, primaryKeyColumns)
+    val resolvedSelectedColumns = resolveTargetColumns(targetTableDef, selectedColumns)
+    val schema = buildTargetSchema(targetTableDef, resolvedSelectedColumns)
+    val targetRows = sourceDF
+      .select(resolvedSourcePK.map(sparkColumn): _*)
+      .distinct()
+      .rdd
+      .leftJoinWithCassandraTable[CassandraSQLRow](
+        targetSettings.keyspace,
+        targetSettings.table,
+        SomeColumns(resolvedSelectedColumns.map(ColumnName(_)): _*),
+        SomeColumns(resolvedTargetPK.map(ColumnName(_)): _*),
+        targetReadConf(spark, targetSettings)
+      )
+      .withConnector(targetConnector)
+      .flatMap(_._2)
+      .map(row => Row.fromSeq(row.toSeq.map(readers.Cassandra.convertValue)))
+    spark.createDataFrame(targetRows, schema)
+  }
+
+  private[scylla] def collectExtraTargetFailureSample(
+    sourceKeys: DataFrame,
+    targetKeys: DataFrame,
+    primaryKeyColumns: Seq[String],
+    failuresToFetch: Int
+  ): List[RowComparisonFailure] =
+    if (failuresToFetch <= 0) Nil
+    else
+      targetKeys
+        .join(sourceKeys.distinct(), primaryKeyColumns, "left_anti")
+        .rdd
+        .map { row =>
+          val targetRepr =
+            primaryKeyColumns
+              .map(pk => s"$pk=${row.getAs[Any](pk)}")
+              .mkString(", ")
+          RowComparisonFailure(
+            targetRepr,
+            None,
+            List(RowComparisonFailure.Item.ExtraTargetRow)
+          )
+        }
+        .take(failuresToFetch)
+        .toList
+
+  private[scylla] def collectExtraTargetFailureSample(
+    sourceDF: DataFrame,
+    targetConnector: CassandraConnector,
+    targetTableDef: TableDef,
+    targetSettings: TargetSettings.Scylla,
+    primaryKeyColumns: Seq[String],
+    failuresToFetch: Int
+  )(implicit spark: SparkSession): List[RowComparisonFailure] =
+    if (failuresToFetch <= 0) Nil
+    else {
+      val sourceKeys = selectAndAliasColumns(sourceDF, primaryKeyColumns)
+      val targetKeys =
+        selectAndAliasColumns(
+          readTargetRows(spark, targetConnector, targetTableDef, targetSettings, primaryKeyColumns),
+          primaryKeyColumns
+        )
+
+      collectExtraTargetFailureSample(sourceKeys, targetKeys, primaryKeyColumns, failuresToFetch)
+    }
+
+  def runValidation(
+    sourceSettings: SourceSettings.MySQL,
+    targetSettings: TargetSettings.Scylla,
+    config: MigratorConfig
+  )(implicit spark: SparkSession): List[RowComparisonFailure] = {
+
+    val validationConfig =
+      config.validation.getOrElse(
+        sys.error("Missing required property 'validation' in the configuration file.")
+      )
+
+    val primaryKey = sourceSettings.primaryKey.getOrElse(
+      sys.error(
+        "Missing required property 'primaryKey' in MySQL source configuration. " +
+          "The validator needs to know which columns form the primary key for joining rows."
+      )
+    )
+
+    if (primaryKey.isEmpty)
+      sys.error("'primaryKey' must contain at least one column name.")
+
+    val hashColumns = validationConfig.hashColumns.filter(_.nonEmpty)
+    hashColumns.foreach(cols =>
+      require(cols.forall(_.trim.nonEmpty), "hashColumns must not contain empty or blank strings")
+    )
+
+    val renamesByLower = buildCaseInsensitiveRenameMap(config.getRenamesOrNil)
+    def resolveRename(column: String): String =
+      renamesByLower.getOrElse(column.toLowerCase(Locale.ROOT), column)
+
+    val renamedPK = primaryKey.map(resolveRename)
+    val renamedPKLower = renamedPK.map(_.toLowerCase(Locale.ROOT)).toSet
+
+    if (config.getRenamesOrNil.nonEmpty) {
+      val unmappedPK =
+        primaryKey.filterNot(pk => renamesByLower.contains(pk.toLowerCase(Locale.ROOT)))
+      if (unmappedPK.nonEmpty)
+        log.warn(
+          s"PK columns with no explicit rename (using identity): ${unmappedPK.mkString(", ")}"
+        )
+    }
+
+    require(
+      renamedPK.distinct.size == renamedPK.size,
+      s"Renames must not map multiple primary key columns to the same target name. Got: ${renamedPK.mkString(", ")}"
+    )
+
+    // Validate that hashColumns do not overlap with primaryKey columns.
+    // hashColumns are documented as source-side names, so check them against source PK names.
+    // After applying renames, also check the renamed hash columns against the target PK names.
+    hashColumns.foreach { cols =>
+      val pkSourceSet = primaryKey.map(_.toLowerCase(Locale.ROOT)).toSet
+      val pkTargetSet = renamedPK.map(_.toLowerCase(Locale.ROOT)).toSet
+      val sourceOverlap = cols.filter(c => pkSourceSet.contains(c.toLowerCase(Locale.ROOT)))
+      val renamedHashCols = cols.map(resolveRename)
+      val targetOverlap =
+        renamedHashCols.filter(c => pkTargetSet.contains(c.toLowerCase(Locale.ROOT)))
+      val overlap = (sourceOverlap ++ targetOverlap).distinct
+      if (overlap.nonEmpty)
+        sys.error(
+          s"hashColumns must not include primary key columns, but found overlap: ${overlap.mkString(", ")}. " +
+            "Primary key columns are always selected directly and must not be hashed."
+        )
+    }
+
+    log.info("Starting MySQL-to-ScyllaDB validation")
+    log.info(
+      s"Source: MySQL ${sourceSettings.database}.${sourceSettings.table} " +
+        s"at ${sourceSettings.host}:${sourceSettings.port}"
+    )
+    log.info(
+      s"Target: ScyllaDB ${targetSettings.keyspace}.${targetSettings.table} " +
+        s"at ${targetSettings.host}:${targetSettings.port}"
+    )
+    log.info(s"Primary key columns: ${primaryKey.mkString(", ")}")
+    log.warn(liveWriteWarning(sourceSettings, targetSettings))
+    hashColumns.foreach(cols =>
+      log.warn(
+        s"Hash-based comparison enabled for columns: ${cols.mkString(", ")}. " +
+          "This reduces Spark-side join/shuffle volume, but the validator still reads the " +
+          "original MySQL and ScyllaDB payload columns before hashing."
+      )
+    )
+
+    val actualSourcePK = sourcePrimaryKeyFromMetadata(sourceSettings)
+    if (actualSourcePK.isEmpty)
+      sys.error(
+        s"MySQL table ${sourceSettings.database}.${sourceSettings.table} does not expose a primary key via JDBC metadata. " +
+          "Validation requires the real source primary key."
+      )
+    validateSourcePrimaryKey(primaryKey, actualSourcePK)
+
+    // Always read all columns from MySQL; hash is computed in Spark (not MySQL)
+    val rawSourceDF = {
+      val df = readers.MySQL.readDataframe(spark, sourceSettings).dataFrame
+      // Validate that all PK columns exist in the MySQL table before proceeding.
+      // This gives a clear error message instead of a confusing "src_xxx not found" later.
+      val dfColsLower = df.columns.map(_.toLowerCase(Locale.ROOT)).toSet
+      val missingPK = primaryKey.filterNot(pk => dfColsLower.contains(pk.toLowerCase(Locale.ROOT)))
+      if (missingPK.nonEmpty)
+        sys.error(
+          s"primaryKey columns not found in MySQL table: ${missingPK.mkString(", ")}. " +
+            s"Available columns: ${df.columns.mkString(", ")}"
+        )
+      if (primaryKey.map(_.toLowerCase(Locale.ROOT)).distinct.size != primaryKey.size)
+        sys.error(s"primaryKey contains duplicate columns: ${primaryKey.mkString(", ")}")
+      val renamed =
+        df.select(df.columns.toIndexedSeq.map(c => sparkColumn(c).as(resolveRename(c))): _*)
+      val renamedCols = renamed.columns.map(_.toLowerCase(Locale.ROOT))
+      val duplicates = renamedCols.diff(renamedCols.distinct)
+      if (duplicates.nonEmpty)
+        sys.error(
+          s"Column rename collision: multiple source columns map to the same target name(s): " +
+            s"${duplicates.distinct.mkString(", ")}. " +
+            "Check your 'renames' configuration for conflicting mappings."
+        )
+      renamed
+    }
+
+    log.info(s"Connecting to ScyllaDB target at ${targetSettings.host}:${targetSettings.port}")
+
+    // Verify that the configured primaryKey (after renames) matches the target table's actual PK.
+    // This prevents silent incorrect validation results when the PK is mis-specified.
+    val targetConnector =
+      Connectors.targetConnector(spark.sparkContext.getConf, targetSettings)
+    val targetTableDef = targetConnector.withSessionDo(
+      Schema.tableFromCassandra(_, targetSettings.keyspace, targetSettings.table)
+    )
+    val actualTargetPK =
+      (targetTableDef.partitionKey ++ targetTableDef.clusteringColumns)
+        .map(_.columnName.toLowerCase(Locale.ROOT))
+    validateTargetPrimaryKey(renamedPK, actualTargetPK)
+    val targetColumnNames = targetTableDef.columns.map(_.columnName)
+    val selectedTargetColumns = rawSourceDF.columns.toSeq
+
+    // Fail when renamed source columns are missing in the target. Continuing would silently drop
+    // those columns from comparison and could produce a false-clean validation result.
+    validateSourceColumnsPresentInTarget(rawSourceDF.columns.toSeq, targetColumnNames)
+    val missingInSource = targetOnlyColumns(rawSourceDF.columns.toSeq, targetColumnNames)
+    if (missingInSource.nonEmpty)
+      log.info(
+        s"Target columns not present in (renamed) source: ${missingInSource.mkString(", ")}"
+      )
+
+    if (sourceSettings.where.isDefined)
+      log.warn(
+        "Source 'where' filter is configured. Disabling extra-target-row detection and " +
+          "probing only target rows matching the filtered source primary keys."
+      )
+    val rawTargetDF = lookupTargetRowsForSourceKeys(
+      spark,
+      rawSourceDF,
+      targetConnector,
+      targetTableDef,
+      targetSettings,
+      renamedPK,
+      selectedTargetColumns
+    )
+
+    val (sourceDF, targetDF, directComparableColumns, hashBackedColumns) = hashColumns match {
+      case Some(cols) =>
+        val renamedCols = cols.map(resolveRename)
+        validateHashColumnsPresentOnBothSides(
+          requestedHashColumns = renamedCols,
+          sourceColumns        = rawSourceDF.columns.toSeq,
+          targetColumns        = targetColumnNames
+        )
+
+        val hashedSource =
+          addContentHash(rawSourceDF, renamedCols, renamedPK, dropHashedColumns = true)
+        val hashedTarget =
+          addContentHash(rawTargetDF, renamedCols, renamedPK, dropHashedColumns = true)
+        val hashBackedColumnsLower = renamedCols.map(_.toLowerCase(Locale.ROOT)).toSet
+        val directCols = hashedSource.columns
+          .filter(c => !renamedPKLower.contains(c.toLowerCase(Locale.ROOT)))
+          .filter(_ != MySQL.ContentHashColumn)
+          .filterNot(c => hashBackedColumnsLower.contains(c.toLowerCase(Locale.ROOT)))
+        (hashedSource, hashedTarget, directCols, renamedCols)
+
+      case None =>
+        val nonPKCols =
+          rawSourceDF.columns.filter(c => !renamedPKLower.contains(c.toLowerCase(Locale.ROOT)))
+        (rawSourceDF, rawTargetDF, nonPKCols, Nil)
+    }
+
+    val targetColumnsLower = targetDF.columns.map(_.toLowerCase(Locale.ROOT)).toSet
+    val droppedColumns =
+      (directComparableColumns ++ (if (hashColumns.isDefined) Seq(MySQL.ContentHashColumn)
+                                   else Nil))
+        .filterNot(c => targetColumnsLower.contains(c.toLowerCase(Locale.ROOT)))
+    if (droppedColumns.nonEmpty)
+      sys.error(
+        s"Comparable columns unexpectedly disappeared from the target schema: ${droppedColumns.mkString(", ")}. " +
+          "Validation cannot continue safely."
+      )
+    val finalDirectComparableColumns =
+      directComparableColumns.filter(c => targetColumnsLower.contains(c.toLowerCase(Locale.ROOT)))
+    val finalHashBackedColumns = hashBackedColumns
+    log.info(
+      s"Comparable columns: ${(finalDirectComparableColumns ++ finalHashBackedColumns).mkString(", ")}"
+    )
+
+    val sourcePrefixed = prefixColumns(sourceDF, "src_")
+    val targetPrefixed = prefixColumns(targetDF, "tgt_")
+
+    // Resolve PK column names against the actual DataFrame schemas using case-insensitive
+    // lookup. This is necessary because ScyllaDB normalizes unquoted column names to lowercase,
+    // so a MySQL column "UserId" may appear as "userid" in the target DataFrame. Spark's
+    // DataFrame.apply() resolves columns case-insensitively, but Row.fieldIndex() is
+    // case-sensitive and would throw IllegalArgumentException on a mismatch.
+    val srcSchemaFields = sourcePrefixed.schema.fieldNames
+    val tgtSchemaFields = targetPrefixed.schema.fieldNames
+
+    val joinCondition = renamedPK
+      .map { pk =>
+        val srcCol = resolveFieldName(srcSchemaFields, s"src_$pk")
+        val tgtCol = resolveFieldName(tgtSchemaFields, s"tgt_$pk")
+        sparkColumn(srcCol) === sparkColumn(tgtCol)
+      }
+      .reduce(_ && _)
+
+    val joined = sourcePrefixed.join(targetPrefixed, joinCondition, "left_outer")
+
+    val joinedSchemaFields = joined.schema.fieldNames
+    val floatTol = validationConfig.floatingPointTolerance
+    val tsTol = validationConfig.timestampMsTolerance
+
+    // Pre-compute field indices to avoid repeated case-insensitive lookups on every row.
+    // For wide tables (100+ columns) × millions of rows, this provides significant speedup.
+    val directFieldIndices = finalDirectComparableColumns.toIndexedSeq.map { colName =>
+      val srcFieldName = resolveFieldName(joinedSchemaFields, s"src_$colName")
+      val tgtFieldName = resolveFieldName(joinedSchemaFields, s"tgt_$colName")
+      (colName, joinedSchemaFields.indexOf(srcFieldName), joinedSchemaFields.indexOf(tgtFieldName))
+    }
+    val contentHashFieldIndices =
+      if (hashColumns.isDefined) {
+        val srcFieldName = resolveFieldName(joinedSchemaFields, s"src_${MySQL.ContentHashColumn}")
+        val tgtFieldName = resolveFieldName(joinedSchemaFields, s"tgt_${MySQL.ContentHashColumn}")
+        Some((joinedSchemaFields.indexOf(srcFieldName), joinedSchemaFields.indexOf(tgtFieldName)))
+      } else None
+    val fieldIndexByName =
+      directFieldIndices.map { case (name, srcIdx, tgtIdx) =>
+        name -> (srcIdx, tgtIdx)
+      }.toMap
+
+    // Pre-compute PK field indices so that the RDD closure uses index-based access
+    // instead of calling resolveField (linear scan) on every row.
+    val srcPKIndices = renamedPK.map { pk =>
+      val fieldName = resolveFieldName(joinedSchemaFields, s"src_$pk")
+      (pk, joinedSchemaFields.indexOf(fieldName))
+    }.toArray
+    val tgtPKIndices = renamedPK.map { pk =>
+      val fieldName = resolveFieldName(joinedSchemaFields, s"tgt_$pk")
+      (pk, joinedSchemaFields.indexOf(fieldName))
+    }.toArray
+
+    val candidateFailuresRdd: RDD[ValidationCandidate] = joined.rdd
+      .flatMap { joinedRow =>
+        val srcNull = srcPKIndices.forall { case (_, idx) => joinedRow.isNullAt(idx) }
+        val tgtNull = tgtPKIndices.forall { case (_, idx) => joinedRow.isNullAt(idx) }
+
+        if (srcNull) {
+          // Row exists in target but not in source
+          val tgtRepr =
+            tgtPKIndices
+              .map { case (pk, idx) => s"$pk=${joinedRow.get(idx)}" }
+              .mkString(", ")
+          Some(
+            FinalValidationFailure(
+              RowComparisonFailure(
+                tgtRepr,
+                None,
+                List(RowComparisonFailure.Item.ExtraTargetRow)
+              )
+            )
+          )
+        } else if (tgtNull) {
+          val srcRepr =
+            srcPKIndices
+              .map { case (pk, idx) => s"$pk=${joinedRow.get(idx)}" }
+              .mkString(", ")
+          Some(
+            FinalValidationFailure(
+              RowComparisonFailure(
+                srcRepr,
+                None,
+                List(RowComparisonFailure.Item.MissingTargetRow)
+              )
+            )
+          )
+        } else {
+          val directDifferingFields =
+            differingFieldNamesForRow(joinedRow, directFieldIndices, tsTol, floatTol).map {
+              colName =>
+                val (srcIdx, tgtIdx) = fieldIndexByName(colName)
+                val srcVal = if (joinedRow.isNullAt(srcIdx)) None else Some(joinedRow.get(srcIdx))
+                val tgtVal = if (joinedRow.isNullAt(tgtIdx)) None else Some(joinedRow.get(tgtIdx))
+                s"$colName (source=${truncateValue(srcVal)}, target=${truncateValue(tgtVal)})"
+            }
+          val hashMismatch =
+            hasContentHashMismatch(joinedRow, contentHashFieldIndices, tsTol, floatTol)
+          if (directDifferingFields.isEmpty && !hashMismatch) None
+          else {
+            val srcPkValues = srcPKIndices.map { case (_, idx) => joinedRow.get(idx) }.toVector
+            val srcRepr =
+              srcPKIndices
+                .map { case (pk, idx) => s"$pk=${joinedRow.get(idx)}" }
+                .mkString(", ")
+            val tgtRepr =
+              tgtPKIndices
+                .map { case (pk, idx) => s"$pk=${joinedRow.get(idx)}" }
+                .mkString(", ")
+            Some(
+              MatchedRowValidationCandidate(
+                srcPkValues,
+                srcRepr,
+                tgtRepr,
+                directDifferingFields.toList,
+                hashMismatch
+              )
+            )
+          }
+        }
+      }
+
+    val sourceSideFailures = collectFailureSample(
+      candidateFailuresRdd,
+      rawSourceDF,
+      rawTargetDF,
+      renamedPK,
+      finalHashBackedColumns,
+      tsTol,
+      floatTol,
+      validationConfig.failuresToFetch
+    )
+    val failures =
+      if (
+        sourceSettings.where.isDefined || sourceSideFailures.size >= validationConfig.failuresToFetch
+      )
+        sourceSideFailures
+      else
+        sourceSideFailures ++ collectExtraTargetFailureSample(
+          rawSourceDF,
+          targetConnector,
+          targetTableDef,
+          targetSettings,
+          renamedPK,
+          validationConfig.failuresToFetch - sourceSideFailures.size
+        )
+    log.info(
+      s"Validation complete for ${sourceSettings.database}.${sourceSettings.table} -> " +
+        s"${targetSettings.keyspace}.${targetSettings.table}. " +
+        s"Collected ${failures.size} failure(s) in sample."
+    )
+
+    failures
+  }
+
+  private[scylla] def resolveHashBackedDifferences(
+    rawSourceDF: DataFrame,
+    rawTargetDF: DataFrame,
+    primaryKey: Seq[String],
+    primaryKeyValues: Seq[Vector[Any]],
+    hashBackedColumns: Seq[String],
+    timestampMsTolerance: Long,
+    floatingPointTolerance: Double
+  )(implicit spark: SparkSession): Map[Vector[Any], List[String]] = {
+    val refinementFrames =
+      createHashRefinementFrames(rawSourceDF, rawTargetDF, primaryKey, hashBackedColumns)
+    try
+      resolveHashBackedDifferences(
+        refinementFrames,
+        primaryKey,
+        primaryKeyValues,
+        hashBackedColumns,
+        timestampMsTolerance,
+        floatingPointTolerance
+      )
+    finally {
+      refinementFrames.source.unpersist(blocking = false)
+      refinementFrames.target.unpersist(blocking = false)
+    }
+  }
+
+  private def resolveHashBackedDifferences(
+    refinementFrames: HashRefinementFrames,
+    primaryKey: Seq[String],
+    primaryKeyValues: Seq[Vector[Any]],
+    hashBackedColumns: Seq[String],
+    timestampMsTolerance: Long,
+    floatingPointTolerance: Double
+  )(implicit spark: SparkSession): Map[Vector[Any], List[String]] = {
+    val projectedSource = refinementFrames.source
+    val projectedTarget = refinementFrames.target
+    val resolvedPrimaryKey = primaryKey.map(resolveFieldName(projectedSource.schema.fieldNames, _))
+    val primaryKeySchema = StructType(resolvedPrimaryKey.map(projectedSource.schema(_)))
+    val distinctPrimaryKeyValues = primaryKeyValues.distinctBy(normalizePrimaryKeyValues)
+    val keyRows = distinctPrimaryKeyValues.map(Row.fromSeq)
+    val keyDf = spark.createDataFrame(spark.sparkContext.parallelize(keyRows), primaryKeySchema)
+
+    val sourceLookup =
+      prefixColumns(keyDf.join(projectedSource, resolvedPrimaryKey, "inner"), "src_")
+    val targetLookup =
+      prefixColumns(keyDf.join(projectedTarget, resolvedPrimaryKey, "inner"), "tgt_")
+
+    val sourceLookupFields = sourceLookup.schema.fieldNames
+    val targetLookupFields = targetLookup.schema.fieldNames
+    val joinCondition = primaryKey
+      .map { pk =>
+        val srcCol = resolveFieldName(sourceLookupFields, s"src_$pk")
+        val tgtCol = resolveFieldName(targetLookupFields, s"tgt_$pk")
+        sparkColumn(srcCol) === sparkColumn(tgtCol)
+      }
+      .reduce(_ && _)
+    val joined = sourceLookup.join(targetLookup, joinCondition, "full_outer")
+    val joinedFields = joined.schema.fieldNames
+    val srcPKIndices = primaryKey.map { pk =>
+      joinedFields.indexOf(resolveFieldName(joinedFields, s"src_$pk"))
+    }.toArray
+    val tgtPKIndices = primaryKey.map { pk =>
+      joinedFields.indexOf(resolveFieldName(joinedFields, s"tgt_$pk"))
+    }.toArray
+    val hashBackedFieldIndices = hashBackedColumns.map { colName =>
+      val srcIdx = joinedFields.indexOf(resolveFieldName(joinedFields, s"src_$colName"))
+      val tgtIdx = joinedFields.indexOf(resolveFieldName(joinedFields, s"tgt_$colName"))
+      (colName, srcIdx, tgtIdx)
+    }
+
+    joined.rdd
+      .map { joinedRow =>
+        val srcNull = srcPKIndices.forall(joinedRow.isNullAt)
+        val tgtNull = tgtPKIndices.forall(joinedRow.isNullAt)
+        val rawPrimaryKeyValues =
+          if (!srcNull) srcPKIndices.map(joinedRow.get).toVector
+          else tgtPKIndices.map(joinedRow.get).toVector
+        val normalizedPrimaryKey = normalizePrimaryKeyValues(rawPrimaryKeyValues)
+        val differingFields =
+          if (srcNull || tgtNull)
+            List(
+              s"hashColumns(${hashBackedColumns.mkString(", ")}) " +
+                "(content hash mismatch; values fetched by PK could not be resolved)"
+            )
+          else
+            hashBackedFieldIndices.flatMap { case (colName, srcIdx, tgtIdx) =>
+              val srcVal = if (joinedRow.isNullAt(srcIdx)) None else Some(joinedRow.get(srcIdx))
+              val tgtVal = if (joinedRow.isNullAt(tgtIdx)) None else Some(joinedRow.get(tgtIdx))
+              if (
+                areDifferent(
+                  srcVal,
+                  tgtVal,
+                  timestampMsTolerance,
+                  floatingPointTolerance
+                )
+              )
+                Some(
+                  s"$colName (source=${truncateValue(srcVal)}, target=${truncateValue(tgtVal)})"
+                )
+              else None
+            }.toList
+        normalizedPrimaryKey -> differingFields
+      }
+      .collect()
+      .toMap
+  }
+
+  /** Add a `_content_hash` column to a DataFrame using per-column SHA-256 digests. Each column is
+    * cast to StringType then hashed with SHA-256, with `sha2("1|", 256)` used as the sentinel for
+    * null values so that every element in the concatenation is a fixed-width hex digest. The
+    * results are concatenated with '|' as separator and the whole concatenation is hashed again.
+    *
+    * This function is applied identically to both the MySQL-sourced DataFrame and the
+    * ScyllaDB-sourced DataFrame, ensuring that the same Spark code path produces the hash on both
+    * sides. This eliminates any risk of hash divergence due to differing string conversion rules
+    * between MySQL and Spark.
+    *
+    * After adding the hash, the original hashed columns are dropped from the DataFrame to reduce
+    * shuffle data volume during the join.
+    */
+  private[scylla] def addContentHash(
+    df: DataFrame,
+    hashCols: List[String],
+    pkCols: List[String],
+    dropHashedColumns: Boolean = true
+  ): DataFrame = {
+    val dfColsLower = df.columns.map(_.toLowerCase(Locale.ROOT)).toSet
+    require(
+      !dfColsLower.contains(MySQL.ContentHashColumn.toLowerCase(Locale.ROOT)),
+      s"Source/target table contains a column named '${MySQL.ContentHashColumn}' which conflicts " +
+        "with the internal hash column. Rename the column or disable hash-based validation."
+    )
+    val existingHashCols = hashCols.filter(c => dfColsLower.contains(c.toLowerCase(Locale.ROOT)))
+    if (existingHashCols.isEmpty) {
+      log.warn("No hash columns found in DataFrame. Skipping hash computation.")
+      df
+    } else {
+      // Resolve user-supplied column names against the actual DataFrame schema so that
+      // subsequent operations (col(), drop()) use the exact case from the schema rather
+      // than the user-supplied case. Spark's drop() is case-insensitive by default, but
+      // using resolved names makes the code robust against configuration changes.
+      val dfCols = df.columns
+      def resolveCol(name: String): String =
+        dfCols.find(_.equalsIgnoreCase(name)).getOrElse(name)
+      val resolvedHashCols =
+        existingHashCols.map(resolveCol).sortBy(_.toLowerCase(Locale.ROOT))
+
+      log.info(
+        s"Computing content hash for columns: ${resolvedHashCols.mkString(", ")}"
+      )
+
+      val contentHashBits = 256
+      val perColHashes = resolvedHashCols.map { c =>
+        val encodedValue = df.schema(c).dataType match {
+          case BinaryType => base64(sparkColumn(c))
+          case _          => sparkColumn(c).cast(StringType)
+        }
+        when(sparkColumn(c).isNull, sha2(lit("1|"), contentHashBits))
+          .otherwise(sha2(concat(lit("0|"), encodedValue), contentHashBits))
+      }
+      val hashCol = sha2(concat_ws("|", perColHashes: _*), contentHashBits)
+      val withHash = df.withColumn(MySQL.ContentHashColumn, hashCol)
+
+      if (!dropHashedColumns) withHash
+      else {
+        // Preserve primary key columns; drop only the hashed columns to reduce shuffle volume.
+        val pkColsLower = pkCols.map(_.toLowerCase(Locale.ROOT)).toSet
+        val colsToDrop = resolvedHashCols
+          .filterNot(c => pkColsLower.contains(c.toLowerCase(Locale.ROOT)))
+        colsToDrop.foldLeft(withHash) { (d, c) =>
+          d.drop(c)
+        }
+      }
+    }
+  }
+
+  private[scylla] def prefixColumns(df: DataFrame, prefix: String): DataFrame =
+    df.select(df.columns.toIndexedSeq.map(c => sparkColumn(c).as(s"$prefix$c")): _*)
+
+  private val MaxValueReprLength = 100
+
+  /** Truncate a value for inclusion in failure messages. */
+  private def truncateValue(value: Option[Any]): String = value match {
+    case None => "NULL"
+    case Some(v) =>
+      val repr = v match {
+        case arr: Array[Byte] => s"[${arr.length} bytes]"
+        case arr: Array[_]    => arr.mkString("[", ",", "]")
+        case other            => other.toString
+      }
+      if (repr.length > MaxValueReprLength) repr.take(MaxValueReprLength) + "..."
+      else repr
+  }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
@@ -79,6 +79,7 @@ trait ScyllaMigratorBase {
 
     log.info("Starting write...")
 
+    var caughtError: Option[Throwable] = None
     try {
       val tokenRangeAccumulator = maybeSavepointsManager.flatMap {
         case cqlManager: CqlSavepointsManager => Some(cqlManager.accumulator)
@@ -98,19 +99,33 @@ trait ScyllaMigratorBase {
           "Caught error while writing the DataFrame. Will create a savepoint before exiting",
           e
         )
+        caughtError = Some(e)
     } finally
       for (savePointsManger <- maybeSavepointsManager) {
-        savePointsManger.dumpMigrationState("final")
+        try
+          savePointsManger.dumpMigrationState("final")
+        catch {
+          case NonFatal(finallyEx) =>
+            caughtError.foreach(_.addSuppressed(finallyEx))
+            if (caughtError.isEmpty) caughtError = Some(finallyEx)
+        }
         if (shouldCloseManager(savePointsManger)) {
-          savePointsManger.close()
+          try
+            savePointsManger.close()
+          catch {
+            case NonFatal(closeEx) =>
+              caughtError.foreach(_.addSuppressed(closeEx))
+              if (caughtError.isEmpty) caughtError = Some(closeEx)
+          }
         }
       }
+    caughtError.foreach(throw _)
   }
 }
 
 object ScyllaMigrator extends ScyllaMigratorBase {
 
-  protected override def createSavepointsManager(
+  private[migrator] def savepointsManagerForSource(
     migratorConfig: MigratorConfig,
     sourceDF: SourceDataFrame
   )(implicit spark: SparkSession): Option[SavepointsManager] =
@@ -120,6 +135,12 @@ object ScyllaMigrator extends ScyllaMigratorBase {
       spark.sparkContext.register(tokenRangeAccumulator, "Token ranges copied")
       Some(CqlSavepointsManager(migratorConfig, tokenRangeAccumulator))
     }
+
+  protected override def createSavepointsManager(
+    migratorConfig: MigratorConfig,
+    sourceDF: SourceDataFrame
+  )(implicit spark: SparkSession): Option[SavepointsManager] =
+    savepointsManagerForSource(migratorConfig, sourceDF)
 
   protected override def shouldCloseManager(manager: SavepointsManager): Boolean = true
 

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaSparkConnectionOptions.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaSparkConnectionOptions.scala
@@ -1,0 +1,47 @@
+package com.scylladb.migrator.scylla
+
+import com.scylladb.migrator.Connectors
+import com.scylladb.migrator.config.TargetSettings
+
+/** Shared construction of Spark Cassandra Connector config options from [[TargetSettings.Scylla]].
+  * This ensures consistent defaults (SSL store types, protocol, enabled cipher suites, etc.)
+  * regardless of whether the options are used by the migrator, the Cassandra-to-Scylla validator,
+  * or the MySQL-to-Scylla validator.
+  *
+  * The defaults here mirror those in [[com.scylladb.migrator.Connectors]] which builds
+  * `CassandraConnectorConf` objects with the same values.
+  */
+object ScyllaSparkConnectionOptions {
+  val MySQLValidatorCluster = "mysql_validator_target"
+
+  private val InputConsistencyLevel = "spark.cassandra.input.consistency.level"
+
+  private def scopeToCluster(cluster: String, options: Map[String, String]): Map[String, String] =
+    options.map { case (key, value) => s"$cluster/$key" -> value }
+
+  /** Build connector session configuration for a dedicated Spark Cassandra cluster alias.
+    *
+    * These settings intentionally exclude table-selection properties so that credentials and SSL
+    * secrets do not need to be passed through DataFrame reader options.
+    */
+  def sessionConfFromTargetSettings(
+    t: TargetSettings.Scylla,
+    cluster: String = MySQLValidatorCluster
+  ): Map[String, String] = {
+    val sessionConf =
+      Connectors.sparkSessionOptions(Connectors.targetSessionOptions(t)) +
+        (InputConsistencyLevel -> t.consistencyLevel)
+    scopeToCluster(cluster, sessionConf)
+  }
+
+  /** Build the non-sensitive DataFrame reader options for the validator's Cassandra scan. */
+  def readerOptionsFromTargetSettings(
+    t: TargetSettings.Scylla,
+    cluster: String = MySQLValidatorCluster
+  ): Map[String, String] =
+    Map(
+      "keyspace" -> t.keyspace,
+      "table"    -> t.table,
+      "cluster"  -> cluster
+    )
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala
@@ -32,6 +32,12 @@ object ScyllaValidator {
         sys.error("Missing required property 'validation' in the configuration file.")
       )
 
+    validationConfig.hashColumns.foreach { _ =>
+      log.warn(
+        "hashColumns is only supported for MySQL-to-ScyllaDB validation and will be ignored."
+      )
+    }
+
     val sourceConnector: CassandraConnector =
       Connectors.sourceConnector(spark.sparkContext.getConf, sourceSettings)
     val targetConnector: CassandraConnector =
@@ -102,12 +108,21 @@ object ScyllaValidator {
       val joinKey = (sourceTableDef.partitionKey ++ sourceTableDef.clusteringColumns)
         .map(colDef => ColumnName(config.renamesMap(colDef.columnName)))
 
+      val targetConsistencyLevel =
+        ConsistencyLevelUtils.parseConsistencyLevel(targetSettings.consistencyLevel)
+      log.info(
+        s"Using consistencyLevel [${targetConsistencyLevel}] for VALIDATOR TARGET based on target config [${targetSettings.consistencyLevel}]"
+      )
+
       source
         .leftJoinWithCassandraTable(
           targetSettings.keyspace,
           targetSettings.table,
           SomeColumns(primaryKeyProjection ++ regularColumnsProjection: _*),
-          SomeColumns(joinKey: _*)
+          SomeColumns(joinKey: _*),
+          readConf = ReadConf
+            .fromSparkConf(spark.sparkContext.getConf)
+            .copy(consistencyLevel = targetConsistencyLevel)
         )
         .withConnector(targetConnector)
     }

--- a/migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala
@@ -6,26 +6,46 @@ import com.scylladb.migrator.alternator.DdbValue
 
 import java.time.temporal.ChronoUnit
 
+/** Represents a single row comparison failure found during validation.
+  *
+  * @param rowRepr
+  *   For most failure types this is the source row's PK representation. For [[Item.ExtraTargetRow]]
+  *   failures, it holds the target row's PK (since no source row exists); the `toString` method
+  *   adjusts the labels accordingly.
+  * @param otherRepr
+  *   The target row's PK representation, or `None` when the target row is missing (or when the
+  *   failure is [[Item.ExtraTargetRow]]).
+  * @param items
+  *   The list of comparison failure details.
+  */
 case class RowComparisonFailure(
   rowRepr: String,
   otherRepr: Option[String],
   items: List[RowComparisonFailure.Item]
 ) {
 
-  override def toString: String =
+  override def toString: String = {
+    val isExtraTarget = items.contains(RowComparisonFailure.Item.ExtraTargetRow)
+    val (srcLabel, tgtLabel) =
+      if (isExtraTarget)
+        ("<N/A - row only exists in target>", rowRepr)
+      else
+        (rowRepr, otherRepr.getOrElse("<MISSING>"))
     s"""
        |Row failure:
-       |* Source row: ${rowRepr}
-       |* Target row: ${otherRepr.getOrElse("<MISSING>")}
+       |* Source row: ${srcLabel}
+       |* Target row: ${tgtLabel}
        |* Failures:
        |${items.map(item => s"  - ${item.description}").mkString("\n")}
      """.stripMargin
+  }
 }
 
 object RowComparisonFailure {
   sealed abstract class Item(val description: String) extends Serializable
   object Item {
     case object MissingTargetRow extends Item("Missing target row")
+    case object ExtraTargetRow extends Item("Extra target row (not present in source)")
     case object MismatchedColumnCount extends Item("Mismatched column count")
     case object MismatchedColumnNames extends Item("Mismatched column names")
     case class DifferingFieldValues(fields: List[String])
@@ -202,16 +222,22 @@ object RowComparisonFailure {
     * @return
     *   `true` if the `leftValue` is different from the `rightValue`
     */
-  private def areDifferent(
+  private[migrator] def areDifferent(
     leftValue: Option[Any],
     rightValue: Option[Any],
     timestampMsTolerance: Long,
     floatingPointTolerance: Double
   ): Boolean =
-    (rightValue, leftValue) match {
+    (leftValue, rightValue) match {
       // All timestamp types need to be compared with a configured tolerance
+      case (Some(l: java.sql.Timestamp), Some(r: java.sql.Timestamp)) if timestampMsTolerance > 0 =>
+        Math.abs(l.getTime - r.getTime) > timestampMsTolerance
+      case (Some(l: java.sql.Timestamp), Some(r: java.sql.Timestamp)) =>
+        l.getTime != r.getTime || l.getNanos != r.getNanos
       case (Some(l: java.time.Instant), Some(r: java.time.Instant)) if timestampMsTolerance > 0 =>
         Math.abs(r.until(l, ChronoUnit.MILLIS)) > timestampMsTolerance
+      case (Some(l: java.time.Instant), Some(r: java.time.Instant)) =>
+        l != r
       // All floating-point-like types need to be compared with a configured tolerance
       case (Some(l: Float), Some(r: Float)) =>
         !DoubleMath.fuzzyEquals(l, r, floatingPointTolerance)
@@ -224,6 +250,8 @@ object RowComparisonFailure {
       // byte buffers are converted to byte arrays by the Spark connector.
       // Arrays can't be compared with standard equality and must be compared
       // with `sameElements`.
+      case (Some(l: Array[Byte]), Some(r: Array[Byte])) =>
+        !java.util.Arrays.equals(l, r)
       case (Some(l: Array[_]), Some(r: Array[_])) =>
         !l.sameElements(r)
 
@@ -259,5 +287,4 @@ object RowComparisonFailure {
     tolerance: BigDecimal
   ): Boolean =
     (x - y).abs > tolerance
-
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -71,6 +71,28 @@ object Scylla {
       )
     }
 
+  private[writers] def requireNoCaseInsensitiveColumnNameCollisions(
+    fieldNames: Seq[String],
+    context: String
+  ): Unit = {
+    val collisions =
+      fieldNames
+        .groupBy(_.toLowerCase(Locale.ROOT))
+        .collect { case (_, names) if names.size > 1 => names.distinct }
+        .toList
+
+    if (collisions.nonEmpty) {
+      val collisionDetails = collisions
+        .map(names => names.mkString("[", ", ", "]"))
+        .mkString(", ")
+      throw new IllegalArgumentException(
+        s"Column name collision detected $context. " +
+          s"Multiple source columns resolve to the same target column name: $collisionDetails. " +
+          "Check the configured renames and source schema."
+      )
+    }
+  }
+
   private[writers] def dropRowsWithNullPrimaryKeys(
     rdd: RDD[Row],
     pkFieldIndices: Array[Int],
@@ -175,6 +197,10 @@ object Scylla {
         acc.withColumnRenamed(from, to)
       }
       .schema
+    requireNoCaseInsensitiveColumnNameCollisions(
+      renamedSchema.fieldNames.toSeq,
+      "after applying renames before writing to ScyllaDB"
+    )
 
     log.info("Schema after renames:")
     log.info(renamedSchema.treeString)

--- a/tests/src/test/configurations/mysql-to-scylla-basic.yaml
+++ b/tests/src/test/configurations/mysql-to-scylla-basic.yaml
@@ -1,0 +1,44 @@
+# Integration-test configuration for MySQL-to-ScyllaDB migration.
+# The hosts below (mysql, scylla) are Docker Compose service names and are remapped to
+# localhost by SparkUtils when the test suite runs in-process.
+
+source:
+  type: mysql
+  host: mysql
+  port: 3306
+  database: testdb
+  table: users
+  credentials:
+    username: migrator
+    password: migrator
+  primaryKey:
+    - id
+  partitionColumn: created_at
+  numPartitions: 2
+  lowerBound: "2024-01-01 00:00:00"
+  upperBound: "2024-02-01 00:00:00"
+  fetchSize: 100
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: users
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+validation:
+  compareTimestamps: false
+  ttlToleranceMillis: 0
+  writetimeToleranceMillis: 0
+  failuresToFetch: 100
+  floatingPointTolerance: 0.001
+  timestampMsTolerance: 1000
+  hashColumns:
+    - payload

--- a/tests/src/test/configurations/mysql-to-scylla-filtered.yaml
+++ b/tests/src/test/configurations/mysql-to-scylla-filtered.yaml
@@ -1,0 +1,45 @@
+# Integration-test configuration for filtered MySQL-to-ScyllaDB validation.
+# The hosts below (mysql, scylla) are Docker Compose service names and are remapped to
+# localhost by SparkUtils when the test suite runs in-process.
+
+source:
+  type: mysql
+  host: mysql
+  port: 3306
+  database: testdb
+  table: users_filtered
+  credentials:
+    username: migrator
+    password: migrator
+  primaryKey:
+    - id
+  partitionColumn: created_at
+  numPartitions: 2
+  lowerBound: "2024-01-01 00:00:00"
+  upperBound: "2024-02-01 00:00:00"
+  fetchSize: 100
+  where: "created_at < '2024-01-15 00:00:00'"
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: users_filtered
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+validation:
+  compareTimestamps: false
+  ttlToleranceMillis: 0
+  writetimeToleranceMillis: 0
+  failuresToFetch: 100
+  floatingPointTolerance: 0.001
+  timestampMsTolerance: 1000
+  hashColumns:
+    - payload

--- a/tests/src/test/configurations/mysql-to-scylla-large-blobs.yaml
+++ b/tests/src/test/configurations/mysql-to-scylla-large-blobs.yaml
@@ -1,0 +1,63 @@
+# Example configuration for migrating MySQL tables with large BLOB columns (up to 100MB+).
+# This is NOT used by automated tests. It serves as a reference template for operators.
+# The hosts below (mysql-host, scylla-host) are placeholders that must be replaced with
+# actual hostnames or Docker Compose service names.
+#
+# Required ScyllaDB cluster settings (scylla.yaml):
+#   commitlog_segment_size_in_mb: 256
+#   compaction_large_row_warning_threshold_mb: 128
+#   compaction_large_cell_warning_threshold_mb: 128
+#
+# Recommended spark-submit settings:
+#   --conf spark.executor.memory=8g
+#   --conf spark.driver.memory=4g
+#   --conf spark.kryoserializer.buffer.max=128m
+#   --conf spark.cassandra.output.batch.size.bytes=1
+#   --conf spark.cassandra.output.batch.grouping.key=none
+#   --conf spark.cassandra.output.concurrent.writes=2
+
+source:
+  type: mysql
+  host: mysql-host
+  port: 3306
+  database: mydb
+  table: documents
+  credentials:
+    username: migrator
+    password: secret
+  primaryKey:
+    - id
+  partitionColumn: id
+  numPartitions: 200
+  lowerBound: 0
+  upperBound: 100000000
+  # Keep fetchSize low for BLOB-heavy tables to limit memory per batch.
+  fetchSize: 100
+  # Override maxAllowedPacket if your BLOBs exceed 256MB (default).
+  # connectionProperties:
+  #   maxAllowedPacket: "536870912"
+
+target:
+  type: scylla
+  host: scylla-host
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: scylla_user
+    password: scylla_pass
+  keyspace: myks
+  table: documents
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+validation:
+  compareTimestamps: false
+  ttlToleranceMillis: 0
+  writetimeToleranceMillis: 0
+  failuresToFetch: 100
+  floatingPointTolerance: 0.001
+  timestampMsTolerance: 1000
+  hashColumns:
+    - content
+    - content_html

--- a/tests/src/test/configurations/mysql-to-scylla-numeric.yaml
+++ b/tests/src/test/configurations/mysql-to-scylla-numeric.yaml
@@ -1,0 +1,44 @@
+# Integration-test configuration for MySQL-to-ScyllaDB migration using numeric partitioning.
+# The hosts below (mysql, scylla) are Docker Compose service names and are remapped to
+# localhost by SparkUtils when the test suite runs in-process.
+
+source:
+  type: mysql
+  host: mysql
+  port: 3306
+  database: testdb
+  table: users_numeric
+  credentials:
+    username: migrator
+    password: migrator
+  primaryKey:
+    - id
+  partitionColumn: id
+  numPartitions: 4
+  lowerBound: 0
+  upperBound: 1000
+  fetchSize: 200
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: users_numeric
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+validation:
+  compareTimestamps: false
+  ttlToleranceMillis: 0
+  writetimeToleranceMillis: 0
+  failuresToFetch: 100
+  floatingPointTolerance: 0.001
+  timestampMsTolerance: 1000
+  hashColumns:
+    - payload

--- a/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
@@ -56,6 +56,15 @@ object SparkUtils {
       .getOrCreate()
   }
 
+  /** Run a block with a SparkSession sharing the suite SparkContext but isolated SQL state. */
+  def withSparkSession[A](
+    extraConfigs: Map[String, String] = Map.empty
+  )(f: SparkSession => A): A = {
+    val session = spark.newSession()
+    extraConfigs.foreach { case (key, value) => session.conf.set(key, value) }
+    f(session)
+  }
+
   /** Run a migration by loading the config, remapping for local execution, and running in-process.
     *
     * @param migratorConfigFile
@@ -133,6 +142,11 @@ object SparkUtils {
     "scylla-source" -> 9044
   )
 
+  /** Map from Docker Compose MySQL hostnames to the exposed localhost port. */
+  private val mysqlHostPortMap: Map[String, Int] = Map(
+    "mysql" -> 3308
+  )
+
   /** Map from Docker Compose DynamoDB-protocol endpoint to (host, port) on localhost. */
   private val dynamoEndpointMap: Map[(String, Int), (String, Int)] = Map(
     ("http://dynamodb", 8000) -> ("http://localhost", 8001),
@@ -155,6 +169,11 @@ object SparkUtils {
         )
       case s: SourceSettings.DynamoDBS3Export =>
         s.copy(endpoint = s.endpoint.map(remapEndpoint))
+      case m: SourceSettings.MySQL =>
+        m.copy(
+          host = "localhost",
+          port = mysqlHostPortMap.getOrElse(m.host, m.port)
+        )
     }
     val newTarget = config.target match {
       case s: TargetSettings.Scylla =>

--- a/tests/src/test/scala/com/scylladb/migrator/ValidatorLoggingTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/ValidatorLoggingTest.scala
@@ -1,0 +1,61 @@
+package com.scylladb.migrator
+
+import com.scylladb.migrator.config.{
+  Credentials,
+  MigratorConfig,
+  Savepoints,
+  SourceSettings,
+  TargetSettings
+}
+
+class ValidatorLoggingTest extends munit.FunSuite {
+
+  test("loadedConfigLogMessage redacts source and target secrets") {
+    val config = MigratorConfig(
+      source = SourceSettings.MySQL(
+        host                 = "mysql.example.com",
+        port                 = 3306,
+        database             = "app",
+        table                = "users",
+        credentials          = Credentials("mysql-user", "mysql-secret"),
+        primaryKey           = Some(List("id")),
+        partitionColumn      = None,
+        numPartitions        = None,
+        lowerBound           = None,
+        upperBound           = None,
+        fetchSize            = 1000,
+        where                = Some("email = 'user@example.com'"),
+        connectionProperties = Some(Map("trustStorePassword" -> "tls-secret"))
+      ),
+      target = TargetSettings.Scylla(
+        host                          = "scylla.example.com",
+        port                          = 9042,
+        localDC                       = Some("dc1"),
+        credentials                   = Some(Credentials("scylla-user", "scylla-secret")),
+        sslOptions                    = None,
+        keyspace                      = "ks",
+        table                         = "users",
+        connections                   = Some(4),
+        stripTrailingZerosForDecimals = false,
+        writeTTLInS                   = None,
+        writeWritetimestampInuS       = None,
+        consistencyLevel              = "LOCAL_QUORUM"
+      ),
+      renames          = None,
+      savepoints       = Savepoints(300, "/tmp/savepoints"),
+      skipTokenRanges  = None,
+      skipSegments     = None,
+      skipParquetFiles = None,
+      validation       = None
+    )
+
+    val logMessage = Validator.loadedConfigLogMessage(config)
+
+    assert(logMessage.startsWith("Loaded config:\n"))
+    assert(logMessage.contains("<redacted>"))
+    assert(!logMessage.contains("mysql-secret"))
+    assert(!logMessage.contains("scylla-secret"))
+    assert(!logMessage.contains("tls-secret"))
+    assert(!logMessage.contains("user@example.com"))
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/config/MySQLSourceSettingsParserTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/MySQLSourceSettingsParserTest.scala
@@ -1,0 +1,1511 @@
+package com.scylladb.migrator.config
+
+import io.circe.Json
+import io.circe.yaml
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.Locale
+
+class MySQLSourceSettingsParserTest extends munit.FunSuite {
+
+  test("valid MySQL source config with all fields") {
+    val config =
+      """type: mysql
+        |host: db.example.com
+        |port: 3306
+        |database: mydb
+        |table: users
+        |credentials:
+        |  username: admin
+        |  password: secret
+        |primaryKey:
+        |  - id
+        |fetchSize: 500
+        |""".stripMargin
+
+    val result = parseSourceSettings(config)
+    assertEquals(result.host, "db.example.com")
+    assertEquals(result.port, 3306)
+    assertEquals(result.database, "mydb")
+    assertEquals(result.table, "users")
+    assertEquals(result.credentials.username, "admin")
+    assertEquals(result.credentials.password, "secret")
+    assertEquals(result.primaryKey, Some(List("id")))
+    assertEquals(result.fetchSize, 500)
+    assertEquals(result.where, None)
+    assertEquals(result.connectionProperties, None)
+    assertEquals(result.partitionColumn, None)
+    assertEquals(result.numPartitions, None)
+    assertEquals(result.lowerBound, None)
+    assertEquals(result.upperBound, None)
+    assertEquals(result.zeroDateTimeBehavior, SourceSettings.MySQL.ZeroDateTimeBehavior.Exception)
+  }
+
+  test("valid MySQL source config with optional fields") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3307
+        |database: testdb
+        |table: orders
+        |credentials:
+        |  username: root
+        |  password: "rootpass"
+        |fetchSize: 1000
+        |where: "status = 'active'"
+        |partitionColumn: id
+        |numPartitions: 4
+        |lowerBound: 0
+        |upperBound: 10000
+        |connectionProperties:
+        |  connectTimeout: "5000"
+        |  socketTimeout: "30000"
+        |""".stripMargin
+
+    val result = parseSourceSettings(config)
+    assertEquals(result.host, "localhost")
+    assertEquals(result.port, 3307)
+    assertEquals(result.where, Some("status = 'active'"))
+    assertEquals(result.partitionColumn, Some("id"))
+    assertEquals(result.numPartitions, Some(4))
+    assertEquals(result.lowerBound, Some(SourceSettings.MySQL.PartitionBound("0")))
+    assertEquals(result.upperBound, Some(SourceSettings.MySQL.PartitionBound("10000")))
+    assertEquals(
+      result.connectionProperties,
+      Some(Map("connectTimeout" -> "5000", "socketTimeout" -> "30000"))
+    )
+  }
+
+  test(
+    "valid MySQL source config supports temporal partition bounds and explicit zero-date policy"
+  ) {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: testdb
+        |table: events
+        |credentials:
+        |  username: root
+        |  password: "rootpass"
+        |partitionColumn: created_at
+        |numPartitions: 2
+        |lowerBound: "2024-01-01 00:00:00"
+        |upperBound: "2024-01-02 00:00:00"
+        |zeroDateTimeBehavior: CONVERT_TO_NULL
+        |""".stripMargin
+
+    val result = parseSourceSettings(config)
+    assertEquals(
+      result.lowerBound,
+      Some(SourceSettings.MySQL.PartitionBound("2024-01-01 00:00:00"))
+    )
+    assertEquals(
+      result.upperBound,
+      Some(SourceSettings.MySQL.PartitionBound("2024-01-02 00:00:00"))
+    )
+    assertEquals(
+      result.zeroDateTimeBehavior,
+      SourceSettings.MySQL.ZeroDateTimeBehavior.ConvertToNull
+    )
+  }
+
+  test("valid MySQL source config accepts same-day timestamp partition bounds") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: testdb
+        |table: events
+        |credentials:
+        |  username: root
+        |  password: "rootpass"
+        |partitionColumn: created_at
+        |numPartitions: 2
+        |lowerBound: "2024-01-01 00:00:00"
+        |upperBound: "2024-01-01 12:00:00"
+        |""".stripMargin
+
+    val result = parseSourceSettings(config)
+    assertEquals(
+      result.lowerBound,
+      Some(SourceSettings.MySQL.PartitionBound("2024-01-01 00:00:00"))
+    )
+    assertEquals(
+      result.upperBound,
+      Some(SourceSettings.MySQL.PartitionBound("2024-01-01 12:00:00"))
+    )
+  }
+
+  test("MySQL source config without optional primaryKey") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |""".stripMargin
+
+    val result = parseSourceSettings(config)
+    assertEquals(result.primaryKey, None)
+  }
+
+  test("invalid MySQL primaryKey values fail at parse time") {
+    List(
+      ("[]", "at least one"),
+      ("""[" "]""", "blank"),
+      ("[id, ID]", "duplicate")
+    ).foreach { case (primaryKeyYaml, expectedError) =>
+      val config =
+        s"""type: mysql
+           |host: localhost
+           |port: 3306
+           |database: mydb
+           |table: data
+           |credentials:
+           |  username: user
+           |  password: pass
+           |primaryKey: $primaryKeyYaml
+           |fetchSize: 100
+           |""".stripMargin
+
+      val parsed = yaml.parser
+        .parse(config)
+        .flatMap(_.as[SourceSettings])
+      assert(parsed.isLeft, s"Should fail for primaryKey: $primaryKeyYaml")
+      assert(parsed.left.exists(_.getMessage.contains(expectedError)))
+    }
+  }
+
+  test("MySQL source config missing required credentials fails") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |fetchSize: 100
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail without credentials")
+  }
+
+  test("invalid zeroDateTimeBehavior fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |zeroDateTimeBehavior: INVALID
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail on an unsupported zeroDateTimeBehavior value")
+  }
+
+  test("dangerous connectionProperties stay blocked under Turkish default locale") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |connectionProperties:
+        |  allowLoadLocalInfile: "true"
+        |""".stripMargin
+
+    val parsed = withDefaultLocale(new Locale("tr", "TR")) {
+      yaml.parser
+        .parse(config)
+        .flatMap(_.as[SourceSettings])
+    }
+
+    assert(parsed.isLeft, "Should reject blocked keys regardless of default locale")
+    assert(parsed.left.exists(_.getMessage.contains("blocked security-sensitive keys")))
+  }
+
+  test("partitionColumn without numPartitions fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |partitionColumn: id
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when partitionColumn is set without numPartitions")
+  }
+
+  test("numPartitions without partitionColumn fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |numPartitions: 4
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when numPartitions is set without partitionColumn")
+  }
+
+  test("partition bounds without partitioning fail at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |lowerBound: 0
+        |upperBound: 100
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when bounds are set without partitioning")
+    assert(parsed.left.exists(_.getMessage.contains("lowerBound and upperBound")))
+  }
+
+  test("partitioned read without bounds fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |partitionColumn: id
+        |numPartitions: 4
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when partitioned read is configured without bounds")
+  }
+
+  test("lowerBound >= upperBound fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |partitionColumn: id
+        |numPartitions: 4
+        |lowerBound: 100
+        |upperBound: 50
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when lowerBound >= upperBound")
+  }
+
+  test("lowerBound == upperBound fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |partitionColumn: id
+        |numPartitions: 4
+        |lowerBound: 100
+        |upperBound: 100
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when lowerBound == upperBound")
+  }
+
+  test("DATE lowerBound after upperBound fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |partitionColumn: created_on
+        |numPartitions: 4
+        |lowerBound: "2024-02-01"
+        |upperBound: "2024-01-01"
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when DATE lowerBound >= upperBound")
+  }
+
+  test("TIMESTAMP lowerBound equal to upperBound fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |partitionColumn: created_at
+        |numPartitions: 4
+        |lowerBound: "2024-01-01 12:00:00"
+        |upperBound: "2024-01-01 12:00:00"
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when TIMESTAMP lowerBound >= upperBound")
+  }
+
+  test("port 0 fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 0
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when port is 0")
+  }
+
+  test("port 70000 fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 70000
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when port is out of range")
+  }
+
+  test("fetchSize 0 fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 0
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when fetchSize is 0")
+  }
+
+  test("negative fetchSize fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: -1
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when fetchSize is negative")
+  }
+
+  test("numPartitions 0 fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |partitionColumn: id
+        |numPartitions: 0
+        |lowerBound: 0
+        |upperBound: 100
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when numPartitions is 0")
+  }
+
+  test("negative numPartitions fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |partitionColumn: id
+        |numPartitions: -1
+        |lowerBound: 0
+        |upperBound: 100
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when numPartitions is negative")
+  }
+
+  test("partitionColumn with SQL injection characters fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |partitionColumn: "id; DROP TABLE users --"
+        |numPartitions: 4
+        |lowerBound: 0
+        |upperBound: 100
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when partitionColumn contains invalid characters")
+  }
+
+  test("backtick-quoted partitionColumn with embedded newline fails at parse time") {
+    // A newline inside a backtick-quoted identifier is syntactically invalid in MySQL and
+    // could be used to smuggle a second SQL statement into the JDBC partition column path.
+    // The YAML \n escape in a double-quoted scalar produces a real newline character.
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |partitionColumn: "`col\nAND 1=1`"
+        |numPartitions: 4
+        |lowerBound: 0
+        |upperBound: 100
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when backtick-quoted partitionColumn contains a newline")
+  }
+
+  test("partitionColumn with valid identifier passes") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |partitionColumn: user_id
+        |numPartitions: 4
+        |lowerBound: 0
+        |upperBound: 100
+        |""".stripMargin
+
+    val result = parseSourceSettings(config)
+    assertEquals(result.partitionColumn, Some("user_id"))
+  }
+
+  test("partitionColumn with backtick-quoted identifier passes") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |partitionColumn: "`1column`"
+        |numPartitions: 4
+        |lowerBound: 0
+        |upperBound: 100
+        |""".stripMargin
+
+    val result = parseSourceSettings(config)
+    assertEquals(result.partitionColumn, Some("`1column`"))
+  }
+
+  test("empty backtick-quoted partitionColumn fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100
+        |partitionColumn: "``"
+        |numPartitions: 4
+        |lowerBound: 0
+        |upperBound: 100
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when backtick-quoted partitionColumn is empty")
+  }
+
+  test("fetchSize defaults to 1000 when omitted") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |""".stripMargin
+
+    val result = parseSourceSettings(config)
+    assertEquals(result.fetchSize, 1000)
+  }
+
+  test("empty host fails at parse time") {
+    val config =
+      """type: mysql
+        |host: ""
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when host is empty")
+  }
+
+  test("empty database fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: ""
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when database is empty")
+  }
+
+  test("empty table fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: ""
+        |credentials:
+        |  username: user
+        |  password: pass
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when table is empty")
+  }
+
+  test("table with control characters (newline) fails at parse time") {
+    val parsed = yaml.parser
+      .parse(
+        "type: mysql\nhost: localhost\nport: 3306\ndatabase: mydb\ntable: \"bad\\ntable\"\n" +
+          "credentials:\n  username: user\n  password: pass\n"
+      )
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when table name contains control characters")
+  }
+
+  test("table with invalid characters (semicolon) fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: "bad;table"
+        |credentials:
+        |  username: user
+        |  password: pass
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when table name contains semicolon")
+  }
+
+  test("table name with dollar sign and underscore passes") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: my_table$1
+        |credentials:
+        |  username: user
+        |  password: pass
+        |""".stripMargin
+
+    val result = parseSourceSettings(config)
+    assertEquals(result.table, "my_table$1")
+  }
+
+  test("empty username fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: ""
+        |  password: pass
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when username is empty")
+  }
+
+  test("empty password fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: ""
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when password is empty")
+  }
+
+  test("host with invalid characters fails at parse time") {
+    val config =
+      """type: mysql
+        |host: "db.com/evil"
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when host contains URL metacharacters")
+  }
+
+  test("database with invalid characters fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: "my/db"
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when database contains invalid characters")
+  }
+
+  test("where clause with control characters fails at parse time") {
+    val parsed = yaml.parser
+      .parse(
+        "type: mysql\nhost: localhost\nport: 3306\ndatabase: mydb\ntable: data\n" +
+          "credentials:\n  username: user\n  password: pass\n" +
+          "where: \"status = 'active'\\n--\"\n"
+      )
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when where clause contains control characters")
+  }
+
+  test("fetchSize larger than 100000 fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |fetchSize: 100001
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when fetchSize is larger than 100000")
+  }
+
+  test("IPv6 host in brackets passes") {
+    val config =
+      """type: mysql
+        |host: "[2001:db8::1]"
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |""".stripMargin
+
+    val result = parseSourceSettings(config)
+    assertEquals(result.host, "[2001:db8::1]")
+  }
+
+  test("connectionProperties with dangerous key fails at parse time") {
+    List(
+      "allowLoadLocalInFile",
+      "allowLoadLocalInfileInPath"
+    ).foreach { dangerousKey =>
+      val config =
+        s"""type: mysql
+           |host: localhost
+           |port: 3306
+           |database: mydb
+           |table: data
+           |credentials:
+           |  username: user
+           |  password: pass
+           |connectionProperties:
+           |  $dangerousKey: "true"
+           |""".stripMargin
+
+      val parsed = yaml.parser
+        .parse(config)
+        .flatMap(_.as[SourceSettings])
+      assert(
+        parsed.isLeft,
+        s"Should fail when connectionProperties contains dangerous key $dangerousKey"
+      )
+    }
+  }
+
+  test("connectionProperties with safe keys passes at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |connectionProperties:
+        |  connectTimeout: "5000"
+        |  socketTimeout: "30000"
+        |""".stripMargin
+
+    val result = parseSourceSettings(config)
+    assertEquals(
+      result.connectionProperties,
+      Some(Map("connectTimeout" -> "5000", "socketTimeout" -> "30000"))
+    )
+  }
+
+  test("connectionProperties with injected connectTimeout fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |connectionProperties:
+        |  connectTimeout: "5000&allowLoadLocalInfile=true"
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when connectTimeout contains injected URL parameters")
+  }
+
+  test("connectionProperties with injected socketTimeout fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |connectionProperties:
+        |  socketTimeout: "600000&allowMultiQueries=true"
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when socketTimeout contains injected URL parameters")
+  }
+
+  test("connectionProperties with zero timeouts pass at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |connectionProperties:
+        |  connectTimeout: "0"
+        |  socketTimeout: "0"
+        |""".stripMargin
+
+    val result = parseSourceSettings(config)
+    assertEquals(
+      result.connectionProperties,
+      Some(Map("connectTimeout" -> "0", "socketTimeout" -> "0"))
+    )
+  }
+
+  test("empty where clause fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |where: ""
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when where clause is empty")
+  }
+
+  test("blank where clause fails at parse time") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: pass
+        |where: "   "
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when where clause is blank")
+  }
+
+  test("redacted password fails at parse time with savepoint hint") {
+    val config =
+      """type: mysql
+        |host: localhost
+        |port: 3306
+        |database: mydb
+        |table: data
+        |credentials:
+        |  username: user
+        |  password: "<redacted>"
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[SourceSettings])
+    assert(parsed.isLeft, "Should fail when password is '<redacted>'")
+    assert(
+      parsed.left.exists(_.getMessage.contains("savepoint")),
+      "Error message should mention savepoint file"
+    )
+  }
+
+  private def parseSourceSettings(yamlContent: String): SourceSettings.MySQL =
+    yaml.parser
+      .parse(yamlContent)
+      .flatMap(_.as[SourceSettings]) match {
+      case Left(error)                         => throw error
+      case Right(source: SourceSettings.MySQL) => source
+      case Right(other) => fail(s"Expected MySQL settings but got ${other.getClass.getSimpleName}")
+    }
+
+  private def withDefaultLocale[A](locale: Locale)(f: => A): A = {
+    val original = Locale.getDefault
+    Locale.setDefault(locale)
+    try f
+    finally Locale.setDefault(original)
+  }
+}
+
+class ValidationConfigParserTest extends munit.FunSuite {
+
+  test("Validation config without hashColumns uses default None") {
+    val config =
+      """compareTimestamps: true
+        |ttlToleranceMillis: 60000
+        |writetimeToleranceMillis: 1000
+        |failuresToFetch: 100
+        |floatingPointTolerance: 0.001
+        |timestampMsTolerance: 0
+        |""".stripMargin
+
+    val result = parseValidation(config)
+    assertEquals(result.hashColumns, None)
+    assertEquals(result.compareTimestamps, true)
+    assertEquals(result.failuresToFetch, 100)
+  }
+
+  test("Validation config with hashColumns") {
+    val config =
+      """compareTimestamps: false
+        |ttlToleranceMillis: 0
+        |writetimeToleranceMillis: 0
+        |failuresToFetch: 50
+        |floatingPointTolerance: 0.0
+        |timestampMsTolerance: 100
+        |hashColumns:
+        |  - data_blob
+        |  - large_text
+        |""".stripMargin
+
+    val result = parseValidation(config)
+    assertEquals(result.hashColumns, Some(List("data_blob", "large_text")))
+    assertEquals(result.timestampMsTolerance, 100L)
+  }
+
+  test("Validation config with empty hashColumns") {
+    val config =
+      """compareTimestamps: false
+        |ttlToleranceMillis: 0
+        |writetimeToleranceMillis: 0
+        |failuresToFetch: 10
+        |floatingPointTolerance: 0.0
+        |timestampMsTolerance: 0
+        |hashColumns: []
+        |""".stripMargin
+
+    val result = parseValidation(config)
+    assertEquals(result.hashColumns, Some(Nil))
+  }
+
+  test("failuresToFetch 0 fails at parse time") {
+    val config =
+      """compareTimestamps: false
+        |ttlToleranceMillis: 0
+        |writetimeToleranceMillis: 0
+        |failuresToFetch: 0
+        |floatingPointTolerance: 0.0
+        |timestampMsTolerance: 0
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[Validation])
+    assert(parsed.isLeft, "Should fail when failuresToFetch is 0")
+  }
+
+  test("negative failuresToFetch fails at parse time") {
+    val config =
+      """compareTimestamps: false
+        |ttlToleranceMillis: 0
+        |writetimeToleranceMillis: 0
+        |failuresToFetch: -1
+        |floatingPointTolerance: 0.0
+        |timestampMsTolerance: 0
+        |""".stripMargin
+
+    val parsed = yaml.parser
+      .parse(config)
+      .flatMap(_.as[Validation])
+    assert(parsed.isLeft, "Should fail when failuresToFetch is negative")
+  }
+
+  test("negative validation tolerances fail at parse time") {
+    List(
+      "ttlToleranceMillis",
+      "writetimeToleranceMillis",
+      "timestampMsTolerance",
+      "floatingPointTolerance"
+    ).foreach { fieldName =>
+      val values = Map(
+        "ttlToleranceMillis"       -> "0",
+        "writetimeToleranceMillis" -> "0",
+        "timestampMsTolerance"     -> "0",
+        "floatingPointTolerance"   -> "0.0"
+      ).updated(fieldName, "-1")
+      val config =
+        s"""compareTimestamps: false
+           |ttlToleranceMillis: ${values("ttlToleranceMillis")}
+           |writetimeToleranceMillis: ${values("writetimeToleranceMillis")}
+           |failuresToFetch: 1
+           |floatingPointTolerance: ${values("floatingPointTolerance")}
+           |timestampMsTolerance: ${values("timestampMsTolerance")}
+           |""".stripMargin
+
+      val parsed = yaml.parser
+        .parse(config)
+        .flatMap(_.as[Validation])
+      assert(parsed.isLeft, s"Should fail when $fieldName is negative")
+      assert(parsed.left.exists(_.getMessage.contains(fieldName)))
+    }
+  }
+
+  test("invalid hashColumns fail at parse time") {
+    List(
+      ("""[data_blob, " "]""", "blank"),
+      ("[data_blob, DATA_BLOB]", "duplicate")
+    ).foreach { case (hashColumnsYaml, expectedError) =>
+      val config =
+        s"""compareTimestamps: false
+           |ttlToleranceMillis: 0
+           |writetimeToleranceMillis: 0
+           |failuresToFetch: 1
+           |floatingPointTolerance: 0.0
+           |timestampMsTolerance: 0
+           |hashColumns: $hashColumnsYaml
+           |""".stripMargin
+
+      val parsed = yaml.parser
+        .parse(config)
+        .flatMap(_.as[Validation])
+      assert(parsed.isLeft, s"Should fail for hashColumns: $hashColumnsYaml")
+      assert(parsed.left.exists(_.getMessage.contains(expectedError)))
+    }
+  }
+
+  private def parseValidation(yamlContent: String): Validation =
+    yaml.parser
+      .parse(yamlContent)
+      .flatMap(_.as[Validation]) match {
+      case Left(error)  => throw error
+      case Right(value) => value
+    }
+}
+
+class MySQLConfigSerializationTest extends munit.FunSuite {
+
+  private val mysqlSource = SourceSettings.MySQL(
+    host            = "db.example.com",
+    port            = 3306,
+    database        = "mydb",
+    table           = "users",
+    credentials     = Credentials("admin", "secret"),
+    primaryKey      = Some(List("id", "tenant_id")),
+    partitionColumn = Some("id"),
+    numPartitions   = Some(4),
+    lowerBound      = Some(SourceSettings.MySQL.PartitionBound("1")),
+    upperBound      = Some(SourceSettings.MySQL.PartitionBound("100000")),
+    fetchSize       = 500,
+    where           = Some("status = 'active'"),
+    connectionProperties = Some(
+      Map(
+        "connectTimeout"     -> "5000",
+        "socketTimeout"      -> "30000",
+        "trustStorePassword" -> "s3cr3t"
+      )
+    )
+  )
+
+  private val config1 = MigratorConfig(
+    source = mysqlSource,
+    target = TargetSettings.Scylla(
+      host                          = "scylla-server",
+      port                          = 9042,
+      localDC                       = Some("datacenter1"),
+      credentials                   = None,
+      sslOptions                    = None,
+      keyspace                      = "test_keyspace",
+      table                         = "test_table",
+      connections                   = Some(16),
+      stripTrailingZerosForDecimals = false,
+      writeTTLInS                   = None,
+      writeWritetimestampInuS       = None,
+      consistencyLevel              = "LOCAL_QUORUM"
+    ),
+    renames          = Some(List(Rename("old_col", "new_col"))),
+    savepoints       = Savepoints(300, "/app/savepoints"),
+    skipTokenRanges  = None,
+    skipSegments     = None,
+    skipParquetFiles = None,
+    validation = Some(
+      Validation(
+        compareTimestamps        = false,
+        ttlToleranceMillis       = 0,
+        writetimeToleranceMillis = 0,
+        failuresToFetch          = 100,
+        floatingPointTolerance   = 0.001,
+        timestampMsTolerance     = 500,
+        hashColumns              = Some(List("data_blob", "large_text"))
+      )
+    )
+  )
+
+  private val resumableConfig = MigratorConfig(
+    source = SourceSettings.Cassandra(
+      host               = "cassandra-source",
+      port               = 9042,
+      localDC            = Some("dc1"),
+      credentials        = Some(Credentials("source-user", "source-secret")),
+      sslOptions         = None,
+      keyspace           = "source_ks",
+      table              = "source_table",
+      splitCount         = Some(8),
+      connections        = Some(4),
+      fetchSize          = 512,
+      preserveTimestamps = false,
+      where              = None,
+      consistencyLevel   = "LOCAL_QUORUM"
+    ),
+    target = TargetSettings.Scylla(
+      host                          = "scylla-target",
+      port                          = 9042,
+      localDC                       = Some("dc1"),
+      credentials                   = Some(Credentials("target-user", "target-secret")),
+      sslOptions                    = None,
+      keyspace                      = "target_ks",
+      table                         = "target_table",
+      connections                   = Some(16),
+      stripTrailingZerosForDecimals = false,
+      writeTTLInS                   = None,
+      writeWritetimestampInuS       = None,
+      consistencyLevel              = "LOCAL_QUORUM"
+    ),
+    renames          = None,
+    savepoints       = Savepoints(300, "/app/savepoints"),
+    skipTokenRanges  = None,
+    skipSegments     = None,
+    skipParquetFiles = None,
+    validation       = None
+  )
+
+  test("rendered YAML round-trips authenticated credentials for resumable configs") {
+    val renderedYaml = resumableConfig.render
+    val tempFile = Files.createTempFile("resumable-config-roundtrip", ".yaml")
+    try {
+      Files.write(tempFile, renderedYaml.getBytes(StandardCharsets.UTF_8))
+      val loaded = MigratorConfig.loadFrom(tempFile.toString)
+      val loadedSource = loaded.source.asInstanceOf[SourceSettings.Cassandra]
+      val loadedTarget = loaded.target.asInstanceOf[TargetSettings.Scylla]
+      assertEquals(loadedSource.credentials, Some(Credentials("source-user", "source-secret")))
+      assertEquals(loadedTarget.credentials, Some(Credentials("target-user", "target-secret")))
+    } finally
+      Files.delete(tempFile)
+  }
+
+  test("MySQL configs can omit savepoints and receive the default value") {
+    val yamlContent =
+      """source:
+        |  type: mysql
+        |  host: db.example.com
+        |  port: 3306
+        |  database: mydb
+        |  table: users
+        |  credentials:
+        |    username: admin
+        |    password: secret
+        |target:
+        |  type: scylla
+        |  host: scylla-server
+        |  port: 9042
+        |  keyspace: test_keyspace
+        |  table: test_table
+        |  consistencyLevel: LOCAL_QUORUM
+        |  stripTrailingZerosForDecimals: false
+        |validation:
+        |  compareTimestamps: false
+        |  ttlToleranceMillis: 0
+        |  writetimeToleranceMillis: 0
+        |  failuresToFetch: 100
+        |  floatingPointTolerance: 0.001
+        |  timestampMsTolerance: 500
+        |""".stripMargin
+    val tempFile = Files.createTempFile("mysql-config-no-savepoints", ".yaml")
+    try {
+      Files.write(tempFile, yamlContent.getBytes(StandardCharsets.UTF_8))
+      val loaded = MigratorConfig.loadFrom(tempFile.toString)
+      assertEquals(loaded.savepoints, Savepoints.Default)
+    } finally
+      Files.delete(tempFile)
+  }
+
+  test("rendered MySQL configs omit savepoints because they are not supported") {
+    val renderedYaml = config1.render
+    val redactedYaml = config1.renderRedacted
+
+    assert(!renderedYaml.contains("savepoints"))
+    assert(!renderedYaml.contains("/app/savepoints"))
+    assert(!redactedYaml.contains("savepoints"))
+    assert(!redactedYaml.contains("/app/savepoints"))
+  }
+
+  test("non-MySQL configs still require explicit savepoints") {
+    val yamlContent =
+      """source:
+        |  type: cassandra
+        |  host: cassandra-source
+        |  port: 9042
+        |  keyspace: source_ks
+        |  table: source_table
+        |  fetchSize: 512
+        |  preserveTimestamps: false
+        |  consistencyLevel: LOCAL_QUORUM
+        |target:
+        |  type: scylla
+        |  host: scylla-target
+        |  port: 9042
+        |  keyspace: target_ks
+        |  table: target_table
+        |  consistencyLevel: LOCAL_QUORUM
+        |  stripTrailingZerosForDecimals: false
+        |""".stripMargin
+    val tempFile = Files.createTempFile("cassandra-config-no-savepoints", ".yaml")
+    try {
+      Files.write(tempFile, yamlContent.getBytes(StandardCharsets.UTF_8))
+      val error = intercept[Throwable](MigratorConfig.loadFrom(tempFile.toString))
+      assert(error.getMessage.contains("savepoints"))
+    } finally
+      Files.delete(tempFile)
+  }
+
+  test("redactSecrets redacts supported sensitive key variants recursively") {
+    val redacted = MigratorConfig.redactSecrets(
+      Json.obj(
+        "type"  -> Json.fromString("mysql"),
+        "where" -> Json.fromString("email = 'user@example.com'"),
+        "credentials" -> Json.obj(
+          "accessKey"  -> Json.fromString("AKIA123456"),
+          "secretKey"  -> Json.fromString("secret-value"),
+          "access_key" -> Json.fromString("AKIA654321")
+        ),
+        "connectionProperties" -> Json.obj(
+          "apiKey"         -> Json.fromString("api-secret"),
+          "access-key"     -> Json.fromString("secondary-secret"),
+          "privateKey"     -> Json.fromString("pem-secret"),
+          "connectTimeout" -> Json.fromString("5000")
+        )
+      )
+    )
+
+    val credentials = redacted.hcursor.downField("credentials")
+    val connectionProperties = redacted.hcursor.downField("connectionProperties")
+
+    assertEquals(redacted.hcursor.get[String]("where").toOption, Some("<redacted>"))
+    assertEquals(credentials.get[String]("accessKey").toOption, Some("<redacted>"))
+    assertEquals(credentials.get[String]("secretKey").toOption, Some("<redacted>"))
+    assertEquals(credentials.get[String]("access_key").toOption, Some("<redacted>"))
+    assertEquals(connectionProperties.get[String]("apiKey").toOption, Some("<redacted>"))
+    assertEquals(connectionProperties.get[String]("access-key").toOption, Some("<redacted>"))
+    assertEquals(connectionProperties.get[String]("privateKey").toOption, Some("<redacted>"))
+    assertEquals(connectionProperties.get[String]("connectTimeout").toOption, Some("5000"))
+  }
+
+  test("renderRedacted hides credentials and sensitive connectionProperties") {
+    val renderedYaml = config1.renderRedacted
+
+    assert(renderedYaml.contains("<redacted>"), "rendered YAML should contain <redacted>")
+    assert(!renderedYaml.contains("secret"), "rendered YAML should not contain the plain password")
+    assert(
+      !renderedYaml.contains("s3cr3t"),
+      "rendered YAML should not contain sensitive connectionProperty values"
+    )
+    assert(
+      !renderedYaml.contains("status = 'active'"),
+      "rendered YAML should not contain the MySQL WHERE predicate"
+    )
+    // Non-sensitive connectionProperties should survive
+    assert(renderedYaml.contains("5000"), "rendered YAML should contain connectTimeout value")
+    assert(renderedYaml.contains("30000"), "rendered YAML should contain socketTimeout value")
+  }
+
+  test("loading renderRedacted YAML fails because credentials are redacted") {
+    val renderedYaml = config1.renderRedacted
+    val tempFile = Files.createTempFile("mysql-roundtrip-config", ".yaml")
+    try {
+      Files.write(tempFile, renderedYaml.getBytes(StandardCharsets.UTF_8))
+      val error = intercept[Throwable](MigratorConfig.loadFrom(tempFile.toString))
+      assert(
+        error.getMessage.contains("savepoint"),
+        "Error should mention savepoint file"
+      )
+    } finally
+      Files.delete(tempFile)
+  }
+
+  test("non-credential fields survive YAML encode/decode round-trip") {
+    // Parse the rendered YAML as raw JSON/YAML to verify non-credential fields
+    // without going through the full config loader (which rejects redacted passwords).
+    val renderedYaml = config1.renderRedacted
+    val json = yaml.parser.parse(renderedYaml).toOption.get
+    val sourceCursor = json.hcursor.downField("source")
+
+    assertEquals(sourceCursor.get[String]("host").toOption, Some("db.example.com"))
+    assertEquals(sourceCursor.get[Int]("port").toOption, Some(3306))
+    assertEquals(sourceCursor.get[String]("database").toOption, Some("mydb"))
+    assertEquals(sourceCursor.get[String]("table").toOption, Some("users"))
+    assertEquals(sourceCursor.get[Int]("fetchSize").toOption, Some(500))
+    assertEquals(sourceCursor.get[String]("where").toOption, Some("<redacted>"))
+    assertEquals(
+      sourceCursor.get[List[String]]("primaryKey").toOption,
+      Some(List("id", "tenant_id"))
+    )
+    assertEquals(sourceCursor.get[String]("partitionColumn").toOption, Some("id"))
+    assertEquals(sourceCursor.get[Int]("numPartitions").toOption, Some(4))
+
+    // Verify connectionProperties redaction at the YAML level
+    val props = sourceCursor.downField("connectionProperties")
+    assertEquals(props.get[String]("connectTimeout").toOption, Some("5000"))
+    assertEquals(props.get[String]("socketTimeout").toOption, Some("30000"))
+    assertEquals(props.get[String]("trustStorePassword").toOption, Some("<redacted>"))
+
+    // Verify validation config
+    val validationCursor = json.hcursor.downField("validation")
+    assertEquals(
+      validationCursor.get[List[String]]("hashColumns").toOption,
+      Some(List("data_blob", "large_text"))
+    )
+    assertEquals(validationCursor.get[Int]("failuresToFetch").toOption, Some(100))
+    assertEquals(validationCursor.get[Long]("timestampMsTolerance").toOption, Some(500L))
+
+    // Verify renames
+    assertEquals(
+      json.hcursor.get[List[Rename]]("renames").toOption,
+      Some(List(Rename("old_col", "new_col")))
+    )
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/readers/MySQLReaderIntegrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/MySQLReaderIntegrationTest.scala
@@ -1,0 +1,108 @@
+package com.scylladb.migrator.readers
+
+import com.scylladb.migrator.{ Integration, SparkUtils }
+import com.scylladb.migrator.config.{ Credentials, SourceSettings }
+import org.apache.spark.sql.functions.{ col, date_format }
+import org.junit.experimental.categories.Category
+
+import java.sql.DriverManager
+import java.util.TimeZone
+import scala.concurrent.duration.{ Duration, DurationInt }
+import scala.util.Using
+
+@Category(Array(classOf[Integration]))
+class MySQLReaderIntegrationTest extends munit.FunSuite {
+
+  override val munitTimeout: Duration = 180.seconds
+
+  private val rootJdbcUrl =
+    "jdbc:mysql://localhost:3308/testdb?zeroDateTimeBehavior=EXCEPTION&tinyInt1IsBit=false&useSSL=false"
+
+  Class.forName("com.mysql.cj.jdbc.Driver")
+
+  private def withRootConnection[A](f: java.sql.Connection => A): A =
+    Using.resource(DriverManager.getConnection(rootJdbcUrl, "root", "root"))(f)
+
+  private def executeRoot(sql: String): Unit =
+    withRootConnection { connection =>
+      Using.resource(connection.createStatement()) { statement =>
+        statement.execute(sql)
+        ()
+      }
+    }
+
+  test(
+    "partitioned timestamp reads stay stable when JVM, Spark, and MySQL session time zones differ"
+  ) {
+    val table = "users_tz_partition"
+    val originalTimeZone = TimeZone.getDefault
+
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
+
+      executeRoot("SET GLOBAL time_zone = '+05:00'")
+      withRootConnection { connection =>
+        Using.resource(connection.createStatement()) { statement =>
+          statement.execute("SET SESSION time_zone = '+05:00'")
+          statement.execute(s"DROP TABLE IF EXISTS $table")
+          statement.execute(
+            s"""CREATE TABLE $table (
+               |  id BIGINT PRIMARY KEY,
+               |  created_at TIMESTAMP NOT NULL
+               |)""".stripMargin
+          )
+          statement.execute(
+            s"""INSERT INTO $table (id, created_at) VALUES
+               |  (1, '2024-01-01 00:30:00'),
+               |  (2, '2024-01-01 12:00:00'),
+               |  (3, '2024-01-01 23:30:00')""".stripMargin
+          )
+        }
+      }
+
+      val source = SourceSettings.MySQL(
+        host                 = "localhost",
+        port                 = 3308,
+        database             = "testdb",
+        table                = table,
+        credentials          = Credentials("migrator", "migrator"),
+        primaryKey           = None,
+        partitionColumn      = Some("created_at"),
+        numPartitions        = Some(2),
+        lowerBound           = Some(SourceSettings.MySQL.PartitionBound("2024-01-01 00:00:00")),
+        upperBound           = Some(SourceSettings.MySQL.PartitionBound("2024-01-02 00:00:00")),
+        zeroDateTimeBehavior = SourceSettings.MySQL.ZeroDateTimeBehavior.Exception,
+        fetchSize            = 1000,
+        where                = None,
+        connectionProperties = None
+      )
+
+      val rows = SparkUtils.withSparkSession(Map("spark.sql.session.timeZone" -> "UTC")) { spark =>
+        MySQL
+          .readDataframe(spark, source)
+          .dataFrame
+          .select(
+            col("id"),
+            date_format(col("created_at"), "yyyy-MM-dd HH:mm:ss").as("created_at_utc")
+          )
+          .orderBy("id")
+          .collect()
+          .toList
+          .map(row => row.getLong(0) -> row.getString(1))
+      }
+
+      assertEquals(
+        rows,
+        List(
+          1L -> "2023-12-31 19:30:00",
+          2L -> "2024-01-01 07:00:00",
+          3L -> "2024-01-01 18:30:00"
+        )
+      )
+    } finally {
+      executeRoot(s"DROP TABLE IF EXISTS $table")
+      executeRoot("SET GLOBAL time_zone = 'SYSTEM'")
+      TimeZone.setDefault(originalTimeZone)
+    }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/readers/MySQLReaderTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/MySQLReaderTest.scala
@@ -1,0 +1,613 @@
+package com.scylladb.migrator.readers
+
+import com.scylladb.migrator.config.{ Credentials, HostValidation, SourceSettings }
+import org.apache.spark.sql.SparkSession
+
+import java.util.Locale
+
+class MySQLReaderTest extends munit.FunSuite {
+
+  private lazy val spark: SparkSession = SparkSession
+    .builder()
+    .master("local[1]")
+    .appName("MySQLReaderTest")
+    .config("spark.ui.enabled", "false")
+    .getOrCreate()
+
+  override def afterAll(): Unit = {
+    spark.stop()
+    super.afterAll()
+  }
+
+  // --- escapeIdentifier tests ---
+
+  test("escapeIdentifier wraps name in backticks") {
+    assertEquals(MySQL.escapeIdentifier("users"), "`users`")
+  }
+
+  test("escapeIdentifier doubles embedded backticks") {
+    assertEquals(MySQL.escapeIdentifier("foo`bar"), "`foo``bar`")
+  }
+
+  test("escapeIdentifier handles multiple embedded backticks") {
+    assertEquals(MySQL.escapeIdentifier("a`b`c"), "`a``b``c`")
+  }
+
+  test("escapeIdentifier handles name that is only a backtick") {
+    assertEquals(MySQL.escapeIdentifier("`"), "````")
+  }
+
+  test("escapeIdentifier rejects empty name") {
+    intercept[IllegalArgumentException] {
+      MySQL.escapeIdentifier("")
+    }
+  }
+
+  test("escapeMetadataPattern escapes wildcard characters and the escape character itself") {
+    assertEquals(
+      MySQL.escapeMetadataPattern("""user_events_2024%backup\archive""", "\\"),
+      """user\_events\_2024\%backup\\archive"""
+    )
+  }
+
+  test("partitionedReadConsistencyWarning explains the lack of a global snapshot") {
+    val warning = MySQL.partitionedReadConsistencyWarning(
+      mysqlSource(database = "app", table = "user_events")
+    )
+
+    assert(warning.contains("app.user_events"))
+    assert(warning.contains("do not provide a single global snapshot"))
+    assert(warning.contains("Concurrent source writes"))
+    assert(warning.contains("quiesce"))
+  }
+
+  // --- buildJdbcUrl tests ---
+
+  private def mysqlSource(
+    host: String = "localhost",
+    port: Int = 3306,
+    database: String = "mydb",
+    table: String = "mytable",
+    partitionColumn: Option[String] = None,
+    numPartitions: Option[Int] = None,
+    lowerBound: Option[String] = None,
+    upperBound: Option[String] = None,
+    zeroDateTimeBehavior: SourceSettings.MySQL.ZeroDateTimeBehavior =
+      SourceSettings.MySQL.ZeroDateTimeBehavior.Exception,
+    connectionProperties: Option[Map[String, String]] = None
+  ): SourceSettings.MySQL =
+    SourceSettings.MySQL(
+      host                 = host,
+      port                 = port,
+      database             = database,
+      table                = table,
+      credentials          = Credentials("user", "pass"),
+      primaryKey           = None,
+      partitionColumn      = partitionColumn,
+      numPartitions        = numPartitions,
+      lowerBound           = lowerBound.map(SourceSettings.MySQL.PartitionBound(_)),
+      upperBound           = upperBound.map(SourceSettings.MySQL.PartitionBound(_)),
+      zeroDateTimeBehavior = zeroDateTimeBehavior,
+      fetchSize            = 1000,
+      where                = None,
+      connectionProperties = connectionProperties
+    )
+
+  test("redactionRegexCoversKeys accepts Spark default redaction coverage") {
+    assert(
+      MySQL.redactionRegexCoversKeys(
+        MySQL.DefaultSensitiveRedactionRegex,
+        Seq("password", "trustStorePassword")
+      )
+    )
+  }
+
+  test("redactionRegexCoversKeys accepts apiKey and access key variants") {
+    assert(
+      MySQL.redactionRegexCoversKeys(
+        MySQL.DefaultSensitiveRedactionRegex,
+        Seq("apiKey", "access_key", "access-key", "privateKey")
+      )
+    )
+  }
+
+  test("redactionRegexCoversKeys rejects regex that misses password keys") {
+    assert(
+      !MySQL.redactionRegexCoversKeys("(?i)token", Seq("password")),
+      "regex that only matches token must not be accepted for password-bearing options"
+    )
+  }
+
+  test("isSensitiveOptionKey recognizes underscore and hyphen variants") {
+    assert(MySQL.isSensitiveOptionKey("apiKey"))
+    assert(MySQL.isSensitiveOptionKey("access_key"))
+    assert(MySQL.isSensitiveOptionKey("access-key"))
+    assert(MySQL.isSensitiveOptionKey("privateKey"))
+  }
+
+  test("ensureSensitiveReaderOptionsAreRedacted accepts default coverage for apiKey variants") {
+    MySQL.ensureSensitiveReaderOptionsAreRedacted(
+      spark,
+      Seq("apiKey", "access_key", "access-key"),
+      "test JDBC reader"
+    )
+  }
+
+  test("buildJdbcUrl produces correct URL with defaults") {
+    val url = MySQL.buildJdbcUrl(mysqlSource())
+    assert(url.startsWith("jdbc:mysql://localhost:3306/mydb?"))
+    assert(url.contains("zeroDateTimeBehavior=EXCEPTION"))
+    assert(url.contains("tinyInt1IsBit=false"))
+    assert(url.contains("useCursorFetch=true"))
+    assert(url.contains(s"maxAllowedPacket=${MySQL.DefaultMaxAllowedPacketBytes}"))
+    assert(url.contains(s"connectionTimeZone=${MySQL.DefaultConnectionTimeZoneId}"))
+    assert(url.contains("forceConnectionTimeZoneToSession=true"))
+  }
+
+  test("buildJdbcUrl encodes named Spark time zones and forces them onto the MySQL session") {
+    val url = MySQL.buildJdbcUrl(
+      mysqlSource(),
+      connectionTimeZoneId = "America/Los_Angeles"
+    )
+    assert(url.contains("connectionTimeZone=America%2FLos_Angeles"))
+    assert(url.contains("forceConnectionTimeZoneToSession=true"))
+  }
+
+  test("buildJdbcUrl uses explicit zeroDateTimeBehavior override") {
+    val url = MySQL.buildJdbcUrl(
+      mysqlSource(
+        zeroDateTimeBehavior = SourceSettings.MySQL.ZeroDateTimeBehavior.ConvertToNull
+      )
+    )
+    assert(url.contains("zeroDateTimeBehavior=CONVERT_TO_NULL"))
+  }
+
+  test("buildJdbcUrl uses custom maxAllowedPacket from connectionProperties") {
+    val url = MySQL.buildJdbcUrl(
+      mysqlSource(connectionProperties = Some(Map("maxAllowedPacket" -> "1024")))
+    )
+    assert(url.contains("maxAllowedPacket=1024"))
+    assert(!url.contains(MySQL.DefaultMaxAllowedPacketBytes.toString))
+  }
+
+  test("buildJdbcUrl uses maxAllowedPacket case-insensitively") {
+    val url = MySQL.buildJdbcUrl(
+      mysqlSource(connectionProperties = Some(Map("maxallowedpacket" -> "2048")))
+    )
+    assert(url.contains("maxAllowedPacket=2048"))
+    assert(!url.contains(MySQL.DefaultMaxAllowedPacketBytes.toString))
+  }
+
+  test("buildJdbcUrl rejects non-numeric maxAllowedPacket") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(
+        mysqlSource(connectionProperties = Some(Map("maxAllowedPacket" -> "notanumber")))
+      )
+    }
+  }
+
+  test("buildJdbcUrl rejects empty maxAllowedPacket") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(
+        mysqlSource(connectionProperties = Some(Map("maxAllowedPacket" -> "")))
+      )
+    }
+  }
+
+  test("buildJdbcUrl rejects zero maxAllowedPacket") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(
+        mysqlSource(connectionProperties = Some(Map("maxAllowedPacket" -> "0")))
+      )
+    }
+  }
+
+  test("buildJdbcUrl rejects injected connectTimeout value") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(
+        mysqlSource(
+          connectionProperties = Some(Map("connectTimeout" -> "5000&allowLoadLocalInfile=true"))
+        )
+      )
+    }
+  }
+
+  test("buildJdbcUrl rejects injected socketTimeout value") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(
+        mysqlSource(
+          connectionProperties = Some(Map("socketTimeout" -> "600000&allowMultiQueries=true"))
+        )
+      )
+    }
+  }
+
+  test("buildJdbcUrl accepts zero connectTimeout and socketTimeout") {
+    val url = MySQL.buildJdbcUrl(
+      mysqlSource(
+        connectionProperties = Some(
+          Map(
+            "connectTimeout" -> "0",
+            "socketTimeout"  -> "0"
+          )
+        )
+      )
+    )
+    assert(url.contains("connectTimeout=0"))
+    assert(url.contains("socketTimeout=0"))
+  }
+
+  test("jdbcReadProperties carries credentials and fetchsize in JDBC properties") {
+    val props = MySQL.jdbcReadProperties(mysqlSource())
+
+    assertEquals(props.getProperty("user"), "user")
+    assertEquals(props.getProperty("password"), "pass")
+    assertEquals(props.getProperty("driver"), "com.mysql.cj.jdbc.Driver")
+    assertEquals(props.getProperty("fetchsize"), "1000")
+  }
+
+  test("buildJdbcUrl rejects empty host") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(mysqlSource(host = ""))
+    }
+  }
+
+  test("buildJdbcUrl rejects host with URL injection characters") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(
+        mysqlSource(host = "evil.com:3306/fakedb?allowLoadLocalInfile=true&user=root#")
+      )
+    }
+  }
+
+  test("buildJdbcUrl rejects host with fragment injection") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(mysqlSource(host = "evil.com#"))
+    }
+  }
+
+  test("buildJdbcUrl rejects host with query string injection") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(mysqlSource(host = "evil.com?foo=bar"))
+    }
+  }
+
+  test("buildJdbcUrl accepts IPv6 host and wraps in brackets") {
+    val url = MySQL.buildJdbcUrl(mysqlSource(host = "::1"))
+    assert(url.contains("jdbc:mysql://[::1]:3306/mydb"))
+  }
+
+  test("buildJdbcUrl accepts already-bracketed IPv6 host") {
+    val url = MySQL.buildJdbcUrl(mysqlSource(host = "[::1]"))
+    assert(url.contains("jdbc:mysql://[::1]:3306/mydb"))
+  }
+
+  test("buildJdbcUrl accepts IPv4-mapped IPv6 host") {
+    val url = MySQL.buildJdbcUrl(mysqlSource(host = "::ffff:192.168.1.1"))
+    assert(url.contains("jdbc:mysql://[::ffff:192.168.1.1]:3306/mydb"))
+  }
+
+  test("buildJdbcUrl accepts bracketed IPv4-mapped IPv6 host") {
+    val url = MySQL.buildJdbcUrl(mysqlSource(host = "[::ffff:10.0.0.1]"))
+    assert(url.contains("jdbc:mysql://[::ffff:10.0.0.1]:3306/mydb"))
+  }
+
+  test("buildJdbcUrl rejects unbalanced opening bracket") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(mysqlSource(host = "[::1"))
+    }
+  }
+
+  test("buildJdbcUrl rejects unbalanced closing bracket") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(mysqlSource(host = "::1]"))
+    }
+  }
+
+  test("buildJdbcUrl rejects invalid database name") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(mysqlSource(database = "bad;name"))
+    }
+  }
+
+  test("buildJdbcUrl accepts database with dollar sign") {
+    val url = MySQL.buildJdbcUrl(mysqlSource(database = "my$db"))
+    assert(url.contains("/my$db?"))
+  }
+
+  test("buildJdbcUrl accepts database with hyphen") {
+    val url = MySQL.buildJdbcUrl(mysqlSource(database = "my-database"))
+    assert(url.contains("/my-database?"))
+  }
+
+  test("buildJdbcUrl includes custom port") {
+    val url = MySQL.buildJdbcUrl(mysqlSource(port = 3307))
+    assert(url.contains(":3307/"))
+  }
+
+  test("buildJdbcUrl rejects colon-only host like ::::") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(mysqlSource(host = "::::"))
+    }
+  }
+
+  test("buildJdbcUrl rejects dot-only host like ...") {
+    intercept[IllegalArgumentException] {
+      MySQL.buildJdbcUrl(mysqlSource(host = "..."))
+    }
+  }
+
+  test("readDataframe rejects unsafe partitionColumn from programmatic config") {
+    val error = intercept[IllegalArgumentException] {
+      MySQL.readDataframe(
+        spark,
+        mysqlSource(
+          partitionColumn = Some("id; DROP TABLE users --"),
+          numPartitions   = Some(4),
+          lowerBound      = Some("1"),
+          upperBound      = Some("100")
+        )
+      )
+    }
+    assert(error.getMessage.contains("partitionColumn"))
+  }
+
+  test("MySQL source dataframes do not support savepoints") {
+    val sourceDF = MySQL.sourceDataFrame(spark.emptyDataFrame)
+
+    assert(!sourceDF.savepointsSupported)
+    assertEquals(sourceDF.timestampColumns, None)
+  }
+
+  test("readDataframe rejects partitioned reads without both bounds from programmatic config") {
+    val error = intercept[IllegalArgumentException] {
+      MySQL.readDataframe(
+        spark,
+        mysqlSource(
+          partitionColumn = Some("id"),
+          numPartitions   = Some(4),
+          lowerBound      = Some("1"),
+          upperBound      = None
+        )
+      )
+    }
+    assert(error.getMessage.contains("Both lowerBound and upperBound"))
+  }
+
+  test("safeConnectionProperties blocks dangerous keys under Turkish default locale") {
+    val safeProps = withDefaultLocale(new Locale("tr", "TR")) {
+      MySQL.safeConnectionProperties(
+        mysqlSource(
+          connectionProperties = Some(
+            Map(
+              "allowLoadLocalInfile" -> "true",
+              "cachePrepStmts"       -> "true"
+            )
+          )
+        )
+      )
+    }
+
+    assertEquals(safeProps, Map("cachePrepStmts" -> "true"))
+  }
+
+  test("safeConnectionProperties filters JDBC keys already embedded in the URL") {
+    val safeProps = MySQL.safeConnectionProperties(
+      mysqlSource(
+        connectionProperties = Some(
+          Map(
+            "zeroDateTimeBehavior"             -> "ROUND",
+            "tinyInt1IsBit"                    -> "true",
+            "maxAllowedPacket"                 -> "1024",
+            "useCursorFetch"                   -> "false",
+            "connectTimeout"                   -> "1",
+            "socketTimeout"                    -> "2",
+            "connectionTimeZone"               -> "LOCAL",
+            "forceConnectionTimeZoneToSession" -> "false",
+            "cachePrepStmts"                   -> "true"
+          )
+        )
+      )
+    )
+
+    assertEquals(safeProps, Map("cachePrepStmts" -> "true"))
+  }
+
+  test("validatePartitionBoundsForColumnType accepts numeric bounds for numeric columns") {
+    MySQL.validatePartitionBoundsForColumnType(
+      partitionColumn = "id",
+      jdbcTypeName    = "BIGINT",
+      columnType      = MySQL.PartitionColumnType.Numeric,
+      lowerBound      = SourceSettings.MySQL.PartitionBound("1"),
+      upperBound      = SourceSettings.MySQL.PartitionBound("100"),
+      timeZoneId      = "UTC"
+    )
+  }
+
+  test("validatePartitionBoundsForColumnType accepts ISO date bounds for DATE columns") {
+    MySQL.validatePartitionBoundsForColumnType(
+      partitionColumn = "created_on",
+      jdbcTypeName    = "DATE",
+      columnType      = MySQL.PartitionColumnType.Date,
+      lowerBound      = SourceSettings.MySQL.PartitionBound("2024-01-01"),
+      upperBound      = SourceSettings.MySQL.PartitionBound("2024-02-01"),
+      timeZoneId      = "UTC"
+    )
+  }
+
+  test("validatePartitionBoundsForColumnType accepts timestamp bounds for TIMESTAMP columns") {
+    MySQL.validatePartitionBoundsForColumnType(
+      partitionColumn = "created_at",
+      jdbcTypeName    = "TIMESTAMP",
+      columnType      = MySQL.PartitionColumnType.Timestamp,
+      lowerBound      = SourceSettings.MySQL.PartitionBound("2024-01-01 00:00:00"),
+      upperBound      = SourceSettings.MySQL.PartitionBound("2024-01-02 00:00:00"),
+      timeZoneId      = "UTC"
+    )
+  }
+
+  test("validatePartitionBoundsForColumnType rejects epoch-millis bounds for DATE columns") {
+    val error = intercept[RuntimeException] {
+      MySQL.validatePartitionBoundsForColumnType(
+        partitionColumn = "created_on",
+        jdbcTypeName    = "DATE",
+        columnType      = MySQL.PartitionColumnType.Date,
+        lowerBound      = SourceSettings.MySQL.PartitionBound("1704067200000"),
+        upperBound      = SourceSettings.MySQL.PartitionBound("1704153600000"),
+        timeZoneId      = "UTC"
+      )
+    }
+    assert(error.getMessage.contains("Epoch-millisecond bounds are not supported"))
+  }
+
+  test("validatePartitionBoundsForColumnType rejects epoch-millis bounds for TIMESTAMP columns") {
+    val error = intercept[RuntimeException] {
+      MySQL.validatePartitionBoundsForColumnType(
+        partitionColumn = "created_at",
+        jdbcTypeName    = "TIMESTAMP",
+        columnType      = MySQL.PartitionColumnType.Timestamp,
+        lowerBound      = SourceSettings.MySQL.PartitionBound("1704067200000"),
+        upperBound      = SourceSettings.MySQL.PartitionBound("1704153600000"),
+        timeZoneId      = "UTC"
+      )
+    }
+    assert(error.getMessage.contains("Epoch-millisecond bounds are not supported"))
+  }
+
+  test("partitionedReadOptions uses the resolved metadata column name for Spark JDBC") {
+    val options = MySQL
+      .partitionedReadOptions(
+        configuredPartitionColumn = "`1column`",
+        partitionColumnInfo = MySQL.PartitionColumnMetadata(
+          columnName   = "1column",
+          jdbcTypeName = "BIGINT",
+          columnType   = MySQL.PartitionColumnType.Numeric
+        ),
+        numPartitions = 4,
+        lowerBound    = SourceSettings.MySQL.PartitionBound("1"),
+        upperBound    = SourceSettings.MySQL.PartitionBound("100")
+      )
+      .toMap
+
+    assertEquals(options("partitionColumn"), "1column")
+    assertNotEquals(options("partitionColumn"), "`1column`")
+    assertEquals(options("numPartitions"), "4")
+    assertEquals(options("lowerBound"), "1")
+    assertEquals(options("upperBound"), "100")
+  }
+
+  // --- isValidHostname tests ---
+
+  test("isValidHostname accepts regular hostname") {
+    assert(HostValidation.isValidHostname("db.example.com"))
+  }
+
+  test("isValidHostname accepts IPv4 address") {
+    assert(HostValidation.isValidHostname("192.168.1.1"))
+  }
+
+  test("isValidHostname accepts localhost") {
+    assert(HostValidation.isValidHostname("localhost"))
+  }
+
+  test("isValidHostname rejects dot-only string") {
+    assert(!HostValidation.isValidHostname("..."))
+  }
+
+  test("isValidHostname rejects hyphen-only string") {
+    assert(!HostValidation.isValidHostname("-foo"))
+  }
+
+  test("isValidHostname rejects empty string") {
+    assert(!HostValidation.isValidHostname(""))
+  }
+
+  // --- isValidIPv6Host tests ---
+
+  test("isValidIPv6Host accepts ::1") {
+    assert(HostValidation.isValidIPv6Host("::1"))
+  }
+
+  test("isValidIPv6Host accepts bracketed ::1") {
+    assert(HostValidation.isValidIPv6Host("[::1]"))
+  }
+
+  test("isValidIPv6Host accepts full IPv6 address") {
+    assert(HostValidation.isValidIPv6Host("2001:0db8:85a3:0000:0000:8a2e:0370:7334"))
+  }
+
+  test("isValidIPv6Host accepts IPv4-mapped IPv6") {
+    assert(HostValidation.isValidIPv6Host("::ffff:192.168.1.1"))
+  }
+
+  test("isValidIPv6Host rejects colon-only string ::::") {
+    assert(!HostValidation.isValidIPv6Host("::::"))
+  }
+
+  test("isValidIPv6Host rejects dot-only string ...") {
+    assert(!HostValidation.isValidIPv6Host("..."))
+  }
+
+  test("isValidIPv6Host rejects empty string") {
+    assert(!HostValidation.isValidIPv6Host(""))
+  }
+
+  test("isValidIPv6Host rejects empty brackets") {
+    assert(!HostValidation.isValidIPv6Host("[]"))
+  }
+
+  test("isValidIPv6Host rejects structurally invalid 9-group address") {
+    assert(!HostValidation.isValidIPv6Host("1:2:3:4:5:6:7:8:9"))
+  }
+
+  // --- validateWhereClause tests ---
+
+  test("validateWhereClause accepts blocked keywords inside string literals") {
+    MySQL.validateWhereClause("event_type = 'delete' AND message LIKE '%union%'")
+  }
+
+  test("validateWhereClause accepts blocked keywords inside quoted identifiers") {
+    MySQL.validateWhereClause("`delete` = 1 AND \"union\" = 'ok'")
+  }
+
+  test("validateWhereClause rejects dangerous keywords outside quotes") {
+    val error = intercept[RuntimeException] {
+      MySQL.validateWhereClause("id = 1 UNION SELECT 1")
+    }
+    assert(error.getMessage.contains("union"))
+  }
+
+  test("validateWhereClause rejects comment-obfuscated dangerous keywords") {
+    val error = intercept[RuntimeException] {
+      MySQL.validateWhereClause("id = 1 UNI/**/ON SELECT 1")
+    }
+    assert(error.getMessage.contains("union"))
+  }
+
+  test("validateWhereClause rejects MySQL executable comments") {
+    val error = intercept[RuntimeException] {
+      MySQL.validateWhereClause("id = 1 /*!50000 UNION SELECT 1 */")
+    }
+    assert(error.getMessage.contains("executable comments"))
+  }
+
+  test("validateWhereClause accepts MySQL executable comment marker inside string literals") {
+    MySQL.validateWhereClause("message = '/*!50000 UNION SELECT 1 */'")
+  }
+
+  test("redactedWhereFilterLogMessage does not expose the filter contents") {
+    val filter = "email = 'user@example.com' AND api_token = 'secret'"
+    val message = MySQL.redactedWhereFilterLogMessage(filter)
+
+    assert(message.contains("content redacted"))
+    assert(message.contains(filter.length.toString))
+    assert(!message.contains(filter))
+  }
+
+  private def withDefaultLocale[A](locale: Locale)(f: => A): A = {
+    val original = Locale.getDefault
+    Locale.setDefault(locale)
+    try f
+    finally Locale.setDefault(original)
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/MySQLMigrationIntegrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/MySQLMigrationIntegrationTest.scala
@@ -1,0 +1,261 @@
+package com.scylladb.migrator.scylla
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.scylladb.migrator.{ Integration, SparkUtils }
+import org.junit.experimental.categories.Category
+
+import java.net.InetSocketAddress
+import java.sql.{ Connection, DriverManager }
+import scala.concurrent.duration.{ Duration, DurationInt }
+import scala.jdk.CollectionConverters._
+import scala.util.Using
+
+@Category(Array(classOf[Integration]))
+class MySQLMigrationIntegrationTest extends munit.FunSuite {
+
+  override val munitTimeout: Duration = 180.seconds
+
+  private val keyspace = "test"
+  private val mysqlJdbcUrl =
+    "jdbc:mysql://localhost:3308/testdb?zeroDateTimeBehavior=EXCEPTION&tinyInt1IsBit=false&useSSL=false"
+
+  val sourceMySQL: Fixture[Connection] = new Fixture[Connection]("sourceMySQL") {
+    private var connection: Connection = null
+
+    def apply(): Connection = connection
+
+    override def beforeAll(): Unit = {
+      Class.forName("com.mysql.cj.jdbc.Driver")
+      connection = DriverManager.getConnection(mysqlJdbcUrl, "migrator", "migrator")
+    }
+
+    override def afterAll(): Unit =
+      if (connection != null) connection.close()
+  }
+
+  val targetScylla: Fixture[CqlSession] = new Fixture[CqlSession]("targetScylla") {
+    private var session: CqlSession = null
+
+    def apply(): CqlSession = session
+
+    override def beforeAll(): Unit = {
+      session = CqlSession
+        .builder()
+        .addContactPoint(new InetSocketAddress("localhost", 9042))
+        .withLocalDatacenter("datacenter1")
+        .withAuthCredentials("dummy", "dummy")
+        .build()
+      session.execute(
+        s"CREATE KEYSPACE IF NOT EXISTS $keyspace " +
+          "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"
+      )
+    }
+
+    override def afterAll(): Unit =
+      if (session != null) session.close()
+  }
+
+  override def munitFixtures: Seq[Fixture[_]] = Seq(sourceMySQL, targetScylla)
+
+  private def executeMySql(sql: String): Unit =
+    Using.resource(sourceMySQL().createStatement()) { statement =>
+      statement.executeUpdate(sql)
+      ()
+    }
+
+  private def withTables(
+    mysqlTable: String,
+    mysqlCreate: String,
+    scyllaTable: String,
+    scyllaCreate: String
+  )(body: => Unit): Unit = {
+    targetScylla().execute(s"DROP TABLE IF EXISTS $keyspace.$scyllaTable")
+    executeMySql(s"DROP TABLE IF EXISTS $mysqlTable")
+    executeMySql(mysqlCreate)
+    targetScylla().execute(scyllaCreate)
+    awaitScyllaTable(scyllaTable)
+    try body
+    finally {
+      targetScylla().execute(s"DROP TABLE IF EXISTS $keyspace.$scyllaTable")
+      executeMySql(s"DROP TABLE IF EXISTS $mysqlTable")
+    }
+  }
+
+  private def awaitScyllaTable(table: String): Unit = {
+    val deadline = System.nanoTime() + 30.seconds.toNanos
+    var visible = false
+
+    while (!visible && System.nanoTime() < deadline) {
+      visible = targetScylla()
+        .execute(
+          s"SELECT table_name FROM system_schema.tables WHERE keyspace_name = '$keyspace' AND table_name = '$table'"
+        )
+        .one() != null
+      if (!visible) Thread.sleep(250)
+    }
+
+    if (!visible) fail(s"Timed out waiting for Scylla table $keyspace.$table to become visible")
+  }
+
+  test("MySQL: numeric partitioning migrates rows from a real JDBC source") {
+    withTables(
+      mysqlTable = "users_numeric",
+      mysqlCreate = """CREATE TABLE users_numeric (
+                      |  id BIGINT PRIMARY KEY,
+                      |  name VARCHAR(255) NOT NULL,
+                      |  payload LONGTEXT NOT NULL
+                      |)""".stripMargin,
+      scyllaTable = "users_numeric",
+      scyllaCreate = s"""CREATE TABLE $keyspace.users_numeric (
+                        |  id bigint PRIMARY KEY,
+                        |  name text,
+                        |  payload text
+                        |)""".stripMargin
+    ) {
+      executeMySql(
+        """INSERT INTO users_numeric (id, name, payload) VALUES
+          |  (1, 'alice', 'payload-a'),
+          |  (2, 'bob', 'payload-b'),
+          |  (3, 'carol', 'payload-c')
+          |""".stripMargin
+      )
+
+      SparkUtils.successfullyPerformMigration("mysql-to-scylla-numeric.yaml")
+
+      val rows = targetScylla()
+        .execute(s"SELECT id, name, payload FROM $keyspace.users_numeric")
+        .all()
+        .asScala
+        .map(row => (row.getLong("id"), row.getString("name"), row.getString("payload")))
+        .sortBy(_._1)
+        .toSeq
+
+      assertEquals(
+        rows,
+        Seq(
+          (1L, "alice", "payload-a"),
+          (2L, "bob", "payload-b"),
+          (3L, "carol", "payload-c")
+        )
+      )
+    }
+  }
+
+  test("MySQL: validator passes on clean data and fails on a hashed-column mismatch") {
+    withTables(
+      mysqlTable = "users_numeric",
+      mysqlCreate = """CREATE TABLE users_numeric (
+                      |  id BIGINT PRIMARY KEY,
+                      |  name VARCHAR(255) NOT NULL,
+                      |  payload LONGTEXT NOT NULL
+                      |)""".stripMargin,
+      scyllaTable = "users_numeric",
+      scyllaCreate = s"""CREATE TABLE $keyspace.users_numeric (
+                        |  id bigint PRIMARY KEY,
+                        |  name text,
+                        |  payload text
+                        |)""".stripMargin
+    ) {
+      executeMySql(
+        """INSERT INTO users_numeric (id, name, payload) VALUES
+          |  (11, 'delta', 'payload-d'),
+          |  (12, 'echo', 'payload-e')
+          |""".stripMargin
+      )
+
+      SparkUtils.successfullyPerformMigration("mysql-to-scylla-numeric.yaml")
+      assertEquals(SparkUtils.performValidation("mysql-to-scylla-numeric.yaml"), 0)
+
+      targetScylla().execute(
+        s"UPDATE $keyspace.users_numeric SET payload = 'tampered' WHERE id = 12"
+      )
+
+      assertEquals(SparkUtils.performValidation("mysql-to-scylla-numeric.yaml"), 1)
+    }
+  }
+
+  test("MySQL: temporal TIMESTAMP partitioning migrates rows from a real JDBC source") {
+    withTables(
+      mysqlTable = "users",
+      mysqlCreate = """CREATE TABLE users (
+                      |  id BIGINT PRIMARY KEY,
+                      |  name VARCHAR(255) NOT NULL,
+                      |  created_at TIMESTAMP NOT NULL,
+                      |  payload LONGTEXT NOT NULL
+                      |)""".stripMargin,
+      scyllaTable = "users",
+      scyllaCreate = s"""CREATE TABLE $keyspace.users (
+                        |  id bigint PRIMARY KEY,
+                        |  name text,
+                        |  created_at timestamp,
+                        |  payload text
+                        |)""".stripMargin
+    ) {
+      executeMySql(
+        """INSERT INTO users (id, name, created_at, payload) VALUES
+          |  (21, 'jan', '2024-01-01 00:00:00', 'payload-jan'),
+          |  (22, 'feb', '2024-01-10 12:00:00', 'payload-feb'),
+          |  (23, 'mar', '2024-01-20 23:59:59', 'payload-mar')
+          |""".stripMargin
+      )
+
+      SparkUtils.successfullyPerformMigration("mysql-to-scylla-basic.yaml")
+
+      val rows = targetScylla()
+        .execute(s"SELECT id, created_at, payload FROM $keyspace.users")
+        .all()
+        .asScala
+        .map(row =>
+          (row.getLong("id"), row.getInstant("created_at") != null, row.getString("payload"))
+        )
+        .sortBy(_._1)
+        .toSeq
+
+      assertEquals(
+        rows,
+        Seq(
+          (21L, true, "payload-jan"),
+          (22L, true, "payload-feb"),
+          (23L, true, "payload-mar")
+        )
+      )
+    }
+  }
+
+  test(
+    "MySQL: filtered validation ignores unrelated target rows and validates only the filtered slice"
+  ) {
+    withTables(
+      mysqlTable = "users_filtered",
+      mysqlCreate = """CREATE TABLE users_filtered (
+                      |  id BIGINT PRIMARY KEY,
+                      |  name VARCHAR(255) NOT NULL,
+                      |  created_at TIMESTAMP NOT NULL,
+                      |  payload LONGTEXT NOT NULL
+                      |)""".stripMargin,
+      scyllaTable = "users_filtered",
+      scyllaCreate = s"""CREATE TABLE $keyspace.users_filtered (
+                        |  id bigint PRIMARY KEY,
+                        |  name text,
+                        |  created_at timestamp,
+                        |  payload text
+                        |)""".stripMargin
+    ) {
+      executeMySql(
+        """INSERT INTO users_filtered (id, name, created_at, payload) VALUES
+          |  (31, 'jan', '2024-01-01 00:00:00', 'payload-jan'),
+          |  (32, 'feb', '2024-01-10 12:00:00', 'payload-feb'),
+          |  (33, 'mar', '2024-01-20 23:59:59', 'payload-mar')
+          |""".stripMargin
+      )
+
+      SparkUtils.successfullyPerformMigration("mysql-to-scylla-filtered.yaml")
+      targetScylla().execute(
+        s"""INSERT INTO $keyspace.users_filtered (id, name, created_at, payload)
+           |VALUES (99, 'extra', '2024-01-05T00:00:00Z', 'unrelated-target-row')""".stripMargin
+      )
+
+      assertEquals(SparkUtils.performValidation("mysql-to-scylla-filtered.yaml"), 0)
+    }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/MySQLSavepointsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/MySQLSavepointsTest.scala
@@ -1,0 +1,81 @@
+package com.scylladb.migrator.scylla
+
+import com.scylladb.migrator.config.{
+  Credentials,
+  MigratorConfig,
+  Savepoints,
+  SourceSettings,
+  TargetSettings
+}
+import org.apache.spark.sql.SparkSession
+
+import java.nio.file.Files
+
+class MySQLSavepointsTest extends munit.FunSuite {
+
+  test("MySQL source does not create savepoint manager even when savepoints are configured") {
+    val tempDir = Files.createTempDirectory("mysql-savepoints-test")
+    val savepointsDir = tempDir.resolve("savepoints")
+
+    try {
+      val config = MigratorConfig(
+        source = SourceSettings.MySQL(
+          host                 = "mysql.example.com",
+          port                 = 3306,
+          database             = "mydb",
+          table                = "users",
+          credentials          = Credentials("mysql-user", "mysql-secret"),
+          primaryKey           = None,
+          partitionColumn      = None,
+          numPartitions        = None,
+          lowerBound           = None,
+          upperBound           = None,
+          zeroDateTimeBehavior = SourceSettings.MySQL.ZeroDateTimeBehavior.Exception,
+          fetchSize            = SourceSettings.MySQL.DefaultFetchSize,
+          where                = None,
+          connectionProperties = None
+        ),
+        target = TargetSettings.Scylla(
+          host                          = "scylla.example.com",
+          port                          = 9042,
+          localDC                       = Some("datacenter1"),
+          credentials                   = None,
+          sslOptions                    = None,
+          keyspace                      = "ks",
+          table                         = "users",
+          connections                   = Some(1),
+          stripTrailingZerosForDecimals = false,
+          writeTTLInS                   = None,
+          writeWritetimestampInuS       = None,
+          consistencyLevel              = "LOCAL_QUORUM"
+        ),
+        renames          = None,
+        savepoints       = Savepoints(300, savepointsDir.toString),
+        skipTokenRanges  = None,
+        skipSegments     = None,
+        skipParquetFiles = None,
+        validation       = None
+      )
+      val mysqlSourceDF = SourceDataFrame(
+        dataFrame           = null,
+        timestampColumns    = None,
+        savepointsSupported = false
+      )
+
+      val manager = ScyllaMigrator.savepointsManagerForSource(config, mysqlSourceDF)(
+        spark = null.asInstanceOf[SparkSession]
+      )
+
+      manager.foreach(_.close())
+      assertEquals(manager, None)
+      assert(!Files.exists(savepointsDir), "savepoints directory should not be created for MySQL")
+    } finally {
+      if (Files.exists(savepointsDir))
+        Files
+          .walk(savepointsDir)
+          .sorted(java.util.Comparator.reverseOrder())
+          .forEach(Files.delete)
+      Files.deleteIfExists(tempDir)
+    }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidatorTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidatorTest.scala
@@ -1,0 +1,923 @@
+package com.scylladb.migrator.scylla
+
+import com.scylladb.migrator.config.Rename
+import com.scylladb.migrator.readers.MySQL
+import com.scylladb.migrator.validation.RowComparisonFailure
+import org.apache.spark.sql.{ Row, SparkSession }
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{ IntegerType, StringType, StructField, StructType }
+
+import java.lang.reflect.{ InvocationHandler, Method, Proxy }
+import java.sql.{ DatabaseMetaData, ResultSet }
+
+class MySQLToScyllaValidatorTest extends munit.FunSuite {
+
+  private def dynamicProxy[A](iface: Class[A])(
+    handler: (Method, Array[AnyRef]) => AnyRef
+  ): A =
+    Proxy
+      .newProxyInstance(
+        iface.getClassLoader,
+        Array(iface),
+        new InvocationHandler {
+          override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef =
+            handler(method, Option(args).getOrElse(Array.empty[AnyRef]))
+        }
+      )
+      .asInstanceOf[A]
+
+  private def primaryKeyResultSet(rows: Seq[(Int, String)]): ResultSet = {
+    var index = -1
+    dynamicProxy(classOf[ResultSet]) { (method, args) =>
+      method.getName match {
+        case "next" =>
+          index += 1
+          Boolean.box(index < rows.size)
+        case "getShort" =>
+          assertEquals(args(0), "KEY_SEQ")
+          Short.box(rows(index)._1.toShort)
+        case "getString" =>
+          assertEquals(args(0), "COLUMN_NAME")
+          rows(index)._2
+        case "close"   => null
+        case "wasNull" => Boolean.box(false)
+        case other     => fail(s"Unexpected ResultSet method: $other")
+      }
+    }
+  }
+
+  private def areDifferent(
+    left: Option[Any],
+    right: Option[Any],
+    fpTol: Double = 0.0,
+    tsTol: Long = 0L
+  ): Boolean =
+    MySQLToScyllaValidator.areDifferent(left, right, tsTol, fpTol)
+
+  // --- Null / None handling ---
+
+  test("both None are equal") {
+    assert(!areDifferent(None, None))
+  }
+
+  test("Some vs None are different") {
+    assert(areDifferent(Some("a"), None))
+  }
+
+  test("None vs Some are different") {
+    assert(areDifferent(None, Some("a")))
+  }
+
+  // --- Basic equality ---
+
+  test("equal strings") {
+    assert(!areDifferent(Some("hello"), Some("hello")))
+  }
+
+  test("different strings") {
+    assert(areDifferent(Some("hello"), Some("world")))
+  }
+
+  test("equal integers") {
+    assert(!areDifferent(Some(42), Some(42)))
+  }
+
+  test("different integers") {
+    assert(areDifferent(Some(42), Some(43)))
+  }
+
+  // --- Timestamp comparison ---
+
+  test("java.sql.Timestamp within tolerance") {
+    val t1 = new java.sql.Timestamp(1000L)
+    val t2 = new java.sql.Timestamp(1050L)
+    assert(!areDifferent(Some(t1), Some(t2), tsTol = 100L))
+  }
+
+  test("java.sql.Timestamp outside tolerance") {
+    val t1 = new java.sql.Timestamp(1000L)
+    val t2 = new java.sql.Timestamp(1200L)
+    assert(areDifferent(Some(t1), Some(t2), tsTol = 100L))
+  }
+
+  test("java.sql.Timestamp with zero tolerance uses standard equality") {
+    val t1 = new java.sql.Timestamp(1000L)
+    val t2 = new java.sql.Timestamp(1001L)
+    assert(areDifferent(Some(t1), Some(t2), tsTol = 0L))
+  }
+
+  test("java.sql.Timestamp with zero tolerance preserves sub-millisecond precision") {
+    val t1 = java.sql.Timestamp.from(java.time.Instant.parse("2024-01-01T00:00:00.123456Z"))
+    val t2 = java.sql.Timestamp.from(java.time.Instant.parse("2024-01-01T00:00:00.123999Z"))
+
+    assert(areDifferent(Some(t1), Some(t2), tsTol = 0L))
+    assert(!areDifferent(Some(t1), Some(t2), tsTol = 1L))
+  }
+
+  test("java.time.Instant within tolerance") {
+    val i1 = java.time.Instant.ofEpochMilli(1000L)
+    val i2 = java.time.Instant.ofEpochMilli(1050L)
+    assert(!areDifferent(Some(i1), Some(i2), tsTol = 100L))
+  }
+
+  test("java.time.Instant outside tolerance") {
+    val i1 = java.time.Instant.ofEpochMilli(1000L)
+    val i2 = java.time.Instant.ofEpochMilli(1200L)
+    assert(areDifferent(Some(i1), Some(i2), tsTol = 100L))
+  }
+
+  test("java.time.Instant with zero tolerance uses standard equality") {
+    val i1 = java.time.Instant.ofEpochMilli(1000L)
+    val i2 = java.time.Instant.ofEpochMilli(1001L)
+    assert(areDifferent(Some(i1), Some(i2), tsTol = 0L))
+  }
+
+  test("java.time.Instant with zero tolerance preserves sub-millisecond precision") {
+    val i1 = java.time.Instant.parse("2024-01-01T00:00:00.123456Z")
+    val i2 = java.time.Instant.parse("2024-01-01T00:00:00.123999Z")
+
+    assert(areDifferent(Some(i1), Some(i2), tsTol = 0L))
+    assert(!areDifferent(Some(i1), Some(i2), tsTol = 1L))
+  }
+
+  // --- Float comparison ---
+
+  test("floats within tolerance") {
+    assert(!areDifferent(Some(1.0f), Some(1.001f), fpTol = 0.01))
+  }
+
+  test("floats outside tolerance") {
+    assert(areDifferent(Some(1.0f), Some(1.1f), fpTol = 0.01))
+  }
+
+  // --- Double comparison ---
+
+  test("doubles within tolerance") {
+    assert(!areDifferent(Some(1.0d), Some(1.001d), fpTol = 0.01))
+  }
+
+  test("doubles outside tolerance") {
+    assert(areDifferent(Some(1.0d), Some(1.1d), fpTol = 0.01))
+  }
+
+  // --- NaN / Infinity edge cases (bug #3) ---
+
+  test("Double NaN values are considered equal") {
+    assert(!areDifferent(Some(Double.NaN), Some(Double.NaN), fpTol = 0.01))
+  }
+
+  test("Float NaN values are considered equal") {
+    assert(!areDifferent(Some(Float.NaN), Some(Float.NaN), fpTol = 0.01))
+  }
+
+  test("Double NaN vs regular value are different") {
+    assert(areDifferent(Some(Double.NaN), Some(1.0d), fpTol = 0.01))
+  }
+
+  test("Float NaN vs regular value are different") {
+    assert(areDifferent(Some(Float.NaN), Some(1.0f), fpTol = 0.01))
+  }
+
+  test("Double positive infinity values are equal") {
+    assert(
+      !areDifferent(Some(Double.PositiveInfinity), Some(Double.PositiveInfinity), fpTol = 0.01)
+    )
+  }
+
+  test("Double positive infinity vs negative infinity are different") {
+    assert(
+      areDifferent(Some(Double.PositiveInfinity), Some(Double.NegativeInfinity), fpTol = 0.01)
+    )
+  }
+
+  // --- BigDecimal comparison ---
+
+  test("BigDecimals within tolerance") {
+    val a = new java.math.BigDecimal("100.001")
+    val b = new java.math.BigDecimal("100.002")
+    assert(!areDifferent(Some(a), Some(b), fpTol = 0.01))
+  }
+
+  test("BigDecimals outside tolerance") {
+    val a = new java.math.BigDecimal("100.0")
+    val b = new java.math.BigDecimal("100.1")
+    assert(areDifferent(Some(a), Some(b), fpTol = 0.01))
+  }
+
+  test("mixed integral wrapper types are considered equal") {
+    assert(!areDifferent(Some(42), Some(42L)))
+  }
+
+  test("integral and decimal wrapper types are considered equal") {
+    val decimal = new java.math.BigDecimal("42.0")
+    assert(!areDifferent(Some(42L), Some(decimal)))
+  }
+
+  test("mixed numeric wrappers still report real inequality") {
+    val decimal = new java.math.BigDecimal("42.1")
+    assert(areDifferent(Some(42), Some(decimal), fpTol = 0.0))
+  }
+
+  test("floating-point specials are normalized across wrapper types") {
+    assert(
+      !areDifferent(Some(Float.PositiveInfinity), Some(Double.PositiveInfinity), fpTol = 0.01)
+    )
+    assert(!areDifferent(Some(Float.NaN), Some(Double.NaN), fpTol = 0.01))
+  }
+
+  // --- Byte array comparison ---
+
+  test("equal byte arrays") {
+    val a = Array[Byte](1, 2, 3)
+    val b = Array[Byte](1, 2, 3)
+    assert(!areDifferent(Some(a), Some(b)))
+  }
+
+  test("different byte arrays") {
+    val a = Array[Byte](1, 2, 3)
+    val b = Array[Byte](1, 2, 4)
+    assert(areDifferent(Some(a), Some(b)))
+  }
+
+  // --- Generic array comparison ---
+
+  test("equal generic arrays") {
+    val a = Array("a", "b")
+    val b = Array("a", "b")
+    assert(!areDifferent(Some(a), Some(b)))
+  }
+
+  test("different generic arrays") {
+    val a = Array("a", "b")
+    val b = Array("a", "c")
+    assert(areDifferent(Some(a), Some(b)))
+  }
+
+  // --- validator preflight checks ---
+
+  test("validateTargetPrimaryKey accepts same columns with different case in the same order") {
+    MySQLToScyllaValidator.validateTargetPrimaryKey(
+      configuredPrimaryKey   = Seq("TenantId", "UserId"),
+      actualTargetPrimaryKey = Seq("tenantid", "userid")
+    )
+  }
+
+  test("validateTargetPrimaryKey rejects mismatched target PK") {
+    val error = intercept[RuntimeException] {
+      MySQLToScyllaValidator.validateTargetPrimaryKey(
+        configuredPrimaryKey   = Seq("tenant_id"),
+        actualTargetPrimaryKey = Seq("tenant_id", "user_id")
+      )
+    }
+    assert(error.getMessage.contains("does not match target table's actual PK"))
+  }
+
+  test("validateTargetPrimaryKey rejects target PK with the same columns in a different order") {
+    val error = intercept[RuntimeException] {
+      MySQLToScyllaValidator.validateTargetPrimaryKey(
+        configuredPrimaryKey   = Seq("TenantId", "UserId"),
+        actualTargetPrimaryKey = Seq("userid", "tenantid")
+      )
+    }
+    assert(error.getMessage.contains("does not match target table's actual PK"))
+  }
+
+  test("validateSourcePrimaryKey accepts same columns with different case in the same order") {
+    MySQLToScyllaValidator.validateSourcePrimaryKey(
+      configuredPrimaryKey   = Seq("TenantId", "UserId"),
+      actualSourcePrimaryKey = Seq("tenantid", "userid")
+    )
+  }
+
+  test("validateSourcePrimaryKey rejects mismatched source PK") {
+    val error = intercept[RuntimeException] {
+      MySQLToScyllaValidator.validateSourcePrimaryKey(
+        configuredPrimaryKey   = Seq("tenant_id"),
+        actualSourcePrimaryKey = Seq("tenant_id", "user_id")
+      )
+    }
+    assert(error.getMessage.contains("does not match the MySQL table's actual PK"))
+  }
+
+  test("validateSourcePrimaryKey rejects source PK with the same columns in a different order") {
+    val error = intercept[RuntimeException] {
+      MySQLToScyllaValidator.validateSourcePrimaryKey(
+        configuredPrimaryKey   = Seq("TenantId", "UserId"),
+        actualSourcePrimaryKey = Seq("userid", "tenantid")
+      )
+    }
+    assert(error.getMessage.contains("does not match the MySQL table's actual PK"))
+  }
+
+  test("sourcePrimaryKeyFromMetadata uses the literal table name") {
+    var requestedCatalog: String = null
+    var requestedTableName: String = null
+    val metaData = dynamicProxy(classOf[DatabaseMetaData]) { (method, args) =>
+      method.getName match {
+        case "getPrimaryKeys" =>
+          requestedCatalog = args(0).asInstanceOf[String]
+          assertEquals(args(1), null)
+          requestedTableName = args(2).asInstanceOf[String]
+          primaryKeyResultSet(Seq(2 -> "created_at", 1 -> "id"))
+        case other => fail(s"Unexpected DatabaseMetaData method: $other")
+      }
+    }
+
+    val primaryKey =
+      MySQLToScyllaValidator
+        .sourcePrimaryKeyFromMetadata(metaData, "source_db", "user_events%archive")
+
+    assertEquals(requestedCatalog, "source_db")
+    assertEquals(requestedTableName, "user_events%archive")
+    assertEquals(primaryKey, Seq("id", "created_at"))
+  }
+
+  test("liveWriteWarning explains the lack of point-in-time safety") {
+    val warning = MySQLToScyllaValidator.liveWriteWarning(
+      sourceSettings = com.scylladb.migrator.config.SourceSettings.MySQL(
+        host                 = "mysql",
+        port                 = 3306,
+        database             = "app",
+        table                = "users",
+        credentials          = com.scylladb.migrator.config.Credentials("u", "p"),
+        primaryKey           = Some(List("id")),
+        partitionColumn      = None,
+        numPartitions        = None,
+        lowerBound           = None,
+        upperBound           = None,
+        fetchSize            = 1000,
+        where                = None,
+        connectionProperties = None
+      ),
+      targetSettings = com.scylladb.migrator.config.TargetSettings.Scylla(
+        host                          = "scylla",
+        port                          = 9042,
+        localDC                       = None,
+        credentials                   = None,
+        sslOptions                    = None,
+        keyspace                      = "ks",
+        table                         = "users",
+        connections                   = None,
+        stripTrailingZerosForDecimals = false,
+        writeTTLInS                   = None,
+        writeWritetimestampInuS       = None,
+        consistencyLevel              = "LOCAL_QUORUM"
+      )
+    )
+
+    assert(warning.contains("not point-in-time safe"))
+    assert(warning.contains("app.users"))
+    assert(warning.contains("ks.users"))
+    assert(warning.contains("quiesced"))
+  }
+
+  test("validateSourceColumnsPresentInTarget allows target-only extra columns") {
+    MySQLToScyllaValidator.validateSourceColumnsPresentInTarget(
+      sourceColumns = Seq("id", "value"),
+      targetColumns = Seq("id", "value", "updated_at")
+    )
+    assertEquals(
+      MySQLToScyllaValidator.targetOnlyColumns(
+        sourceColumns = Seq("id", "value"),
+        targetColumns = Seq("id", "value", "updated_at")
+      ),
+      Seq("updated_at")
+    )
+  }
+
+  test("validateSourceColumnsPresentInTarget rejects source columns missing in target") {
+    val error = intercept[RuntimeException] {
+      MySQLToScyllaValidator.validateSourceColumnsPresentInTarget(
+        sourceColumns = Seq("id", "value", "missing_col"),
+        targetColumns = Seq("id", "value")
+      )
+    }
+    assert(error.getMessage.contains("missing_col"))
+  }
+
+  test("validateHashColumnsPresentOnBothSides accepts columns present in source and target") {
+    MySQLToScyllaValidator.validateHashColumnsPresentOnBothSides(
+      requestedHashColumns = Seq("payload", "checksum"),
+      sourceColumns        = Seq("id", "payload", "checksum"),
+      targetColumns        = Seq("id", "checksum", "payload", "updated_at")
+    )
+  }
+
+  test("validateHashColumnsPresentOnBothSides rejects columns missing in target") {
+    val error = intercept[RuntimeException] {
+      MySQLToScyllaValidator.validateHashColumnsPresentOnBothSides(
+        requestedHashColumns = Seq("payload", "checksum"),
+        sourceColumns        = Seq("id", "payload", "checksum"),
+        targetColumns        = Seq("id", "payload")
+      )
+    }
+    assert(error.getMessage.contains("missing in target: checksum"))
+  }
+
+  test("validateHashColumnsPresentOnBothSides rejects columns missing in source") {
+    val error = intercept[RuntimeException] {
+      MySQLToScyllaValidator.validateHashColumnsPresentOnBothSides(
+        requestedHashColumns = Seq("payload", "checksum"),
+        sourceColumns        = Seq("id", "payload"),
+        targetColumns        = Seq("id", "payload", "checksum")
+      )
+    }
+    assert(error.getMessage.contains("missing in source: checksum"))
+  }
+
+  test("buildCaseInsensitiveRenameMap resolves mixed-case rename entries") {
+    val renames = MySQLToScyllaValidator.buildCaseInsensitiveRenameMap(
+      List(Rename("UserId", "user_id"), Rename("DisplayName", "display_name"))
+    )
+
+    assertEquals(renames("userid"), "user_id")
+    assertEquals(renames("displayname"), "display_name")
+  }
+
+  test("buildCaseInsensitiveRenameMap rejects conflicting case-insensitive renames") {
+    val error = intercept[RuntimeException] {
+      MySQLToScyllaValidator.buildCaseInsensitiveRenameMap(
+        List(Rename("UserId", "user_id"), Rename("userid", "account_id"))
+      )
+    }
+
+    assert(error.getMessage.contains("conflicting case-insensitive mappings"))
+  }
+
+  test("escapeSparkColumnName quotes dots and doubles embedded backticks") {
+    assertEquals(MySQLToScyllaValidator.escapeSparkColumnName("user.name"), "`user.name`")
+    assertEquals(MySQLToScyllaValidator.escapeSparkColumnName("a`b"), "`a``b`")
+  }
+
+  test("compareFieldsBySchemaForRow ignores hash mismatches when decimal values are equal") {
+    val differingFields = MySQLToScyllaValidator.compareFieldsBySchemaForRow(
+      joinedRow = Row(
+        new java.math.BigDecimal("1.0"),
+        new java.math.BigDecimal("1.00"),
+        "src-hash",
+        "tgt-hash"
+      ),
+      directFieldIndices      = Nil,
+      hashBackedFieldIndices  = Seq(("amount", 0, 1)),
+      contentHashFieldIndices = Some((2, 3)),
+      timestampMsTolerance    = 0L,
+      floatingPointTolerance  = 0.0
+    )
+
+    assertEquals(differingFields, Nil)
+  }
+
+  test("compareFieldsBySchemaForRow reports hash-backed values outside tolerance") {
+    val differingFields = MySQLToScyllaValidator.compareFieldsBySchemaForRow(
+      joinedRow = Row(
+        new java.math.BigDecimal("1.0"),
+        new java.math.BigDecimal("1.2"),
+        "src-hash",
+        "tgt-hash"
+      ),
+      directFieldIndices      = Nil,
+      hashBackedFieldIndices  = Seq(("amount", 0, 1)),
+      contentHashFieldIndices = Some((2, 3)),
+      timestampMsTolerance    = 0L,
+      floatingPointTolerance  = 0.05
+    )
+
+    assertEquals(differingFields, List("amount"))
+  }
+
+  test("differingFieldsBetweenRows ignores decimal scale-only differences") {
+    val differingFields = MySQLToScyllaValidator.differingFieldsBetweenRows(
+      sourceRow              = Row(1, new java.math.BigDecimal("1.0")),
+      sourceFields           = Array("id", "amount"),
+      targetRow              = Row(1, new java.math.BigDecimal("1.00")),
+      targetFields           = Array("id", "amount"),
+      columns                = Seq("amount"),
+      timestampMsTolerance   = 0L,
+      floatingPointTolerance = 0.0
+    )
+
+    assertEquals(differingFields, Nil)
+  }
+
+  // --- prefixColumns tests (Spark-local) ---
+
+  private lazy val spark: SparkSession = SparkSession
+    .builder()
+    .master("local[1]")
+    .appName("MySQLToScyllaValidatorTest")
+    .config("spark.ui.enabled", "false")
+    .getOrCreate()
+
+  override def afterAll(): Unit = {
+    spark.stop()
+    super.afterAll()
+  }
+
+  test("prefixColumns renames all columns atomically") {
+    import spark.implicits._
+    val df = Seq((1, "a"), (2, "b")).toDF("id", "name")
+    val prefixed = MySQLToScyllaValidator.prefixColumns(df, "src_")
+    assertEquals(prefixed.columns.toList, List("src_id", "src_name"))
+    assertEquals(prefixed.count(), 2L)
+  }
+
+  test("prefixColumns handles columns that match prefix pattern") {
+    import spark.implicits._
+    // Column "src_status" already looks like a prefixed name -- should not collide
+    val df = Seq((1, "ok", "active")).toDF("status", "src_status", "flag")
+    val prefixed = MySQLToScyllaValidator.prefixColumns(df, "src_")
+    assertEquals(prefixed.columns.sorted.toList, List("src_flag", "src_src_status", "src_status"))
+    assertEquals(prefixed.count(), 1L)
+  }
+
+  test("sparkColumn resolves literal column names with dots and backticks") {
+    import spark.implicits._
+    val df = Seq((1, "alpha", "beta")).toDF("id", "user.name", "a`b")
+    val selected = df.select(
+      MySQLToScyllaValidator.sparkColumn("user.name").as("user.name"),
+      MySQLToScyllaValidator.sparkColumn("a`b").as("a`b")
+    )
+
+    assertEquals(selected.columns.toList, List("user.name", "a`b"))
+    assertEquals(selected.collect().toList, List(Row("alpha", "beta")))
+  }
+
+  test("prefixColumns preserves literal column names with dots and backticks") {
+    import spark.implicits._
+    val df = Seq((1, "alpha", "beta")).toDF("id", "user.name", "a`b")
+    val prefixed = MySQLToScyllaValidator.prefixColumns(df, "src_")
+
+    assertEquals(prefixed.columns.toList, List("src_id", "src_user.name", "src_a`b"))
+    assertEquals(prefixed.collect().toList, List(Row(1, "alpha", "beta")))
+  }
+
+  // --- addContentHash tests (Spark-local) ---
+
+  test("addContentHash adds hash column and drops hashed columns") {
+    import spark.implicits._
+    val df = Seq((1, "hello", 42)).toDF("id", "text", "num")
+    val hashed =
+      MySQLToScyllaValidator.addContentHash(df, List("text", "num"), List("id"))
+    assert(hashed.columns.contains(MySQL.ContentHashColumn))
+    assert(!hashed.columns.contains("text"))
+    assert(!hashed.columns.contains("num"))
+    assert(hashed.columns.contains("id"))
+  }
+
+  test("addContentHash preserves PK columns even if they are in hashCols") {
+    import spark.implicits._
+    val df = Seq((1, "hello")).toDF("id", "text")
+    // id is in pkCols, so it should not be dropped even though we hash text
+    val hashed =
+      MySQLToScyllaValidator.addContentHash(df, List("text"), List("id"))
+    assert(hashed.columns.contains("id"))
+    assert(hashed.columns.contains(MySQL.ContentHashColumn))
+  }
+
+  test("addContentHash returns DF unchanged when no hash columns exist") {
+    import spark.implicits._
+    val df = Seq((1, "hello")).toDF("id", "text")
+    val result =
+      MySQLToScyllaValidator.addContentHash(df, List("nonexistent"), List("id"))
+    assertEquals(result.columns.toSet, df.columns.toSet)
+    assert(!result.columns.contains(MySQL.ContentHashColumn))
+  }
+
+  test("addContentHash handles NULL values without error") {
+    import spark.implicits._
+    val df = Seq((1, Option.empty[String]), (2, Some("hello"))).toDF("id", "text")
+    val hashed =
+      MySQLToScyllaValidator.addContentHash(df, List("text"), List("id"))
+    assert(hashed.columns.contains(MySQL.ContentHashColumn))
+    assertEquals(hashed.count(), 2L)
+  }
+
+  test("addContentHash produces SHA-256 hex digests") {
+    import spark.implicits._
+    val df = Seq((1, "hello")).toDF("id", "text")
+    val hashed = MySQLToScyllaValidator.addContentHash(df, List("text"), List("id"))
+    val hash = hashed.select(MySQL.ContentHashColumn).collect().head.getString(0)
+
+    assertEquals(hash.length, 64)
+    assert(hash.matches("[0-9a-f]{64}"))
+  }
+
+  test("addContentHash distinguishes NULL from the literal string 'NULL'") {
+    import spark.implicits._
+    val df = Seq(
+      (1, Option.empty[String]),
+      (2, Some("NULL"))
+    ).toDF("id", "text")
+    val hashed = MySQLToScyllaValidator.addContentHash(df, List("text"), List("id"))
+    val hashes = hashed.select(MySQL.ContentHashColumn).collect().map(_.getString(0))
+    assertNotEquals(hashes(0), hashes(1))
+  }
+
+  test("addContentHash distinguishes NULL from the literal string '__NULL_SENTINEL__'") {
+    import spark.implicits._
+    val df = Seq(
+      (1, Option.empty[String]),
+      (2, Some("__NULL_SENTINEL__"))
+    ).toDF("id", "text")
+    val hashed = MySQLToScyllaValidator.addContentHash(df, List("text"), List("id"))
+    val hashes = hashed.orderBy("id").select(MySQL.ContentHashColumn).collect().map(_.getString(0))
+    assertNotEquals(hashes(0), hashes(1))
+  }
+
+  test("addContentHash hashes binary columns from raw bytes") {
+    import spark.implicits._
+    val df = Seq(
+      (1, Array[Byte](1, 2, 3)),
+      (2, Array[Byte](1, 2, 4))
+    ).toDF("id", "payload")
+    val hashed = MySQLToScyllaValidator.addContentHash(df, List("payload"), List("id"))
+    val hashes = hashed.orderBy("id").select(MySQL.ContentHashColumn).collect().map(_.getString(0))
+    assertNotEquals(hashes(0), hashes(1))
+  }
+
+  test("addContentHash handles column names with dots and backticks") {
+    import spark.implicits._
+    val df = Seq((1, "alpha", "beta")).toDF("id", "user.name", "a`b")
+    val hashed =
+      MySQLToScyllaValidator.addContentHash(df, List("user.name", "a`b"), List("id"))
+
+    assertEquals(hashed.columns.toList, List("id", MySQL.ContentHashColumn))
+    assertEquals(hashed.count(), 1L)
+  }
+
+  test("addContentHash produces same hash regardless of DataFrame column order") {
+    import spark.implicits._
+    // Simulate source with columns in one order and target with columns in different order.
+    // The hash should be identical for the same data.
+    val df1 = Seq((1, "hello", 42)).toDF("id", "Name", "Age")
+    val df2 = Seq((1, 42, "hello")).toDF("id", "age", "name")
+    val hashed1 =
+      MySQLToScyllaValidator.addContentHash(df1, List("Name", "Age"), List("id"))
+    val hashed2 =
+      MySQLToScyllaValidator.addContentHash(df2, List("name", "age"), List("id"))
+    val hash1 = hashed1.select(MySQL.ContentHashColumn).collect().map(_.getString(0))
+    val hash2 = hashed2.select(MySQL.ContentHashColumn).collect().map(_.getString(0))
+    assertEquals(hash1.toList, hash2.toList)
+  }
+
+  test("addContentHash can preserve hash-backed columns for fallback comparison") {
+    import spark.implicits._
+    val df = Seq((1, "hello", 42)).toDF("id", "text", "num")
+    val hashed =
+      MySQLToScyllaValidator.addContentHash(
+        df,
+        List("text", "num"),
+        List("id"),
+        dropHashedColumns = false
+      )
+
+    assert(hashed.columns.contains("text"))
+    assert(hashed.columns.contains("num"))
+    assert(hashed.columns.contains(MySQL.ContentHashColumn))
+  }
+
+  test("hash-based comparison join schema excludes hashed payload columns") {
+    import spark.implicits._
+    val source = Seq((1, "hello", 42)).toDF("id", "text", "num")
+    val target = Seq((1, "hello", 42)).toDF("id", "text", "num")
+
+    val hashedSource =
+      MySQLToScyllaValidator.addContentHash(source, List("text", "num"), List("id"))
+    val hashedTarget =
+      MySQLToScyllaValidator.addContentHash(target, List("text", "num"), List("id"))
+
+    val joined = MySQLToScyllaValidator
+      .prefixColumns(hashedSource, "src_")
+      .join(
+        MySQLToScyllaValidator.prefixColumns(hashedTarget, "tgt_"),
+        col("src_id") === col("tgt_id"),
+        "inner"
+      )
+
+    assert(!joined.columns.contains("src_text"))
+    assert(!joined.columns.contains("src_num"))
+    assert(!joined.columns.contains("tgt_text"))
+    assert(!joined.columns.contains("tgt_num"))
+    assert(joined.columns.contains(s"src_${MySQL.ContentHashColumn}"))
+    assert(joined.columns.contains(s"tgt_${MySQL.ContentHashColumn}"))
+  }
+
+  test("resolveHashBackedDifferences refines sampled hash mismatches by primary key") {
+    import spark.implicits._
+    implicit val sparkSession: SparkSession = spark
+    val source = Seq(
+      (1, "blob-a", "same"),
+      (2, "blob-b", "same")
+    ).toDF("id", "payload", "comment")
+    val target = Seq(
+      (1, "blob-a", "same"),
+      (2, "blob-b", "changed")
+    ).toDF("id", "payload", "comment")
+
+    val differingFields = MySQLToScyllaValidator.resolveHashBackedDifferences(
+      rawSourceDF            = source,
+      rawTargetDF            = target,
+      primaryKey             = Seq("id"),
+      primaryKeyValues       = Seq(Vector[Any](2)),
+      hashBackedColumns      = Seq("payload", "comment"),
+      timestampMsTolerance   = 0L,
+      floatingPointTolerance = 0.0
+    )(spark)
+
+    assertEquals(
+      differingFields,
+      Map(Vector[Any](2) -> List("comment (source=same, target=changed)"))
+    )
+  }
+
+  test("selectColumnsForHashRefinement keeps only PK and hash-backed columns") {
+    import spark.implicits._
+    val df = Seq((1, "blob-a", "same", "ignored")).toDF("id", "payload", "comment", "extra")
+
+    val selected = MySQLToScyllaValidator.selectColumnsForHashRefinement(
+      df,
+      primaryKey        = Seq("id"),
+      hashBackedColumns = Seq("payload", "comment")
+    )
+
+    assertEquals(selected.columns.toList, List("id", "payload", "comment"))
+  }
+
+  test("collectExtraTargetFailureSample only reports target-only keys and honors the limit") {
+    import spark.implicits._
+    val sourceKeys = Seq((1, "tenant-a"), (2, "tenant-b")).toDF("id", "tenant")
+    val targetKeys =
+      Seq((1, "tenant-a"), (3, "tenant-c"), (4, "tenant-d")).toDF("id", "tenant")
+
+    val failures = MySQLToScyllaValidator.collectExtraTargetFailureSample(
+      sourceKeys,
+      targetKeys,
+      primaryKeyColumns = Seq("id", "tenant"),
+      failuresToFetch   = 1
+    )
+
+    assertEquals(failures.length, 1)
+    assertEquals(failures.head.otherRepr, None)
+    assertEquals(failures.head.items, List(RowComparisonFailure.Item.ExtraTargetRow))
+    assert(failures.head.rowRepr.contains("id="))
+    assert(failures.head.rowRepr.contains("tenant="))
+  }
+
+  test("resolveHashBackedDifferences handles binary primary keys by content") {
+    import spark.implicits._
+    implicit val sparkSession: SparkSession = spark
+    val source = Seq(
+      (Array[Byte](1, 2), "blob-a", "same")
+    ).toDF("id", "payload", "comment")
+    val target = Seq(
+      (Array[Byte](1, 2), "blob-a", "changed")
+    ).toDF("id", "payload", "comment")
+    val requestedPk = Vector[Any](Array[Byte](1, 2))
+
+    val differingFields = MySQLToScyllaValidator.resolveHashBackedDifferences(
+      rawSourceDF            = source,
+      rawTargetDF            = target,
+      primaryKey             = Seq("id"),
+      primaryKeyValues       = Seq(requestedPk),
+      hashBackedColumns      = Seq("payload", "comment"),
+      timestampMsTolerance   = 0L,
+      floatingPointTolerance = 0.0
+    )(spark)
+
+    assertEquals(
+      differingFields,
+      Map(
+        MySQLToScyllaValidator.normalizePrimaryKeyValues(requestedPk) ->
+          List("comment (source=same, target=changed)")
+      )
+    )
+  }
+
+  test("collectFailureSample keeps scanning until it finds a real hash-backed failure") {
+    import spark.implicits._
+    implicit val sparkSession: SparkSession = spark
+
+    val source = Seq(
+      (1, new java.math.BigDecimal("1.0")),
+      (2, new java.math.BigDecimal("2.0"))
+    ).toDF("id", "amount")
+    val target = Seq(
+      (1, new java.math.BigDecimal("1.00")),
+      (2, new java.math.BigDecimal("3.0"))
+    ).toDF("id", "amount")
+
+    val candidates = spark.sparkContext.parallelize(
+      Seq[MySQLToScyllaValidator.ValidationCandidate](
+        MySQLToScyllaValidator.MatchedRowValidationCandidate(
+          sourcePkValues        = Vector[Any](1),
+          sourceRepr            = "id=1",
+          targetRepr            = "id=1",
+          directDifferingFields = Nil,
+          hashMismatch          = true
+        ),
+        MySQLToScyllaValidator.MatchedRowValidationCandidate(
+          sourcePkValues        = Vector[Any](2),
+          sourceRepr            = "id=2",
+          targetRepr            = "id=2",
+          directDifferingFields = Nil,
+          hashMismatch          = true
+        )
+      ),
+      1
+    )
+
+    val failures = MySQLToScyllaValidator.collectFailureSample(
+      candidateFailuresRdd   = candidates,
+      rawSourceDF            = source,
+      rawTargetDF            = target,
+      primaryKey             = Seq("id"),
+      hashBackedColumns      = Seq("amount"),
+      timestampMsTolerance   = 0L,
+      floatingPointTolerance = 0.0,
+      failuresToFetch        = 1
+    )(spark)
+
+    assertEquals(failures.map(_.rowRepr), List("id=2"))
+    val differingFields =
+      failures.head.items.collectFirst {
+        case RowComparisonFailure.Item.DifferingFieldValues(fields) => fields
+      }
+    assertEquals(differingFields.map(_.size), Some(1))
+    assert(differingFields.exists(_.head.startsWith("amount (source=2")))
+    assert(differingFields.exists(_.head.contains("target=3")))
+  }
+
+  test("collectFailureSample reuses cached hash refinement projections across batches") {
+    implicit val sparkSession: SparkSession = spark
+
+    val schema = StructType(
+      Seq(
+        StructField("id", IntegerType, nullable     = false),
+        StructField("payload", StringType, nullable = true)
+      )
+    )
+
+    val sourceReads = spark.sparkContext.longAccumulator("hash-refinement-source-reads")
+    val targetReads = spark.sparkContext.longAccumulator("hash-refinement-target-reads")
+
+    val source = spark.createDataFrame(
+      spark.sparkContext
+        .parallelize(
+          Seq(Row(1, "same"), Row(2, "left")),
+          1
+        )
+        .mapPartitions { rows =>
+          sourceReads.add(1L)
+          rows
+        },
+      schema
+    )
+    val target = spark.createDataFrame(
+      spark.sparkContext
+        .parallelize(
+          Seq(Row(1, "same"), Row(2, "right")),
+          1
+        )
+        .mapPartitions { rows =>
+          targetReads.add(1L)
+          rows
+        },
+      schema
+    )
+
+    val candidates = spark.sparkContext.parallelize(
+      Seq[MySQLToScyllaValidator.ValidationCandidate](
+        MySQLToScyllaValidator.MatchedRowValidationCandidate(
+          sourcePkValues        = Vector[Any](1),
+          sourceRepr            = "id=1",
+          targetRepr            = "id=1",
+          directDifferingFields = Nil,
+          hashMismatch          = true
+        ),
+        MySQLToScyllaValidator.MatchedRowValidationCandidate(
+          sourcePkValues        = Vector[Any](2),
+          sourceRepr            = "id=2",
+          targetRepr            = "id=2",
+          directDifferingFields = Nil,
+          hashMismatch          = true
+        )
+      ),
+      1
+    )
+
+    val failures = MySQLToScyllaValidator.collectFailureSample(
+      candidateFailuresRdd   = candidates,
+      rawSourceDF            = source,
+      rawTargetDF            = target,
+      primaryKey             = Seq("id"),
+      hashBackedColumns      = Seq("payload"),
+      timestampMsTolerance   = 0L,
+      floatingPointTolerance = 0.0,
+      failuresToFetch        = 1
+    )
+
+    assertEquals(failures.map(_.rowRepr), List("id=2"))
+    assert(sourceReads.value == 1L)
+    assert(targetReads.value == 1L)
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaSparkConnectionOptionsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaSparkConnectionOptionsTest.scala
@@ -1,0 +1,198 @@
+package com.scylladb.migrator.scylla
+
+import com.datastax.spark.connector.datasource.CassandraSourceUtil
+import com.scylladb.migrator.Connectors
+import com.scylladb.migrator.config.{ Credentials, SSLOptions, TargetSettings }
+import org.apache.spark.SparkConf
+
+class ScyllaSparkConnectionOptionsTest extends munit.FunSuite {
+
+  private val baseTarget = TargetSettings.Scylla(
+    host                          = "scylla-host",
+    port                          = 9042,
+    localDC                       = None,
+    credentials                   = None,
+    sslOptions                    = None,
+    keyspace                      = "ks",
+    table                         = "tbl",
+    connections                   = None,
+    stripTrailingZerosForDecimals = false,
+    writeTTLInS                   = None,
+    writeWritetimestampInuS       = None,
+    consistencyLevel              = "LOCAL_QUORUM"
+  )
+
+  private def scoped(
+    key: String,
+    cluster: String = ScyllaSparkConnectionOptions.MySQLValidatorCluster
+  ) =
+    s"$cluster/$key"
+
+  test("base case: no credentials, no SSL, no localDC, no connections") {
+    val readerOpts = ScyllaSparkConnectionOptions.readerOptionsFromTargetSettings(baseTarget)
+    val sessionConf = ScyllaSparkConnectionOptions.sessionConfFromTargetSettings(baseTarget)
+    assertEquals(readerOpts("keyspace"), "ks")
+    assertEquals(readerOpts("table"), "tbl")
+    assertEquals(readerOpts("cluster"), ScyllaSparkConnectionOptions.MySQLValidatorCluster)
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.host")), "scylla-host")
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.port")), "9042")
+    assert(!sessionConf.contains("spark.cassandra.connection.host"))
+    assert(!readerOpts.contains("spark.cassandra.connection.host"))
+    assert(!readerOpts.contains("spark.cassandra.auth.username"))
+    assert(!sessionConf.contains(scoped("spark.cassandra.auth.password")))
+    assert(!sessionConf.contains(scoped("spark.cassandra.connection.ssl.enabled")))
+    assert(!sessionConf.contains(scoped("spark.cassandra.connection.localDC")))
+    assert(!sessionConf.contains(scoped("spark.cassandra.connection.localConnectionsPerExecutor")))
+  }
+
+  test("full case: all options provided") {
+    val target = baseTarget.copy(
+      localDC     = Some("dc1"),
+      credentials = Some(Credentials("user", "pass")),
+      sslOptions = Some(
+        SSLOptions(
+          clientAuthEnabled  = true,
+          enabled            = true,
+          enabledAlgorithms  = Some(Set("TLS_RSA_WITH_AES_128_CBC_SHA")),
+          keyStorePassword   = Some("ksPass"),
+          keyStorePath       = Some("/path/ks"),
+          keyStoreType       = Some("PKCS12"),
+          protocol           = Some("TLSv1.2"),
+          trustStorePassword = Some("tsPass"),
+          trustStorePath     = Some("/path/ts"),
+          trustStoreType     = Some("PKCS12")
+        )
+      ),
+      connections = Some(16)
+    )
+    val readerOpts = ScyllaSparkConnectionOptions.readerOptionsFromTargetSettings(target)
+    val sessionConf = ScyllaSparkConnectionOptions.sessionConfFromTargetSettings(target)
+    assertEquals(readerOpts("cluster"), ScyllaSparkConnectionOptions.MySQLValidatorCluster)
+    assertEquals(sessionConf(scoped("spark.cassandra.auth.username")), "user")
+    assertEquals(sessionConf(scoped("spark.cassandra.auth.password")), "pass")
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.localDC")), "dc1")
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.ssl.enabled")), "true")
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.ssl.clientAuth.enabled")), "true")
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.ssl.trustStore.path")), "/path/ts")
+    assertEquals(
+      sessionConf(scoped("spark.cassandra.connection.ssl.trustStore.password")),
+      "tsPass"
+    )
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.ssl.trustStore.type")), "PKCS12")
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.ssl.keyStore.path")), "/path/ks")
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.ssl.keyStore.password")), "ksPass")
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.ssl.keyStore.type")), "PKCS12")
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.ssl.protocol")), "TLSv1.2")
+    assertEquals(
+      sessionConf(scoped("spark.cassandra.connection.ssl.enabledAlgorithms")),
+      "TLS_RSA_WITH_AES_128_CBC_SHA"
+    )
+    assertEquals(
+      sessionConf(scoped("spark.cassandra.connection.localConnectionsPerExecutor")),
+      "16"
+    )
+    assertEquals(
+      sessionConf(scoped("spark.cassandra.connection.remoteConnectionsPerExecutor")),
+      "16"
+    )
+  }
+
+  test("partial SSL: some SSL fields None are absent from the result map") {
+    val target = baseTarget.copy(
+      sslOptions = Some(
+        SSLOptions(
+          clientAuthEnabled  = false,
+          enabled            = true,
+          enabledAlgorithms  = None,
+          keyStorePassword   = None,
+          keyStorePath       = None,
+          keyStoreType       = None,
+          protocol           = None,
+          trustStorePassword = Some("tsPass"),
+          trustStorePath     = Some("/path/ts"),
+          trustStoreType     = None
+        )
+      )
+    )
+    val sessionConf = ScyllaSparkConnectionOptions.sessionConfFromTargetSettings(target)
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.ssl.enabled")), "true")
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.ssl.trustStore.path")), "/path/ts")
+    assertEquals(
+      sessionConf(scoped("spark.cassandra.connection.ssl.trustStore.password")),
+      "tsPass"
+    )
+    // Defaults are applied for type, protocol, algorithms
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.ssl.trustStore.type")), "JKS")
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.ssl.keyStore.type")), "JKS")
+    assertEquals(sessionConf(scoped("spark.cassandra.connection.ssl.protocol")), "TLS")
+    // Optional fields that are None should be absent
+    assert(!sessionConf.contains(scoped("spark.cassandra.connection.ssl.keyStore.path")))
+    assert(!sessionConf.contains(scoped("spark.cassandra.connection.ssl.keyStore.password")))
+    // No null values in the map
+    assert(sessionConf.values.forall(_ != null), "Map must not contain null values")
+  }
+
+  test("credentials present adds auth keys") {
+    val target = baseTarget.copy(credentials = Some(Credentials("admin", "secret")))
+    val readerOpts = ScyllaSparkConnectionOptions.readerOptionsFromTargetSettings(target)
+    val sessionConf = ScyllaSparkConnectionOptions.sessionConfFromTargetSettings(target)
+    assert(!readerOpts.contains("spark.cassandra.auth.username"))
+    assert(!readerOpts.contains("spark.cassandra.auth.password"))
+    assertEquals(sessionConf(scoped("spark.cassandra.auth.username")), "admin")
+    assertEquals(sessionConf(scoped("spark.cassandra.auth.password")), "secret")
+  }
+
+  test("credentials absent omits auth keys") {
+    val sessionConf = ScyllaSparkConnectionOptions.sessionConfFromTargetSettings(baseTarget)
+    assert(!sessionConf.contains(scoped("spark.cassandra.auth.username")))
+    assert(!sessionConf.contains(scoped("spark.cassandra.auth.password")))
+  }
+
+  test("connector consolidates alias-scoped session config for non-default cluster") {
+    val readerOpts = ScyllaSparkConnectionOptions.readerOptionsFromTargetSettings(baseTarget)
+    val sessionConf = ScyllaSparkConnectionOptions.sessionConfFromTargetSettings(baseTarget)
+    val cluster = readerOpts("cluster")
+    val consolidated = CassandraSourceUtil.consolidateConfs(
+      sparkConf   = new SparkConf(false),
+      sqlConf     = sessionConf,
+      cluster     = cluster,
+      keyspace    = readerOpts("keyspace"),
+      userOptions = readerOpts
+    )
+
+    assertEquals(consolidated.get("spark.cassandra.connection.host"), "scylla-host")
+    assertEquals(consolidated.get("spark.cassandra.connection.port"), "9042")
+    assertEquals(consolidated.get("spark.cassandra.query.retry.count"), "-1")
+  }
+
+  test("helper reuses the production target connector session defaults") {
+    val target = baseTarget.copy(
+      localDC     = Some("dc1"),
+      credentials = Some(Credentials("user", "pass")),
+      sslOptions = Some(
+        SSLOptions(
+          clientAuthEnabled  = true,
+          enabled            = true,
+          enabledAlgorithms  = Some(Set("TLS_RSA_WITH_AES_128_CBC_SHA")),
+          keyStorePassword   = Some("ksPass"),
+          keyStorePath       = Some("/path/ks"),
+          keyStoreType       = Some("PKCS12"),
+          protocol           = Some("TLSv1.2"),
+          trustStorePassword = Some("tsPass"),
+          trustStorePath     = Some("/path/ts"),
+          trustStoreType     = Some("PKCS12")
+        )
+      ),
+      connections = Some(16)
+    )
+
+    val sharedSessionDefaults =
+      Connectors.sparkSessionOptions(Connectors.targetSessionOptions(target))
+    val helperSessionConf = ScyllaSparkConnectionOptions.sessionConfFromTargetSettings(target)
+
+    assertEquals(
+      helperSessionConf - scoped("spark.cassandra.input.consistency.level"),
+      sharedSessionDefaults.map { case (key, value) => scoped(key) -> value }
+    )
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
@@ -102,4 +102,21 @@ class CassandraRowComparisonTest extends munit.FunSuite {
     assertEquals(result, expected)
   }
 
+  test("BigDecimal and integral wrappers remain different for Cassandra validation") {
+    val left = CassandraRow.fromMap(Map("foo" -> new java.math.BigDecimal("42.0")))
+    val right = CassandraRow.fromMap(Map("foo" -> 42L))
+
+    val result = compareItems(left, Some(right))
+    val expected =
+      Some(
+        cassandraRowComparisonFailure(
+          left,
+          Some(right),
+          List(Item.DifferingFieldValues(List("foo")))
+        )
+      )
+
+    assertEquals(result, expected)
+  }
+
 }

--- a/tests/src/test/scala/com/scylladb/migrator/validation/DynamoDBRowComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/DynamoDBRowComparisonTest.scala
@@ -320,4 +320,15 @@ class DynamoDBRowComparisonTest extends munit.FunSuite {
     assertEquals(result, expected)
   }
 
+  test("BigDecimal and integral wrappers remain different for shared row comparison") {
+    assert(
+      RowComparisonFailure.areDifferent(
+        Some(new java.math.BigDecimal("42.0")),
+        Some(42L),
+        timestampMsTolerance   = 0L,
+        floatingPointTolerance = floatingPointTolerance
+      )
+    )
+  }
+
 }

--- a/tests/src/test/scala/com/scylladb/migrator/writers/ScyllaPrimaryKeyFilteringTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/writers/ScyllaPrimaryKeyFilteringTest.scala
@@ -88,4 +88,41 @@ class ScyllaPrimaryKeyFilteringTest extends munit.FunSuite {
     assertEquals(keptRows, Set(("a", "1", "ok-1"), ("d", "4", "ok-2")))
     assert(droppedRows.value == 2L)
   }
+
+  test("requireNoCaseInsensitiveColumnNameCollisions accepts unique names") {
+    Scylla.requireNoCaseInsensitiveColumnNameCollisions(
+      Seq("id", "Value", "payload"),
+      "while testing"
+    )
+  }
+
+  test("requireNoCaseInsensitiveColumnNameCollisions rejects duplicate names after renames") {
+    import spark.implicits._
+
+    val df = Seq((1, 2)).toDF("a", "b")
+    val renamedSchema = df.withColumnRenamed("a", "b").schema
+
+    val error = intercept[IllegalArgumentException] {
+      Scylla.requireNoCaseInsensitiveColumnNameCollisions(
+        renamedSchema.fieldNames.toSeq,
+        "after applying renames before writing to ScyllaDB"
+      )
+    }
+
+    assert(
+      error.getMessage.contains("Column name collision detected")
+    )
+    assert(error.getMessage.contains("[b]"))
+  }
+
+  test("requireNoCaseInsensitiveColumnNameCollisions rejects case-only duplicates") {
+    val error = intercept[IllegalArgumentException] {
+      Scylla.requireNoCaseInsensitiveColumnNameCollisions(
+        Seq("UserId", "userid", "value"),
+        "while testing"
+      )
+    }
+
+    assert(error.getMessage.contains("[UserId, userid]"))
+  }
 }


### PR DESCRIPTION
## Summary
Add MySQL as a migration and validation source for ScyllaDB, with comprehensive security hardening, config validation, and hash-based validation support.

## Context
The scylla-migrator previously supported Cassandra, DynamoDB, and Parquet as migration sources. This PR adds MySQL as a new source type, enabling users to migrate data from MySQL databases to ScyllaDB via Spark JDBC. A post-migration validator is also included to verify data integrity using either full row comparison or content-hash-based comparison for large tables.

## Changes

### Core Migration Support
- New `SourceSettings.MySQL` configuration type with full YAML parsing, defaults, and extensive parse-time validation (~20 checks including host/database/table format, port range, credential non-emptiness, partition consistency, SQL injection prevention)
- JDBC reader (`readers/MySQL.scala`) with hardened URL construction, cursor-based fetching, and partitioned read support
- `MySQLSchemaLogger` for diagnostic logging of MySQL-to-CQL type mappings
- Wiring in `Migrator.scala` and `Validator.scala` for the `(MySQL, Scylla)` source/target combination

### Validation
- `MySQLToScyllaValidator` with full-outer join approach, column rename support, case-insensitive field resolution, and content-hash mode (`MD5`-based, computed in Spark on both sides to avoid cross-system hash divergence)
- `hashColumns` config option in `Validation` to reduce shuffle volume for wide tables
- Shared `RowComparisonFailure.areDifferent` with tolerance support for timestamps, floats, BigDecimals, NaN/Infinity, and byte arrays

### Security Hardening
- 21 dangerous JDBC properties blocked (`allowLoadLocalInFile`, `autoDeserialize`, `queryInterceptors`, etc.)
- Dangerous SQL keyword detection in WHERE clauses upgraded to hard reject with expanded keyword list (DROP, DELETE, TRUNCATE, ALTER, CREATE, EXEC, EXECUTE, UNION, INTO, OUTFILE, DUMPFILE, LOAD_FILE, BENCHMARK, SLEEP, GRANT, REVOKE)
- SQL comment stripping before keyword check to prevent bypass via `UNI/**/ON`
- Control character blocking in WHERE clauses
- Password redaction in savepoint YAML output with clear error when loading redacted savepoints
- Connection property redaction for sensitive keys (`password|secret|token|credential`)
- TLS keystore URL scheme warnings
- `spark.redaction.regex` configuration warnings

### Code Review Fixes (second commit)
- Narrowed `connectionProperties` redaction regex from `password|secret|key` to `password|secret|token|credential` to avoid false positives on keys like `sslKeyManagerFactory`
- Replaced `df.rdd.getNumPartitions` with `df.queryExecution.executedPlan.execute().getNumPartitions` to avoid RDD conversion overhead
- Added `fetchSize > 10000` warning for memory-sensitive workloads
- Removed trivial `valuesAreDifferent` wrapper, calling `RowComparisonFailure.areDifferent` directly
- Fixed incorrect test comment about `timestampMsTolerance = 0` code path

## Testing
Unit tests (no external services required):
```bash
make test-unit
```

All 283 unit tests pass, including:
- `MySQLSourceSettingsParserTest` (35 tests) - config parsing, validation failures, edge cases
- `MySQLReaderTest` - `escapeIdentifier`, `buildJdbcUrl`, host validation
- `MySQLToScyllaValidatorTest` - value comparison, prefix columns, content hash computation
- `MySQLConfigSerializationTest` (3 tests) - YAML render/redaction verification
- `ScyllaSparkConnectionOptionsTest` - target connection options

Linting:
```bash
make lint
```
