### PR TITLE
address the case of missing removeConsumedCapacity in the yaml (#256)

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
@@ -112,7 +112,7 @@ object DynamoUtils {
         target.endpoint,
         target.finalCredentials.map(_.toProvider),
         target.region,
-        if (target.removeConsumedCapacity.getOrElse(false))
+        if (target.removeConsumedCapacity.getOrElse(true))
           Seq(new RemoveConsumedCapacityInterceptor)
         else Nil,
         target.alternator

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
@@ -46,7 +46,7 @@ object AlternatorValidator {
       sourceSettings.readThroughput,
       sourceSettings.throughputReadPercent,
       skipSegments           = None,
-      removeConsumedCapacity = targetSettings.removeConsumedCapacity.getOrElse(false)
+      removeConsumedCapacity = targetSettings.removeConsumedCapacity.getOrElse(true)
     )
 
     // Define some aliases to prevent the Spark engine to try to serialize the whole object graph

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
@@ -38,7 +38,7 @@ object DynamoDB {
       source.readThroughput,
       source.throughputReadPercent,
       skipSegments,
-      source.removeConsumedCapacity.getOrElse(false),
+      source.removeConsumedCapacity.getOrElse(true),
       source.alternator
     )
 

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
@@ -36,7 +36,9 @@ object DynamoDB {
           target.endpoint,
           target.finalCredentials.map(_.toProvider),
           target.region,
-          Seq.empty,
+          if (target.removeConsumedCapacity.getOrElse(true))
+            Seq(new DynamoUtils.RemoveConsumedCapacityInterceptor)
+          else Nil,
           target.alternator
         )
 
@@ -92,7 +94,7 @@ object DynamoDB {
       maybeScanSegments = None,
       maybeMaxMapTasks  = None,
       target.finalCredentials,
-      target.removeConsumedCapacity.getOrElse(false),
+      target.removeConsumedCapacity.getOrElse(true),
       target.alternator
     )
     jobConf.set(DynamoDBConstants.OUTPUT_TABLE_NAME, target.table)

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoStreamReplication.scala
@@ -57,7 +57,9 @@ object DynamoStreamReplication {
             target.endpoint,
             target.finalCredentials.map(_.toProvider),
             target.region,
-            Seq.empty,
+            if (target.removeConsumedCapacity.getOrElse(true))
+              Seq(new DynamoUtils.RemoveConsumedCapacityInterceptor)
+            else Nil,
             target.alternator
           )
         try

--- a/tests/src/test/scala/com/scylladb/migrator/DynamoUtilsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/DynamoUtilsTest.scala
@@ -42,6 +42,15 @@ class DynamoUtilsTest extends munit.FunSuite {
     assertEquals(modified.returnConsumedCapacity(), null)
   }
 
+  test("Strips INDEXES returnConsumedCapacity from BatchWriteItemRequest") {
+    val request = BatchWriteItemRequest
+      .builder()
+      .returnConsumedCapacity(ReturnConsumedCapacity.INDEXES)
+      .build()
+    val modified = modifyRequest(request).asInstanceOf[BatchWriteItemRequest]
+    assertEquals(modified.returnConsumedCapacity(), null)
+  }
+
   test("Strips returnConsumedCapacity from PutItemRequest") {
     val request = PutItemRequest
       .builder()
@@ -258,6 +267,12 @@ class DynamoUtilsTest extends munit.FunSuite {
     val jobConf = new JobConf()
     DynamoUtils.setDynamoDBJobConf(jobConf, None, None, None, None, None)
     assertEquals(jobConf.get(DynamoDBConstants.MAX_ITEMS_PER_BATCH), null)
+  }
+
+  test("removeConsumedCapacity defaults to false in setDynamoDBJobConf") {
+    val jobConf = new JobConf()
+    DynamoUtils.setDynamoDBJobConf(jobConf, None, None, None, None, None)
+    assertEquals(jobConf.get("scylla.migrator.remove_consumed_capacity"), "false")
   }
 
 }

--- a/tests/src/test/scala/com/scylladb/migrator/config/DynamoDBTargetSettingParserTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/DynamoDBTargetSettingParserTest.scala
@@ -62,6 +62,41 @@ class DynamoDBTargetSettingParserTest extends munit.FunSuite {
     assertEquals(parsedSettings.alternator.get.maxItemsPerBatch, Some(100))
   }
 
+  test("removeConsumedCapacity decodes as None when omitted from YAML") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |streamChanges: false
+        |""".stripMargin
+
+    val parsedSettings = parseDynamoDBTargetSettings(config)
+    assertEquals(parsedSettings.removeConsumedCapacity, None)
+  }
+
+  test("removeConsumedCapacity decodes as Some(true) when explicitly set") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |streamChanges: false
+        |removeConsumedCapacity: true
+        |""".stripMargin
+
+    val parsedSettings = parseDynamoDBTargetSettings(config)
+    assertEquals(parsedSettings.removeConsumedCapacity, Some(true))
+  }
+
+  test("removeConsumedCapacity decodes as Some(false) when explicitly disabled") {
+    val config =
+      """type: dynamodb
+        |table: Dummy
+        |streamChanges: false
+        |removeConsumedCapacity: false
+        |""".stripMargin
+
+    val parsedSettings = parseDynamoDBTargetSettings(config)
+    assertEquals(parsedSettings.removeConsumedCapacity, Some(false))
+  }
+
   private def parseDynamoDBTargetSettings(yamlContent: String): TargetSettings.DynamoDB =
     yaml.parser
       .parse(yamlContent)


### PR DESCRIPTION
The PR is to address the issue in https://github.com/scylladb/scylla-migrator/issues/256

When removeConsumedCapacity is not defined in the yaml, the value is set to false, that causes the issue reported.

The code change is to set the value to true, which is inline with the intention of the default "true" for this configuration parameter, also, added the test cases accordingly.