### PR TITLE
fix the issue reported in issue #247

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
@@ -145,6 +145,10 @@ object AlternatorMigrator {
               .writeRDD(target, migratorConfig.renamesMap, sourceRDD, targetTableDesc)
           }
         } else {
+          log.warn(
+            "Savepoints are not supported when the source is a DynamoDB S3 export. " +
+              "If the migration is interrupted, it will reprocess all data on restart."
+          )
           log.info("Starting write...")
           writers.DynamoDB.writeRDD(target, migratorConfig.renamesMap, sourceRDD, targetTableDesc)
         }

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
@@ -26,7 +26,14 @@ object AlternatorMigrator {
     val (sourceRDD, sourceTableDesc) =
       readers.DynamoDB.readRDD(spark, source, migratorConfig.skipSegments)
     val maybeStreamedSource = if (target.streamChanges) Some(source) else None
-    migrate(sourceRDD, sourceTableDesc, maybeStreamedSource, target, migratorConfig)
+    migrate(
+      sourceRDD,
+      sourceTableDesc,
+      maybeStreamedSource,
+      target,
+      migratorConfig,
+      hadoopPartitionedSource = true
+    )
   }
 
   def migrateToS3Export(
@@ -65,7 +72,14 @@ object AlternatorMigrator {
     if (target.streamChanges) {
       log.warn("'streamChanges: true' is not supported when the source is a DynamoDB S3 export.")
     }
-    migrate(normalizedRDD, sourceTableDesc, None, target, migratorConfig)
+    migrate(
+      normalizedRDD,
+      sourceTableDesc,
+      None,
+      target,
+      migratorConfig,
+      hadoopPartitionedSource = false
+    )
   }
 
   /** @param sourceRDD
@@ -78,6 +92,11 @@ object AlternatorMigrator {
     *   Target table settings
     * @param migratorConfig
     *   The complete original configuration
+    * @param hadoopPartitionedSource
+    *   Whether the source RDD uses `HadoopPartition`s (from the DynamoDB Hadoop connector)
+    *   containing `DynamoDBSplit`s. When `true`, scan segment progress is tracked via
+    *   `DynamoDbSavepointsManager`. Must be `false` for source types whose RDDs use other partition
+    *   types (e.g., `ParallelCollectionPartition` from S3 exports).
     * @param spark
     *   Spark session
     */
@@ -86,7 +105,8 @@ object AlternatorMigrator {
     sourceTableDesc: TableDescription,
     maybeStreamedSource: Option[SourceSettings.DynamoDB],
     target: TargetSettings.DynamoDB,
-    migratorConfig: MigratorConfig
+    migratorConfig: MigratorConfig,
+    hadoopPartitionedSource: Boolean
   )(implicit spark: SparkSession): Unit = {
 
     log.info("We need to transfer: " + sourceRDD.getNumPartitions + " partitions in total")
@@ -109,10 +129,17 @@ object AlternatorMigrator {
       if (target.streamChanges && target.skipInitialSnapshotTransfer.contains(true)) {
         log.info("Skip transferring table snapshot")
       } else {
-        Using.resource(DynamoDbSavepointsManager(migratorConfig, sourceRDD, spark.sparkContext)) {
-          _ =>
+        if (hadoopPartitionedSource) {
+          Using.resource(
+            DynamoDbSavepointsManager(migratorConfig, sourceRDD, spark.sparkContext)
+          ) { _ =>
             log.info("Starting write...")
-            writers.DynamoDB.writeRDD(target, migratorConfig.renamesMap, sourceRDD, targetTableDesc)
+            writers.DynamoDB
+              .writeRDD(target, migratorConfig.renamesMap, sourceRDD, targetTableDesc)
+          }
+        } else {
+          log.info("Starting write...")
+          writers.DynamoDB.writeRDD(target, migratorConfig.renamesMap, sourceRDD, targetTableDesc)
         }
         log.info("Done transferring table snapshot")
       }

--- a/tests/src/test/configurations/dynamodb-s3-export-to-alternator-no-savepoints.yaml
+++ b/tests/src/test/configurations/dynamodb-s3-export-to-alternator-no-savepoints.yaml
@@ -20,7 +20,7 @@ source:
     billingMode: PAY_PER_REQUEST
 
 target:
-  type: dynamodb
+  type: alternator
   table: BasicTest
   region: dummy
   endpoint:
@@ -33,6 +33,8 @@ target:
   removeConsumedCapacity: true
   billingMode: PAY_PER_REQUEST
 
+# Savepoint settings are required by the config schema but unused for
+# DynamoDB S3 export imports, since savepoints are not supported on this path.
 savepoints:
   path: /app/savepoints/s3-export-no-savepoints
   intervalSeconds: 300

--- a/tests/src/test/configurations/dynamodb-s3-export-to-alternator-no-savepoints.yaml
+++ b/tests/src/test/configurations/dynamodb-s3-export-to-alternator-no-savepoints.yaml
@@ -1,0 +1,38 @@
+source:
+  type: dynamodb-s3-export
+  bucket: test-bucket
+  manifestKey: dynamodb-export/AWSDynamoDB/01715685260608-c488b4e1/manifest-summary.json
+  region: eu-central-1
+  endpoint:
+    host: http://s3
+    port: 4566
+  credentials:
+    accessKey: dummy
+    secretKey: dummy
+  usePathStyleAccess: true
+  tableDescription:
+    attributeDefinitions:
+      - name: id
+        type: S
+    keySchema:
+      - name: id
+        type: HASH
+    billingMode: PAY_PER_REQUEST
+
+target:
+  type: dynamodb
+  table: BasicTest
+  region: dummy
+  endpoint:
+    host: http://scylla
+    port: 8000
+  credentials:
+    accessKey: dummy
+    secretKey: dummy
+  streamChanges: false
+  removeConsumedCapacity: true
+  billingMode: PAY_PER_REQUEST
+
+savepoints:
+  path: /app/savepoints/s3-export-no-savepoints
+  intervalSeconds: 300

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBS3ExportMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBS3ExportMigrationTest.scala
@@ -1,5 +1,6 @@
 package com.scylladb.migrator.alternator
 
+import com.scylladb.migrator.TestFileUtils
 import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.dynamodb.model.{
@@ -17,7 +18,6 @@ import software.amazon.awssdk.services.s3.model.{ CreateBucketRequest, PutObject
 import java.nio.file.{ Files, Path, Paths }
 import java.util.function.Consumer
 import scala.jdk.CollectionConverters._
-import scala.util.Using
 
 class DynamoDBS3ExportMigrationTest extends MigratorSuiteWithDynamoDBLocal {
 
@@ -68,28 +68,8 @@ class DynamoDBS3ExportMigrationTest extends MigratorSuiteWithDynamoDBLocal {
           }
       })
 
-    // Perform the migration and verify no savepoint files are created (issue #247:
-    // S3 export sources use ParallelCollectionPartitions, not HadoopPartitions,
-    // so DynamoDbSavepointsManager must not be instantiated for this path).
-    val beforeMigration = System.currentTimeMillis()
+    // Perform the migration
     successfullyPerformMigration(configFile)
-
-    val savepointsDir = Paths.get("docker/spark-master")
-    if (Files.exists(savepointsDir)) {
-      Using.resource(Files.list(savepointsDir)) { stream =>
-        val newSavepoints = stream
-          .iterator()
-          .asScala
-          .filter(p => Files.isRegularFile(p))
-          .filter(_.getFileName.toString.startsWith("savepoint_"))
-          .filter(p => Files.getLastModifiedTime(p).toMillis >= beforeMigration)
-          .toList
-        assert(
-          newSavepoints.isEmpty,
-          s"S3 export import should not create savepoint files, but found: $newSavepoints"
-        )
-      }
-    }
 
     // Check that the schema has been correctly defined on the target table
     checkSchemaWasMigrated(
@@ -141,6 +121,31 @@ class DynamoDBS3ExportMigrationTest extends MigratorSuiteWithDynamoDBLocal {
       )
     )
     checkItemWasMigrated(tableName, item3Key, item3Data)
+  }
+
+  // Verify that the S3 export import path does not instantiate DynamoDbSavepointsManager
+  // (issue #247). The SavepointsManager base class unconditionally creates the savepoints
+  // directory in its constructor, so its absence proves the manager was never instantiated.
+  private val savepointsDir =
+    Paths.get("docker/spark-master/s3-export-no-savepoints")
+
+  withResources("test-bucket", "BasicTest").test(
+    "S3 export import does not instantiate DynamoDbSavepointsManager (issue #247)"
+  ) { case (bucketName, tableName) =>
+    if (savepointsDir.toFile.exists())
+      TestFileUtils.deleteRecursive(savepointsDir.toFile)
+
+    runS3ExportMigration(
+      bucketName,
+      tableName,
+      "dynamodb-s3-export-to-alternator-no-savepoints.yaml"
+    )
+
+    assert(
+      !Files.exists(savepointsDir),
+      s"DynamoDbSavepointsManager should not be instantiated for S3 export imports, " +
+        s"but its directory was created at $savepointsDir"
+    )
   }
 
   // Make sure to properly set up and clean up the target database and the S3 instance

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBS3ExportMigrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBS3ExportMigrationTest.scala
@@ -17,6 +17,7 @@ import software.amazon.awssdk.services.s3.model.{ CreateBucketRequest, PutObject
 import java.nio.file.{ Files, Path, Paths }
 import java.util.function.Consumer
 import scala.jdk.CollectionConverters._
+import scala.util.Using
 
 class DynamoDBS3ExportMigrationTest extends MigratorSuiteWithDynamoDBLocal {
 
@@ -67,8 +68,28 @@ class DynamoDBS3ExportMigrationTest extends MigratorSuiteWithDynamoDBLocal {
           }
       })
 
-    // Perform the migration
+    // Perform the migration and verify no savepoint files are created (issue #247:
+    // S3 export sources use ParallelCollectionPartitions, not HadoopPartitions,
+    // so DynamoDbSavepointsManager must not be instantiated for this path).
+    val beforeMigration = System.currentTimeMillis()
     successfullyPerformMigration(configFile)
+
+    val savepointsDir = Paths.get("docker/spark-master")
+    if (Files.exists(savepointsDir)) {
+      Using.resource(Files.list(savepointsDir)) { stream =>
+        val newSavepoints = stream
+          .iterator()
+          .asScala
+          .filter(p => Files.isRegularFile(p))
+          .filter(_.getFileName.toString.startsWith("savepoint_"))
+          .filter(p => Files.getLastModifiedTime(p).toMillis >= beforeMigration)
+          .toList
+        assert(
+          newSavepoints.isEmpty,
+          s"S3 export import should not create savepoint files, but found: $newSavepoints"
+        )
+      }
+    }
 
     // Check that the schema has been correctly defined on the target table
     checkSchemaWasMigrated(


### PR DESCRIPTION
This PR is to fix the issue reported in https://github.com/scylladb/scylla-migrator/issues/247

The root cause is that DynamoDbSavepointsManager only handles the HadoopPartition, while migrateFromS3Export path creates the RDD using spark.parallelize() which generates ParallelCollectionPartition instead. 

When save points manager tries to extract DynamoDBSplit segiment from the partitions, it fails processing such partition.

The PR introduces a parameter in underlying migrate() method on which type of partition it is, and invokes writers.DynamoDB.writeRDD for S3 ParallelCollectionPartition paths. 

The PR doesn't have the save points support for S3 path, as it would require a different mechanism to keep tracking of the processed files and filter out these files on restart. We can have an enhancement to support this in future. 