### PR TITLE
fix race condition and add fail safe logic for exceptional cases

### DIFF
--- a/docs/source/resume-interrupted-migration.rst
+++ b/docs/source/resume-interrupted-migration.rst
@@ -10,4 +10,12 @@ Savepoints are configuration files that contain information about the already mi
 
 You can control the savepoints location and the interval at which they are generated in the configuration file under the top-level property ``savepoints``. See the corresponding section of the :ref:`configuration reference <config-savepoints>` .
 
-During the migration, the savepoints are generated with file names like ``savepoint_xxx.yaml``, where ``xxx`` is a timestamp looking like ``1234567890``. To resume a migration, start a new migration with the latest savepoint as configuration file.
+During the migration, the savepoints are generated with file names like ``savepoint_<epochMillis>_<counter>.yaml``, where:
+
+* ``<epochMillis>`` is a 13-digit, zero-padded millisecond timestamp (monotonic within a migrator instance), and
+* ``<counter>`` is a 10-digit, zero-padded per-instance sequence number that disambiguates dumps produced within the same millisecond.
+
+Both components are zero-padded so that **lexicographical order matches chronological order**: listing the directory and picking the alphabetically last file (``ls <savepoints-dir> | tail -n 1``) always yields the most recent savepoint. To resume a migration, start a new migration with that latest savepoint as configuration file.
+
+.. note::
+   Older versions of the migrator produced file names like ``savepoint_1234567890.yaml`` (a single Unix-epoch-seconds component). The migrator still reads those files, but any new savepoint written during a resumed migration follows the two-component format above.

--- a/migrator/src/main/scala/com/scylladb/migrator/SavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/SavepointsManager.scala
@@ -5,8 +5,22 @@ import org.apache.logging.log4j.LogManager
 import sun.misc.{ Signal, SignalHandler }
 
 import java.nio.charset.StandardCharsets
-import java.nio.file.{ Files, Paths }
+import java.nio.file.{
+  AccessDeniedException,
+  AtomicMoveNotSupportedException,
+  Files,
+  Path,
+  Paths,
+  StandardCopyOption
+}
+import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.locks.ReentrantLock
 import java.util.concurrent.{ ScheduledThreadPoolExecutor, TimeUnit }
+import scala.jdk.CollectionConverters._
+import scala.util.Using
+import scala.util.control.NonFatal
 
 /** A component that manages savepoints. Savepoints provide a way to resume an interrupted
   * migration.
@@ -25,8 +39,27 @@ import java.util.concurrent.{ ScheduledThreadPoolExecutor, TimeUnit }
   * This class is abstract. Subclasses are responsible for implementing how to track the migration
   * progress, and for communicating the updated state of the migration via the method
   * `updateConfigWithMigrationState`.
+  *
+  * Concurrency and ordering guarantees:
+  *   - `dumpMigrationState` is serialized so that the accumulator snapshot and the on-disk write
+  *     happen atomically with respect to other dumps. This prevents a scheduled dump from
+  *     overwriting a later terminal dump with a stale snapshot.
+  *   - Savepoint filenames embed a zero-padded millisecond timestamp and a zero-padded per-instance
+  *     monotonic counter (`savepoint_<epochMillis>_<counter>.yaml`). The timestamp is clamped to a
+  *     monotonic non-decreasing value within the manager instance, so a backward wall-clock step
+  *     cannot make a later savepoint sort earlier than an older one. Zero-padding keeps
+  *     lexicographical order consistent with chronological order, so `ls | tail -n 1` also returns
+  *     the newest savepoint.
+  *   - `close()` awaits the scheduler so no scheduled tick races the final dump issued by the
+  *     caller after `close()`. The wait is bounded by `MaxCloseAwaitMillis` so a stuck filesystem
+  *     cannot hang shutdown indefinitely.
+  *   - The first SIGINT/SIGTERM/USR2 still writes a savepoint before exit. A second signal acts as
+  *     a force-quit escape hatch, so operators can terminate even if the first dump is stuck on
+  *     slow or unhealthy storage.
   */
 abstract class SavepointsManager(migratorConfig: MigratorConfig) extends AutoCloseable {
+
+  import SavepointsManager._
 
   val log = LogManager.getLogger(this.getClass.getName)
   private val scheduler = new ScheduledThreadPoolExecutor(1)
@@ -34,7 +67,21 @@ abstract class SavepointsManager(migratorConfig: MigratorConfig) extends AutoClo
   private var oldTermHandler: SignalHandler = _
   private var oldIntHandler: SignalHandler = _
 
+  // Serializes `dumpMigrationState` across the scheduler, the driver thread, and signal handlers.
+  // `ReentrantLock` (rather than a bare `synchronized`) lets the signal handler use `tryLock` with
+  // a bounded timeout, which avoids turning a stuck write into an unkillable process.
+  private val dumpLock = new ReentrantLock()
+  // Per-instance monotonic counter: disambiguates dumps that share the same millisecond timestamp
+  // and makes the filename order consistent with the logical order of dumps.
+  private val savepointSequence = new AtomicLong(0L)
+  // First signal writes a savepoint before exit; the second skips dumping and exits immediately.
+  private val signalDumpInProgress = new AtomicBoolean(false)
+  // Guarded by `dumpLock`: prevents a backward wall-clock step from making a later dump sort
+  // earlier than an older one.
+  private var lastSavepointMillis = 0L
+
   createSavepointsDirectory()
+  seedStateFromExistingSavepoints()
   addUSR2Handler()
   startSavepointSchedule()
 
@@ -48,8 +95,82 @@ abstract class SavepointsManager(migratorConfig: MigratorConfig) extends AutoClo
     }
   }
 
-  private def savepointFilename(path: String): String =
-    s"${path}/savepoint_${System.currentTimeMillis / 1000}.yaml"
+  /** Scan the savepoints directory once at startup and seed `lastSavepointMillis` /
+    * `savepointSequence` so that filenames written by this instance are strictly greater than any
+    * filename already on disk.
+    *
+    * Without this seed, a JVM restart on a host whose wall clock has drifted backwards (NTP
+    * step-back, VM migration, docker host time skew) would make new savepoints sort *earlier* than
+    * savepoints written by the previous run still present in the same directory. Resume would then
+    * silently pick a stale savepoint and lose progress. Seeding closes that window by ensuring the
+    * `(millis, seq)` key monotonically increases across process boundaries as long as the directory
+    * is not wiped.
+    */
+  private def seedStateFromExistingSavepoints(): Unit = {
+    val savepointsDirectory = Paths.get(migratorConfig.savepoints.path)
+    if (!Files.exists(savepointsDirectory)) return
+
+    var maxMillis = 0L
+    var maxSeq = 0L
+    try
+      Using.resource(Files.list(savepointsDirectory)) { stream =>
+        stream.iterator().asScala.foreach { path =>
+          val name = path.getFileName.toString
+          name match {
+            case SavepointsManager.SavepointName(head, tailOrNull) =>
+              val millis =
+                try
+                  if (tailOrNull == null) java.lang.Long.parseLong(head) * 1000L
+                  else java.lang.Long.parseLong(head)
+                catch { case _: NumberFormatException => 0L }
+              val seq =
+                if (tailOrNull == null) 0L
+                else
+                  try java.lang.Long.parseLong(tailOrNull)
+                  catch { case _: NumberFormatException => 0L }
+              if (millis > maxMillis || (millis == maxMillis && seq > maxSeq)) {
+                maxMillis = millis
+                maxSeq    = seq
+              }
+            case _ => ()
+          }
+        }
+      }
+    catch {
+      case NonFatal(e) =>
+        log.warn(
+          s"Could not scan ${savepointsDirectory} to seed savepoint state; " +
+            s"falling back to clock-only ordering: ${e.getMessage}"
+        )
+        return
+    }
+
+    if (maxMillis > 0L) {
+      lastSavepointMillis = maxMillis
+      savepointSequence.set(maxSeq)
+      log.info(
+        s"Seeded savepoint state from existing files: " +
+          s"lastSavepointMillis=${maxMillis}, nextSequence=${maxSeq + 1}"
+      )
+    }
+  }
+
+  private def savepointFilename(path: String): String = {
+    val millis = math.max(lastSavepointMillis, System.currentTimeMillis())
+    lastSavepointMillis = millis
+    val seq = savepointSequence.incrementAndGet()
+    // Zero-padded so that lexicographical order matches chronological order (handy for `ls`).
+    // `Locale.ROOT` pins the numeric formatter to ASCII digits; the JVM default locale on some
+    // hosts (e.g. `ar-SA`, `th-TH`) would otherwise emit non-ASCII numerals that break the
+    // filename regex and chronological sort used for resume.
+    String.format(
+      Locale.ROOT,
+      "%s/savepoint_%013d_%010d.yaml",
+      path,
+      java.lang.Long.valueOf(millis),
+      java.lang.Long.valueOf(seq)
+    )
+  }
 
   private def addUSR2Handler(): Unit = {
     log.info(
@@ -58,8 +179,32 @@ abstract class SavepointsManager(migratorConfig: MigratorConfig) extends AutoClo
 
     val handler = new SignalHandler {
       override def handle(signal: Signal): Unit = {
-        dumpMigrationState(signal.toString)
-        sys.exit(0)
+        val reason = signal.toString
+        if (!signalDumpInProgress.compareAndSet(false, true)) {
+          log.warn(
+            s"Received ${reason} while another signal-triggered savepoint dump is already in " +
+              s"progress; forcing exit immediately."
+          )
+          sys.exit(0)
+        }
+
+        // The first signal preserves the historical contract: write a savepoint before exiting.
+        // If the dump itself fails (disk full, permission denied, subclass bug), we still need
+        // to honour "first signal -> exit": swallow the error, log it, reset the in-progress
+        // flag so the JVM is not left in a half-terminated state, and proceed to `sys.exit(0)`
+        // from the `finally` block. A second signal while the dump is in flight still takes the
+        // fast-path above.
+        try dumpMigrationState(reason)
+        catch {
+          case NonFatal(t) =>
+            log.error(
+              s"Signal-triggered savepoint dump for ${reason} failed; exiting anyway.",
+              t
+            )
+        } finally {
+          signalDumpInProgress.set(false)
+          sys.exit(0)
+        }
       }
     }
 
@@ -92,26 +237,106 @@ abstract class SavepointsManager(migratorConfig: MigratorConfig) extends AutoClo
 
   /** Dump the current state of the migration into a configuration file that can be used to resume
     * the migration.
+    *
+    * Snapshotting the current state and writing it to disk are performed under a lock so that
+    * concurrent callers (scheduler, driver, signal handler) cannot interleave and overwrite each
+    * other with stale snapshots. The file is first written to a temporary path and then atomically
+    * renamed, so readers never observe a truncated YAML file. The temp file is deleted if the
+    * rename does not succeed, so failures do not leak sibling `*.yaml.tmp` files on disk.
+    *
     * @param reason
     *   Human-readable, informal, event that caused the dump.
     */
   final def dumpMigrationState(reason: String): Unit = {
-    val filename =
+    dumpLock.lock()
+    try doDump(reason)
+    finally dumpLock.unlock()
+  }
+
+  private def doDump(reason: String): Unit = {
+    val finalPath =
       Paths.get(savepointFilename(migratorConfig.savepoints.path)).normalize
+    val tempPath = Paths.get(finalPath.toString + ".tmp").normalize
 
     val modifiedConfig = updateConfigWithMigrationState()
+    val payload = modifiedConfig.render.getBytes(StandardCharsets.UTF_8)
 
-    Files.write(filename, modifiedConfig.render.getBytes(StandardCharsets.UTF_8))
+    var moved = false
+    try {
+      Files.write(tempPath, payload)
+      atomicReplace(tempPath, finalPath)
+      moved = true
+    } finally
+      if (!moved) {
+        // Best-effort cleanup so a failed rename does not leak `.yaml.tmp` siblings that would
+        // otherwise accumulate on a flaky filesystem.
+        try Files.deleteIfExists(tempPath)
+        catch {
+          case cleanupErr: Throwable =>
+            log.warn(s"Failed to clean up temp savepoint ${tempPath}: ${cleanupErr.getMessage}")
+        }
+      }
 
     log.info(
-      s"Created a savepoint config at ${filename} due to ${reason}. ${describeMigrationState()}"
+      s"Created a savepoint config at ${finalPath} due to ${reason}. ${describeMigrationState()}"
     )
   }
 
+  private def atomicReplace(source: Path, target: Path): Unit =
+    try
+      Files.move(
+        source,
+        target,
+        StandardCopyOption.ATOMIC_MOVE,
+        StandardCopyOption.REPLACE_EXISTING
+      )
+    catch {
+      case _: AtomicMoveNotSupportedException =>
+        // Fallback for filesystems that do not support atomic rename (e.g. certain object-store
+        // mounts). Semantics degrade to "replace" but all other guarantees are preserved.
+        log.warn(
+          s"Atomic rename not supported on the filesystem backing ${target}; " +
+            s"falling back to non-atomic replace."
+        )
+        Files.move(source, target, StandardCopyOption.REPLACE_EXISTING)
+      case e: AccessDeniedException =>
+        // On Windows, ATOMIC_MOVE can throw AccessDeniedException if a reader holds the target
+        // file open. Fall back to a non-atomic replace rather than failing the dump.
+        log.warn(
+          s"Atomic rename denied on ${target} (likely a concurrent reader on Windows); " +
+            s"falling back to non-atomic replace: ${e.getMessage}"
+        )
+        Files.move(source, target, StandardCopyOption.REPLACE_EXISTING)
+    }
+
   /** Stop the periodic creation of savepoints and release the associated resources.
+    *
+    * Blocks briefly for in-flight scheduled ticks to finish so that no scheduled dump can race with
+    * a terminal dump issued by the caller after `close()`. The wait is bounded on both ends
+    * (`MinCloseAwaitMillis` / `MaxCloseAwaitMillis`) so `close()` never hangs indefinitely on a
+    * stuck filesystem nor returns before a reasonable in-flight dump can finish; if the scheduler
+    * fails to terminate within the deadline the method logs a warning and forces shutdown.
     */
   def close(): Unit = {
     scheduler.shutdown()
+    val awaitMillis =
+      math.min(
+        MaxCloseAwaitMillis,
+        math.max(MinCloseAwaitMillis, 2L * migratorConfig.savepoints.intervalSeconds * 1000L)
+      )
+    val terminated =
+      try scheduler.awaitTermination(awaitMillis, TimeUnit.MILLISECONDS)
+      catch {
+        case _: InterruptedException =>
+          Thread.currentThread().interrupt()
+          false
+      }
+    if (!terminated) {
+      log.warn(
+        s"Savepoint scheduler did not terminate within ${awaitMillis} ms; forcing shutdown."
+      )
+      scheduler.shutdownNow()
+    }
     Signal.handle(new Signal("USR2"), oldUsr2Handler)
     Signal.handle(new Signal("TERM"), oldTermHandler)
     Signal.handle(new Signal("INT"), oldIntHandler)
@@ -126,4 +351,23 @@ abstract class SavepointsManager(migratorConfig: MigratorConfig) extends AutoClo
     */
   def updateConfigWithMigrationState(): MigratorConfig
 
+}
+
+object SavepointsManager {
+  // Floor for the `awaitTermination` deadline in `close()`. Gives the in-flight scheduled dump
+  // time to finish even when `intervalSeconds` is tiny (e.g. 1s in integration tests).
+  private val MinCloseAwaitMillis: Long = 5_000L
+
+  // Ceiling for the same deadline. Prevents `close()` from blocking for multiple minutes when
+  // `intervalSeconds` is large (e.g. 3600) and the filesystem is stuck.
+  private val MaxCloseAwaitMillis: Long = 30_000L
+
+  // Filename grammar for savepoints. Two groups:
+  //   - new format: `savepoint_<epochMillis>_<counter>.yaml` (tail is the counter)
+  //   - legacy:     `savepoint_<epochSeconds>.yaml`          (tail is null)
+  // This regex is the single source of truth for parsing filenames produced by this manager.
+  // Test helpers and the startup seed both reuse it to stay in sync with what `savepointFilename`
+  // writes.
+  private[migrator] val SavepointName: scala.util.matching.Regex =
+    """^savepoint_(\d+)(?:_(\d+))?\.yaml$""".r
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/SavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/SavepointsManager.scala
@@ -53,9 +53,11 @@ import scala.util.control.NonFatal
   *   - `close()` awaits the scheduler so no scheduled tick races the final dump issued by the
   *     caller after `close()`. The wait is bounded by `MaxCloseAwaitMillis` so a stuck filesystem
   *     cannot hang shutdown indefinitely.
-  *   - The first SIGINT/SIGTERM/USR2 still writes a savepoint before exit. A second signal acts as
-  *     a force-quit escape hatch, so operators can terminate even if the first dump is stuck on
-  *     slow or unhealthy storage.
+  *   - The first SIGINT/SIGTERM/USR2 attempts to write a savepoint before exit, but the wait for
+  *     `dumpLock` is bounded by `SignalDumpLockTimeoutMillis`. If a previous dump is stuck past
+  *     that deadline, the signal still triggers `sys.exit(0)` without writing — preserving "first
+  *     signal exits" over "first signal writes". A second signal acts as a force-quit escape hatch,
+  *     so operators can terminate even if the first dump is stuck on slow or unhealthy storage.
   */
 abstract class SavepointsManager(migratorConfig: MigratorConfig) extends AutoCloseable {
 
@@ -68,8 +70,12 @@ abstract class SavepointsManager(migratorConfig: MigratorConfig) extends AutoClo
   private var oldIntHandler: SignalHandler = _
 
   // Serializes `dumpMigrationState` across the scheduler, the driver thread, and signal handlers.
-  // `ReentrantLock` (rather than a bare `synchronized`) lets the signal handler use `tryLock` with
-  // a bounded timeout, which avoids turning a stuck write into an unkillable process.
+  // `ReentrantLock` (rather than a bare `synchronized`) is used so that signal-triggered dumps
+  // can call `tryLock(SignalDumpLockTimeoutMillis, …)` via `tryDumpMigrationState` and avoid
+  // waiting forever on a wedged scheduled dump: a stuck write can otherwise turn the first
+  // SIGTERM/SIGINT into an unkillable process when the orchestrator only emits one graceful
+  // signal before SIGKILL. The driver and scheduler paths still acquire the lock unconditionally
+  // because they have no deadline pressure.
   private val dumpLock = new ReentrantLock()
   // Per-instance monotonic counter: disambiguates dumps that share the same millisecond timestamp
   // and makes the filename order consistent with the logical order of dumps.
@@ -120,15 +126,32 @@ abstract class SavepointsManager(migratorConfig: MigratorConfig) extends AutoClo
             case SavepointsManager.SavepointName(head, tailOrNull) =>
               val millis =
                 try
-                  if (tailOrNull == null) java.lang.Long.parseLong(head) * 1000L
+                  if (tailOrNull == null)
+                    // Legacy filenames carry epoch seconds; scale to millis but reject values
+                    // that would silently overflow `Long`. `multiplyExact` throws
+                    // `ArithmeticException` instead of wrapping around to a negative number,
+                    // so a hostile filename like `savepoint_99999999999999999.yaml` cannot
+                    // poison the seeded `lastSavepointMillis` with a bogus huge value.
+                    java.lang.Math.multiplyExact(java.lang.Long.parseLong(head), 1000L)
                   else java.lang.Long.parseLong(head)
-                catch { case _: NumberFormatException => 0L }
+                catch {
+                  case _: NumberFormatException | _: ArithmeticException => 0L
+                }
               val seq =
                 if (tailOrNull == null) 0L
                 else
                   try java.lang.Long.parseLong(tailOrNull)
                   catch { case _: NumberFormatException => 0L }
-              if (millis > maxMillis || (millis == maxMillis && seq > maxSeq)) {
+              // Reject hostile near-`Long.MAX_VALUE` values; a single planted file must not be
+              // allowed to push `savepointSequence` to within one `incrementAndGet` of overflow
+              // (which would emit a negative counter in the next filename and permanently break
+              // the `\d{10}` regex on resume).
+              if (millis >= MaxReasonableSeedValue || seq >= MaxReasonableSeedValue) {
+                log.warn(
+                  s"Ignoring hostile/corrupted savepoint filename ${name} during seed " +
+                    s"(millis=${millis}, seq=${seq} exceeds ${MaxReasonableSeedValue})."
+                )
+              } else if (millis > maxMillis || (millis == maxMillis && seq > maxSeq)) {
                 maxMillis = millis
                 maxSeq    = seq
               }
@@ -189,22 +212,35 @@ abstract class SavepointsManager(migratorConfig: MigratorConfig) extends AutoClo
         }
 
         // The first signal preserves the historical contract: write a savepoint before exiting.
-        // If the dump itself fails (disk full, permission denied, subclass bug), we still need
-        // to honour "first signal -> exit": swallow the error, log it, reset the in-progress
-        // flag so the JVM is not left in a half-terminated state, and proceed to `sys.exit(0)`
-        // from the `finally` block. A second signal while the dump is in flight still takes the
+        // Crucially, the lock acquisition is bounded by `SignalDumpLockTimeoutMillis` so a
+        // wedged scheduled dump cannot indefinitely stall a graceful shutdown — orchestrators
+        // like k8s typically deliver only one SIGTERM before promoting to SIGKILL, so blocking
+        // here would defeat the shutdown deadline. If the lock cannot be acquired in time, or
+        // the dump itself fails (disk full, permission denied, subclass bug), we still honour
+        // "first signal -> exit": log the cause, reset the in-progress flag, and `sys.exit(0)`
+        // from the `finally` block. A second signal during an in-flight dump still takes the
         // fast-path above.
-        try dumpMigrationState(reason)
-        catch {
+        try {
+          val wrote = tryDumpMigrationState(reason, SignalDumpLockTimeoutMillis)
+          if (!wrote) {
+            log.warn(
+              s"Did not write a savepoint for ${reason}: dumpLock was contended or the wait " +
+                s"was interrupted within ${SignalDumpLockTimeoutMillis} ms. See prior warnings " +
+                s"for the specific cause. Exiting anyway to preserve the first-signal-exits contract."
+            )
+          }
+        } catch {
           case NonFatal(t) =>
             log.error(
               s"Signal-triggered savepoint dump for ${reason} failed; exiting anyway.",
               t
             )
-        } finally {
-          signalDumpInProgress.set(false)
+        } finally
+          // The JVM is already on its way out via `sys.exit(0)`. Resetting the in-progress
+          // flag here serves no purpose (no future signal can observe the reset before the
+          // JVM halts) and opens a tiny re-entry window where a third signal could pass the
+          // CAS gate and start a redundant dump. Leave the flag set and exit.
           sys.exit(0)
-        }
       }
     }
 
@@ -251,6 +287,38 @@ abstract class SavepointsManager(migratorConfig: MigratorConfig) extends AutoClo
     dumpLock.lock()
     try doDump(reason)
     finally dumpLock.unlock()
+  }
+
+  /** Bounded-wait variant of `dumpMigrationState` for the signal-handler fail-safe path.
+    *
+    * Returns `true` if `dumpLock` was acquired within `timeoutMillis` and the dump was attempted
+    * (any exception from `doDump` propagates so the caller can log it). Returns `false` if the lock
+    * could not be acquired in time, so the caller can give up the dump and continue exiting.
+    *
+    * Visible to `private[migrator]` so unit tests can exercise the timeout branch without going
+    * through `sys.exit`.
+    */
+  private[migrator] def tryDumpMigrationState(reason: String, timeoutMillis: Long): Boolean = {
+    val acquired =
+      try dumpLock.tryLock(timeoutMillis, TimeUnit.MILLISECONDS)
+      catch {
+        case _: InterruptedException =>
+          // Distinguish interrupt from timeout: the handler's generic log would otherwise
+          // misattribute the cause to "lock contention", masking the real reason (shutdown
+          // hook or framework-initiated interrupt) in incident review.
+          log.warn(
+            s"tryDumpMigrationState(${reason}) was interrupted while waiting for dumpLock; " +
+              s"not writing a savepoint."
+          )
+          Thread.currentThread().interrupt()
+          false
+      }
+    if (!acquired) false
+    else
+      try {
+        doDump(reason)
+        true
+      } finally dumpLock.unlock()
   }
 
   private def doDump(reason: String): Unit = {
@@ -361,6 +429,20 @@ object SavepointsManager {
   // Ceiling for the same deadline. Prevents `close()` from blocking for multiple minutes when
   // `intervalSeconds` is large (e.g. 3600) and the filesystem is stuck.
   private val MaxCloseAwaitMillis: Long = 30_000L
+
+  // How long a signal-triggered dump waits for `dumpLock` before giving up and exiting without
+  // writing a savepoint. Chosen well below the typical orchestrator grace period (k8s default is
+  // 30 s before SIGKILL) so the JVM still has headroom to flush logs and run shutdown hooks
+  // after the bounded wait, even if a scheduled dump is wedged on slow/unhealthy storage.
+  private[migrator] val SignalDumpLockTimeoutMillis: Long = 5_000L
+
+  // Sanity ceiling for values read from filenames during seed. Any field at or above this
+  // threshold is treated as hostile / corrupted: ignoring it keeps a single planted file from
+  // poisoning `lastSavepointMillis` / `savepointSequence` to within one increment of
+  // `Long.MAX_VALUE`, which would wrap the next counter to `Long.MIN_VALUE` and break the
+  // `\d{10}` filename regex. Chosen as half of `Long.MAX_VALUE` (~year 146,135,510 AD for
+  // millis) so legitimate values have effectively infinite headroom.
+  private[migrator] val MaxReasonableSeedValue: Long = java.lang.Long.MAX_VALUE / 2L
 
   // Filename grammar for savepoints. Two groups:
   //   - new format: `savepoint_<epochMillis>_<counter>.yaml` (tail is the counter)

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
@@ -1,11 +1,6 @@
 package com.scylladb.migrator
 
-import com.scylladb.migrator.config.{
-  MigratorConfig,
-  Savepoints,
-  SourceSettings,
-  TargetSettings
-}
+import com.scylladb.migrator.config.{ MigratorConfig, Savepoints, SourceSettings, TargetSettings }
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, Path }
@@ -45,8 +40,8 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
         writeWritetimestampInuS       = None,
         consistencyLevel              = "LOCAL_QUORUM"
       ),
-      renames          = None,
-      savepoints       = Savepoints(intervalSeconds = intervalSeconds, path = savepointsDir.toString),
+      renames    = None,
+      savepoints = Savepoints(intervalSeconds = intervalSeconds, path = savepointsDir.toString),
       skipTokenRanges  = None,
       skipSegments     = None,
       skipParquetFiles = None,
@@ -123,7 +118,7 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
   test("filenames are monotonically unique even when written in the same millisecond") {
     val dir = Files.createTempDirectory("savepoints-unique-names")
     try {
-      val cfg     = newConfig(dir, intervalSeconds = 3600)
+      val cfg = newConfig(dir, intervalSeconds = 3600)
       val manager = new TestManager(cfg, processed = Set("a"))
       try {
         (1 to 50).foreach(_ => manager.dumpMigrationState("rapid"))
@@ -158,9 +153,9 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
     // wall-clock instant so the `ReentrantLock` actually gets contended; this replaces the prior
     // reliance on a short `Thread.sleep` as a race amplifier, which could be defeated by a slow
     // CI host where the scheduler serialized submissions before any contention could occur.
-    val dir   = Files.createTempDirectory("savepoints-race")
+    val dir = Files.createTempDirectory("savepoints-race")
     val state = new AtomicInteger(0)
-    val cfg   = newConfig(dir, intervalSeconds = 3600)
+    val cfg = newConfig(dir, intervalSeconds = 3600)
     val rounds = 30
 
     try {
@@ -172,9 +167,9 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
         // Pool sized to the round count so every submission gets its own thread and all
         // `rounds` runnables can simultaneously wait on the barrier; a smaller pool would
         // deadlock at `barrier.await` because only the first N threads would ever arrive.
-        val pool    = Executors.newFixedThreadPool(rounds)
+        val pool = Executors.newFixedThreadPool(rounds)
         val barrier = new CyclicBarrier(rounds)
-        val latch   = new CountDownLatch(rounds)
+        val latch = new CountDownLatch(rounds)
         try {
           (1 to rounds).foreach { i =>
             pool.submit(new Runnable {
@@ -214,7 +209,7 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
 
       // The final file (by filename order) must be the terminal dump with the full set.
       val winner = latest(dir)
-      val cfg2   = MigratorConfig.loadFrom(winner.toString)
+      val cfg2 = MigratorConfig.loadFrom(winner.toString)
       assertEquals(
         cfg2.skipParquetFiles.getOrElse(Set.empty),
         (1 to 30).map(i => s"file-$i").toSet,
@@ -226,41 +221,40 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
   test("atomic write prevents torn reads of the savepoint") {
     // A reader thread continuously parses the latest savepoint while the writer dumps repeatedly.
     // With the temp-file + ATOMIC_MOVE strategy the reader must never observe a truncated YAML.
-    val dir     = Files.createTempDirectory("savepoints-atomic")
+    val dir = Files.createTempDirectory("savepoints-atomic")
     val counter = new AtomicInteger(0)
-    val cfg     = newConfig(dir, intervalSeconds = 3600)
+    val cfg = newConfig(dir, intervalSeconds = 3600)
 
     try {
       val manager = new TestManager(
         cfg,
         processed = (1 to counter.get()).map(i => s"f-$i").toSet
       )
-      val stop    = new java.util.concurrent.atomic.AtomicBoolean(false)
-      val torn    = new java.util.concurrent.atomic.AtomicInteger(0)
-      val reader  = new Thread(() => {
-        while (!stop.get()) {
-          try {
+      val stop = new java.util.concurrent.atomic.AtomicBoolean(false)
+      val torn = new java.util.concurrent.atomic.AtomicInteger(0)
+      val reader = new Thread(() =>
+        while (!stop.get())
+          try
             listSavepoints(dir).sortBy(sortKey).lastOption.foreach { p =>
               try {
                 val _ = MigratorConfig.loadFrom(p.toString)
               } catch {
                 // File content was partial/unparseable: that is a torn read.
-                case _: io.circe.ParsingFailure            => torn.incrementAndGet()
-                case _: io.circe.DecodingFailure           => torn.incrementAndGet()
-                case _: java.io.EOFException               => torn.incrementAndGet()
+                case _: io.circe.ParsingFailure  => torn.incrementAndGet()
+                case _: io.circe.DecodingFailure => torn.incrementAndGet()
+                case _: java.io.EOFException     => torn.incrementAndGet()
                 // The file may disappear between listing and reading (atomic rename or
                 // filesystem cleanup). That is not a torn read, just a benign race.
-                case _: java.nio.file.NoSuchFileException  => ()
-                case _: java.io.FileNotFoundException      => ()
+                case _: java.nio.file.NoSuchFileException => ()
+                case _: java.io.FileNotFoundException     => ()
               }
             }
-          } catch {
+          catch {
             // Directory listing / sort key can race with rename; ignore and re-list.
             case _: java.nio.file.NoSuchFileException => ()
-            case _: java.io.FileNotFoundException    => ()
+            case _: java.io.FileNotFoundException     => ()
           }
-        }
-      })
+      )
       reader.setDaemon(true)
       reader.start()
 
@@ -296,7 +290,7 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
       val planted = dir.resolve(f"savepoint_${farFuture}%013d_${9999L}%010d.yaml")
       Files.write(planted, Array.emptyByteArray)
 
-      val cfg     = newConfig(dir, intervalSeconds = 3600)
+      val cfg = newConfig(dir, intervalSeconds = 3600)
       val manager = new TestManager(cfg, processed = Set("seed"))
       try manager.dumpMigrationState("after-seed")
       finally manager.close()
@@ -323,7 +317,7 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
       val hostile = dir.resolve("savepoint_9999999999999999999999999_1.yaml")
       Files.write(hostile, "irrelevant".getBytes(StandardCharsets.UTF_8))
 
-      val cfg     = newConfig(dir, intervalSeconds = 3600)
+      val cfg = newConfig(dir, intervalSeconds = 3600)
       val manager = new TestManager(cfg, processed = Set("real"))
       try manager.dumpMigrationState("real")
       finally manager.close()
@@ -346,9 +340,9 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
     // a scheduled dump may already be in flight, then the driver writes "final" / "completed",
     // then `close()` drains the scheduler. The latest savepoint on disk must still contain the
     // terminal snapshot.
-    val dir   = Files.createTempDirectory("savepoints-await")
+    val dir = Files.createTempDirectory("savepoints-await")
     val state = new AtomicInteger(0)
-    val cfg   = newConfig(dir, intervalSeconds = 1)
+    val cfg = newConfig(dir, intervalSeconds = 1)
     val scheduledTickStarted = new CountDownLatch(1)
 
     try {

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
@@ -1,0 +1,379 @@
+package com.scylladb.migrator
+
+import com.scylladb.migrator.config.{
+  MigratorConfig,
+  Savepoints,
+  SourceSettings,
+  TargetSettings
+}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Path }
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{ CountDownLatch, CyclicBarrier, Executors, TimeUnit }
+import scala.jdk.CollectionConverters._
+import scala.util.Using
+import scala.util.matching.Regex
+
+/** Unit tests for `SavepointsManager` that focus on the concurrency and filename invariants
+  * introduced to fix issue #347. These tests do not require Spark or any external services.
+  */
+class SavepointsManagerConcurrencyTest extends munit.FunSuite {
+
+  private val savepointName: Regex =
+    """^savepoint_(\d+)(?:_(\d+))?\.yaml$""".r
+
+  private def newConfig(savepointsDir: Path, intervalSeconds: Int): MigratorConfig =
+    MigratorConfig(
+      source = SourceSettings.Parquet(
+        path        = "dummy",
+        credentials = None,
+        region      = None,
+        endpoint    = None
+      ),
+      target = TargetSettings.Scylla(
+        host                          = "localhost",
+        port                          = 9042,
+        localDC                       = None,
+        credentials                   = None,
+        sslOptions                    = None,
+        keyspace                      = "ks",
+        table                         = "t",
+        connections                   = None,
+        stripTrailingZerosForDecimals = false,
+        writeTTLInS                   = None,
+        writeWritetimestampInuS       = None,
+        consistencyLevel              = "LOCAL_QUORUM"
+      ),
+      renames          = None,
+      savepoints       = Savepoints(intervalSeconds = intervalSeconds, path = savepointsDir.toString),
+      skipTokenRanges  = None,
+      skipSegments     = None,
+      skipParquetFiles = None,
+      validation       = None
+    )
+
+  /** Test double: reports whatever subset of processed files the caller has registered.
+    *
+    * `snapshotDelayMillis` is injected into `updateConfigWithMigrationState` so that concurrent
+    * dumps can deterministically overlap: the snapshot is taken, a brief delay occurs, then the
+    * write happens. This reproduces the real race between a scheduled dump (early snapshot, late
+    * write) and a terminal dump (late snapshot, late write).
+    */
+  private class TestManager(
+    cfg: MigratorConfig,
+    processed: => Set[String],
+    snapshotDelayMillis: Long = 0L,
+    onSnapshotStarted: () => Unit = () => ()
+  ) extends SavepointsManager(cfg) {
+    def describeMigrationState(): String = s"Processed: ${processed.size}"
+    def updateConfigWithMigrationState(): MigratorConfig = {
+      onSnapshotStarted()
+      val snapshot = processed
+      if (snapshotDelayMillis > 0) Thread.sleep(snapshotDelayMillis)
+      cfg.copy(skipParquetFiles = Some(snapshot))
+    }
+  }
+
+  private def listSavepoints(dir: Path): Seq[Path] =
+    Using.resource(Files.list(dir)) { stream =>
+      stream
+        .iterator()
+        .asScala
+        .filter(Files.isRegularFile(_))
+        .filter { p =>
+          val name = p.getFileName.toString
+          // Exclude temp files produced by the atomic-rename write path.
+          name.startsWith("savepoint_") && name.endsWith(".yaml")
+        }
+        .toSeq
+    }
+
+  private def sortKey(path: Path): (Long, Long) =
+    path.getFileName.toString match {
+      case savepointName(head, tailOrNull) =>
+        // Defensive: hostile filenames with overflow-long numerics must not crash the sort.
+        try
+          if (tailOrNull == null)
+            (java.lang.Math.multiplyExact(java.lang.Long.parseLong(head), 1000L), -1L)
+          else
+            (java.lang.Long.parseLong(head), java.lang.Long.parseLong(tailOrNull))
+        catch {
+          case _: NumberFormatException | _: ArithmeticException =>
+            (Files.getLastModifiedTime(path).toMillis, -1L)
+        }
+      case _ => (Files.getLastModifiedTime(path).toMillis, -1L)
+    }
+
+  private def latest(dir: Path): Path = {
+    // Materialize the sort key once per file: avoids N log N `getLastModifiedTime` syscalls in
+    // the legacy-fallback branch under the heavier stress tests in this suite.
+    val ranked = listSavepoints(dir).map(p => sortKey(p) -> p).sortBy(_._1)
+    ranked.last._2
+  }
+
+  private def deleteRecursively(dir: Path): Unit =
+    if (Files.exists(dir)) {
+      Files
+        .walk(dir)
+        .sorted(java.util.Comparator.reverseOrder())
+        .forEach(Files.delete)
+    }
+
+  test("filenames are monotonically unique even when written in the same millisecond") {
+    val dir = Files.createTempDirectory("savepoints-unique-names")
+    try {
+      val cfg     = newConfig(dir, intervalSeconds = 3600)
+      val manager = new TestManager(cfg, processed = Set("a"))
+      try {
+        (1 to 50).foreach(_ => manager.dumpMigrationState("rapid"))
+      } finally manager.close()
+
+      val names = listSavepoints(dir).map(_.getFileName.toString)
+      assertEquals(names.distinct.size, names.size, "every savepoint file should be unique")
+      assert(
+        names.forall(savepointName.pattern.matcher(_).matches()),
+        s"all savepoint filenames must match the new pattern, got: $names"
+      )
+
+      val sorted = listSavepoints(dir).sortBy(sortKey).map(_.getFileName.toString)
+      val counters =
+        sorted.collect { case n @ savepointName(_, c) if c != null => n -> c.toLong }
+      assert(counters.size >= 50, s"expected >=50 counters, got ${counters.size}")
+      val isMonotonic = counters.map(_._2).sliding(2).forall {
+        case Seq(a, b) => a < b
+        case _         => true
+      }
+      assert(isMonotonic, s"counters must increase monotonically in filename order: $counters")
+    } finally deleteRecursively(dir)
+  }
+
+  test("concurrent dumps never overwrite a later snapshot with a stale one") {
+    // Simulates the #347 race: one thread (scheduler) snapshots an early subset of processed
+    // files and takes a long time to write, while another thread (driver) snapshots the full set
+    // and writes immediately after. The invariant we assert is that the file with the highest
+    // (millis, counter) always contains the most advanced snapshot.
+    //
+    // A `CyclicBarrier` ensures all worker threads arrive at `dumpMigrationState` at the same
+    // wall-clock instant so the `ReentrantLock` actually gets contended; this replaces the prior
+    // reliance on a short `Thread.sleep` as a race amplifier, which could be defeated by a slow
+    // CI host where the scheduler serialized submissions before any contention could occur.
+    val dir   = Files.createTempDirectory("savepoints-race")
+    val state = new AtomicInteger(0)
+    val cfg   = newConfig(dir, intervalSeconds = 3600)
+    val rounds = 30
+
+    try {
+      val manager = new TestManager(
+        cfg,
+        processed = (1 to state.get()).map(i => s"file-$i").toSet
+      )
+      try {
+        // Pool sized to the round count so every submission gets its own thread and all
+        // `rounds` runnables can simultaneously wait on the barrier; a smaller pool would
+        // deadlock at `barrier.await` because only the first N threads would ever arrive.
+        val pool    = Executors.newFixedThreadPool(rounds)
+        val barrier = new CyclicBarrier(rounds)
+        val latch   = new CountDownLatch(rounds)
+        try {
+          (1 to rounds).foreach { i =>
+            pool.submit(new Runnable {
+              override def run(): Unit =
+                try {
+                  // All 30 submissions wait here until the last one arrives; from that moment
+                  // they race the `ReentrantLock` deterministically regardless of CI speed.
+                  barrier.await(30, TimeUnit.SECONDS)
+                  state.set(i)
+                  manager.dumpMigrationState(s"round-$i")
+                } finally latch.countDown()
+            })
+          }
+          assert(latch.await(30, TimeUnit.SECONDS), "concurrent dumps did not finish in time")
+        } finally pool.shutdownNow()
+
+        // Terminal dump with the full state, emulating the "final"/"completed" dump issued by the
+        // driver after scheduling has quiesced.
+        state.set(rounds)
+        manager.dumpMigrationState("final")
+      } finally manager.close()
+
+      // Every file must be a valid YAML parseable as MigratorConfig.
+      listSavepoints(dir).foreach { p =>
+        val text = new String(Files.readAllBytes(p), StandardCharsets.UTF_8)
+        assert(text.nonEmpty, s"file $p is empty")
+        val parsed = MigratorConfig.loadFrom(p.toString)
+        val snapshot = parsed.skipParquetFiles.getOrElse(
+          fail(s"skipParquetFiles missing from $p"): Set[String]
+        )
+        // Every recorded snapshot must be a prefix subset of {file-1, ..., file-30}.
+        assert(
+          snapshot.forall(_.startsWith("file-")),
+          s"unexpected entries in $p: $snapshot"
+        )
+      }
+
+      // The final file (by filename order) must be the terminal dump with the full set.
+      val winner = latest(dir)
+      val cfg2   = MigratorConfig.loadFrom(winner.toString)
+      assertEquals(
+        cfg2.skipParquetFiles.getOrElse(Set.empty),
+        (1 to 30).map(i => s"file-$i").toSet,
+        s"latest savepoint ${winner.getFileName} did not contain the final snapshot"
+      )
+    } finally deleteRecursively(dir)
+  }
+
+  test("atomic write prevents torn reads of the savepoint") {
+    // A reader thread continuously parses the latest savepoint while the writer dumps repeatedly.
+    // With the temp-file + ATOMIC_MOVE strategy the reader must never observe a truncated YAML.
+    val dir     = Files.createTempDirectory("savepoints-atomic")
+    val counter = new AtomicInteger(0)
+    val cfg     = newConfig(dir, intervalSeconds = 3600)
+
+    try {
+      val manager = new TestManager(
+        cfg,
+        processed = (1 to counter.get()).map(i => s"f-$i").toSet
+      )
+      val stop    = new java.util.concurrent.atomic.AtomicBoolean(false)
+      val torn    = new java.util.concurrent.atomic.AtomicInteger(0)
+      val reader  = new Thread(() => {
+        while (!stop.get()) {
+          try {
+            listSavepoints(dir).sortBy(sortKey).lastOption.foreach { p =>
+              try {
+                val _ = MigratorConfig.loadFrom(p.toString)
+              } catch {
+                // File content was partial/unparseable: that is a torn read.
+                case _: io.circe.ParsingFailure            => torn.incrementAndGet()
+                case _: io.circe.DecodingFailure           => torn.incrementAndGet()
+                case _: java.io.EOFException               => torn.incrementAndGet()
+                // The file may disappear between listing and reading (atomic rename or
+                // filesystem cleanup). That is not a torn read, just a benign race.
+                case _: java.nio.file.NoSuchFileException  => ()
+                case _: java.io.FileNotFoundException      => ()
+              }
+            }
+          } catch {
+            // Directory listing / sort key can race with rename; ignore and re-list.
+            case _: java.nio.file.NoSuchFileException => ()
+            case _: java.io.FileNotFoundException    => ()
+          }
+        }
+      })
+      reader.setDaemon(true)
+      reader.start()
+
+      try {
+        (1 to 200).foreach { i =>
+          counter.set(i)
+          manager.dumpMigrationState(s"iter-$i")
+        }
+      } finally {
+        stop.set(true)
+        reader.join(5000L)
+        manager.close()
+      }
+
+      assertEquals(
+        torn.get(),
+        0,
+        "reader observed a torn/unparseable savepoint; atomic write is broken"
+      )
+    } finally deleteRecursively(dir)
+  }
+
+  test("new manager seeds state from existing savepoints so new files always sort after old ones") {
+    // Guards against the JVM-restart + backward-clock window: if the new manager's counter
+    // restarted at 0 and the host clock drifted behind the previous run, new filenames would
+    // sort BEFORE existing ones and resume would silently regress.  Seeding on startup pins
+    // `(millis, seq)` above anything already on disk.
+    val dir = Files.createTempDirectory("savepoints-seed")
+    try {
+      // Plant a pre-existing savepoint with an absurdly future millis so any "fresh" clamp that
+      // did not consult the directory would produce a filename that sorts BEFORE this one.
+      val farFuture = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365)
+      val planted = dir.resolve(f"savepoint_${farFuture}%013d_${9999L}%010d.yaml")
+      Files.write(planted, Array.emptyByteArray)
+
+      val cfg     = newConfig(dir, intervalSeconds = 3600)
+      val manager = new TestManager(cfg, processed = Set("seed"))
+      try manager.dumpMigrationState("after-seed")
+      finally manager.close()
+
+      val winner = latest(dir)
+      assert(
+        winner.getFileName.toString != planted.getFileName.toString,
+        s"new dump did not beat the planted savepoint ${planted.getFileName}"
+      )
+      // And the new file must be a real dump, not the empty planted one.
+      val cfg2 = MigratorConfig.loadFrom(winner.toString)
+      assertEquals(cfg2.skipParquetFiles.getOrElse(Set.empty), Set("seed"))
+    } finally deleteRecursively(dir)
+  }
+
+  test("hostile filenames do not crash sort / findLatest") {
+    // An attacker (or a buggy external tool) could drop a savepoint-looking file whose numeric
+    // fields overflow `Long`.  `parseLong` then throws `NumberFormatException`; an un-guarded
+    // `sortBy` would surface that as a resume-time crash (DoS).  `sortKey` must treat such a
+    // name as unknown and fall back to mtime, so the real savepoint still wins.
+    val dir = Files.createTempDirectory("savepoints-hostile")
+    try {
+      // 25-digit head overflows `Long.MAX_VALUE` (19 digits).
+      val hostile = dir.resolve("savepoint_9999999999999999999999999_1.yaml")
+      Files.write(hostile, "irrelevant".getBytes(StandardCharsets.UTF_8))
+
+      val cfg     = newConfig(dir, intervalSeconds = 3600)
+      val manager = new TestManager(cfg, processed = Set("real"))
+      try manager.dumpMigrationState("real")
+      finally manager.close()
+
+      // Sort must not throw.
+      val ranked = listSavepoints(dir).map(p => sortKey(p) -> p).sortBy(_._1)
+      assert(ranked.nonEmpty, "no files listed")
+      val winner = ranked.last._2
+      // The new legitimate dump must win: its key is (currentMillis, counter>=1), which is far
+      // larger than a fallback-to-mtime key produced for the pre-existing hostile file.
+      assert(
+        winner.getFileName.toString != hostile.getFileName.toString,
+        s"hostile filename ${hostile.getFileName} beat the real savepoint in sort order"
+      )
+    } finally deleteRecursively(dir)
+  }
+
+  test("final/completed dumps before close still win over an in-flight scheduled dump") {
+    // Mirror the production ordering in Parquet.scala / ScyllaMigrator.scala:
+    // a scheduled dump may already be in flight, then the driver writes "final" / "completed",
+    // then `close()` drains the scheduler. The latest savepoint on disk must still contain the
+    // terminal snapshot.
+    val dir   = Files.createTempDirectory("savepoints-await")
+    val state = new AtomicInteger(0)
+    val cfg   = newConfig(dir, intervalSeconds = 1)
+    val scheduledTickStarted = new CountDownLatch(1)
+
+    try {
+      val manager = new TestManager(
+        cfg,
+        processed           = (1 to state.get()).map(i => s"x-$i").toSet,
+        snapshotDelayMillis = 400,
+        onSnapshotStarted   = () => scheduledTickStarted.countDown()
+      )
+      assert(
+        scheduledTickStarted.await(10, TimeUnit.SECONDS),
+        "scheduled tick never started"
+      )
+      state.set(99)
+      manager.dumpMigrationState("final")
+      manager.dumpMigrationState("completed")
+      manager.close()
+
+      val winner = latest(dir)
+      val parsed = MigratorConfig.loadFrom(winner.toString)
+      assertEquals(
+        parsed.skipParquetFiles.getOrElse(Set.empty),
+        (1 to 99).map(i => s"x-$i").toSet,
+        s"latest savepoint ${winner.getFileName} did not contain the completed terminal snapshot"
+      )
+    } finally deleteRecursively(dir)
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
@@ -171,7 +171,11 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
         val barrier = new CyclicBarrier(rounds)
         val latch = new CountDownLatch(rounds)
         try {
-          (1 to rounds).foreach { i =>
+          // Collect the `Future`s so worker exceptions surface as test failures. Without this,
+          // a broken `CyclicBarrier` or a thrown `dumpMigrationState` would still hit
+          // `latch.countDown()` in the `finally`, the latch would drain, and the post-assertions
+          // could pass even though no real contention occurred — a silent false negative.
+          val futures: Seq[java.util.concurrent.Future[_]] = (1 to rounds).map { i =>
             pool.submit(new Runnable {
               override def run(): Unit =
                 try {
@@ -184,6 +188,19 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
             })
           }
           assert(latch.await(30, TimeUnit.SECONDS), "concurrent dumps did not finish in time")
+          futures.foreach { f =>
+            try f.get(5, TimeUnit.SECONDS)
+            catch {
+              case e: java.util.concurrent.ExecutionException =>
+                // Surface the worker's original exception with its full stack trace instead of
+                // the generic `ExecutionException` wrapper, which would otherwise hide the
+                // actual broken-barrier or dump-throw cause.
+                throw new AssertionError(
+                  s"worker future failed: ${e.getCause.getMessage}",
+                  e.getCause
+                )
+            }
+          }
         } finally pool.shutdownNow()
 
         // Terminal dump with the full state, emulating the "final"/"completed" dump issued by the
@@ -306,6 +323,38 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
     } finally deleteRecursively(dir)
   }
 
+  test("seed rejects hostile near-Long.MAX_VALUE filenames so the counter cannot wrap") {
+    // Reproduces the lens-C finding: a planted `savepoint_<near-MAX>_<near-MAX>.yaml` would,
+    // pre-fix, seed `savepointSequence` to near `Long.MAX_VALUE`. The next `incrementAndGet`
+    // wraps to `Long.MIN_VALUE`, `String.format("%010d", ...)` emits a negative 20-char field,
+    // the `\d{10}` regex no longer matches, and resume permanently fails. The seed must
+    // reject these values up front and produce a sane next filename.
+    val dir = Files.createTempDirectory("savepoints-hostile-seed")
+    try {
+      val near = java.lang.Long.MAX_VALUE - 2L
+      val hostile =
+        dir.resolve(f"savepoint_${near}%013d_${near}%010d.yaml")
+      Files.write(hostile, Array.emptyByteArray)
+
+      val cfg = newConfig(dir, intervalSeconds = 3600)
+      val manager = new TestManager(cfg, processed = Set("alpha"))
+      try manager.dumpMigrationState("after-hostile-seed")
+      finally manager.close()
+
+      // The new savepoint's filename must still match the `savepoint_\d{13}_\d{10}.yaml`
+      // grammar — i.e., the counter did NOT wrap negative.
+      val produced =
+        listSavepoints(dir).map(_.getFileName.toString).filter(_ != hostile.getFileName.toString)
+      assert(produced.nonEmpty, "manager produced no new savepoint after the hostile seed")
+      produced.foreach { name =>
+        assert(
+          savepointName.pattern.matcher(name).matches(),
+          s"produced filename ${name} does not match the new-format regex (counter likely wrapped)"
+        )
+      }
+    } finally deleteRecursively(dir)
+  }
+
   test("hostile filenames do not crash sort / findLatest") {
     // An attacker (or a buggy external tool) could drop a savepoint-looking file whose numeric
     // fields overflow `Long`.  `parseLong` then throws `NumberFormatException`; an un-guarded
@@ -332,6 +381,76 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
         winner.getFileName.toString != hostile.getFileName.toString,
         s"hostile filename ${hostile.getFileName} beat the real savepoint in sort order"
       )
+    } finally deleteRecursively(dir)
+  }
+
+  test("signal fail-safe: tryDumpMigrationState gives up if dumpLock is held past the deadline") {
+    // Reproduces the dkropachev PR-356 review concern: the signal handler must not wait
+    // indefinitely on a wedged scheduled dump that still holds `dumpLock`. With the bounded
+    // `tryLock` path, `tryDumpMigrationState` must return `false` close to the requested
+    // timeout when another thread is holding the lock. Previously the signal path used
+    // unconditional `lock()` and would block for the full duration of the in-flight dump.
+    val dir = Files.createTempDirectory("savepoints-trylock-fail")
+    val cfg = newConfig(dir, intervalSeconds = 3600)
+    try {
+      val holdMillis = 1_500L
+      val timeoutMillis = 200L
+      val snapshotStarted = new CountDownLatch(1)
+      val manager = new TestManager(
+        cfg,
+        processed           = Set("x"),
+        snapshotDelayMillis = holdMillis,
+        onSnapshotStarted   = () => snapshotStarted.countDown()
+      )
+      try {
+        val blockerFinished = new CountDownLatch(1)
+        val blocker = new Thread(() =>
+          try manager.dumpMigrationState("blocker")
+          finally blockerFinished.countDown()
+        )
+        blocker.setDaemon(true)
+        blocker.start()
+        assert(
+          snapshotStarted.await(5, TimeUnit.SECONDS),
+          "blocker never entered the snapshot delay (lock not yet held)"
+        )
+
+        val start = System.nanoTime()
+        val wrote = manager.tryDumpMigrationState("signal", timeoutMillis)
+        val elapsedMillis = (System.nanoTime() - start) / 1_000_000L
+        assert(!wrote, "tryDumpMigrationState must time out under a contended dumpLock")
+        // Tight upper bound: timeout budget + generous CI jitter slack. A regression that
+        // swaps `tryLock(timeout)` back to unconditional `lock()` would block until the
+        // blocker finishes (~holdMillis = 1500 ms) and would fail this assertion. The
+        // previous bound of `< holdMillis` could not distinguish "bounded 200 ms wait" from
+        // "unbounded 1499 ms wait".
+        val maxAllowedMillis = timeoutMillis + 800L
+        assert(
+          elapsedMillis < maxAllowedMillis,
+          s"tryDumpMigrationState waited ${elapsedMillis} ms; expected bounded by ~${maxAllowedMillis} ms " +
+            s"(timeout=${timeoutMillis} ms, hold=${holdMillis} ms)"
+        )
+        assert(blockerFinished.await(5, TimeUnit.SECONDS), "blocker dump never finished")
+      } finally manager.close()
+    } finally deleteRecursively(dir)
+  }
+
+  test("signal fail-safe: tryDumpMigrationState writes when the lock is uncontended") {
+    // Counterpart to the timeout test: when no other thread holds `dumpLock`, the bounded
+    // `tryLock` must succeed (return true) and produce a real savepoint, so the routine
+    // signal path still writes the savepoint as before.
+    val dir = Files.createTempDirectory("savepoints-trylock-ok")
+    val cfg = newConfig(dir, intervalSeconds = 3600)
+    try {
+      val manager = new TestManager(cfg, processed = Set("alpha", "beta"))
+      try {
+        val wrote = manager.tryDumpMigrationState("signal", 5_000L)
+        assert(wrote, "uncontended tryDumpMigrationState must succeed")
+        val files = listSavepoints(dir)
+        assert(files.nonEmpty, "tryDumpMigrationState returned true but wrote no savepoint")
+        val parsed = MigratorConfig.loadFrom(latest(dir).toString)
+        assertEquals(parsed.skipParquetFiles.getOrElse(Set.empty), Set("alpha", "beta"))
+      } finally manager.close()
     } finally deleteRecursively(dir)
   }
 

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBToS3ExportSavepointsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBToS3ExportSavepointsTest.scala
@@ -104,20 +104,59 @@ class DynamoDBToS3ExportSavepointsTest extends MigratorSuiteWithDynamoDBLocal {
     )
   }
 
+  // Matches:
+  //   new format: savepoint_<epochMillis>_<counter>.yaml
+  //   legacy:     savepoint_<epochSeconds>.yaml
+  private val savepointNamePattern =
+    """^savepoint_(\d+)(?:_(\d+))?\.yaml$""".r
+
+  /** Sort key for a savepoint file. Uses the filename timestamp + counter for files produced by
+    * the current `SavepointsManager`, and falls back to the last-modified time for unknown
+    * files. This selection is independent of filesystem mtime granularity (which was the root
+    * cause of issue #347).
+    *
+    * Defensive: overflow-long or otherwise hostile filenames must not crash the sort; treat them
+    * as unknown and fall through to mtime.
+    */
+  private def savepointSortKey(path: Path): (Long, Long) =
+    path.getFileName.toString match {
+      case savepointNamePattern(head, tailOrNull) =>
+        try
+          if (tailOrNull == null)
+            (java.lang.Math.multiplyExact(java.lang.Long.parseLong(head), 1000L), -1L)
+          else
+            (java.lang.Long.parseLong(head), java.lang.Long.parseLong(tailOrNull))
+        catch {
+          case _: NumberFormatException | _: ArithmeticException =>
+            (Files.getLastModifiedTime(path).toMillis, -1L)
+        }
+      case _ =>
+        (Files.getLastModifiedTime(path).toMillis, -1L)
+    }
+
   private def findLatestSavepoint(directory: Path): Option[Path] =
     if (!Files.exists(directory)) None
-    else
-      Using
-        .resource(Files.list(directory)) { stream =>
+    else {
+      val candidates =
+        Using.resource(Files.list(directory)) { stream =>
           stream
             .iterator()
             .asScala
             .filter(path => Files.isRegularFile(path))
-            .filter(_.getFileName.toString.startsWith("savepoint_"))
+            .filter { path =>
+              val name = path.getFileName.toString
+              // Exclude temp files produced by the atomic-rename write path.
+              name.startsWith("savepoint_") && name.endsWith(".yaml")
+            }
             .toSeq
         }
-        .sortBy(path => Files.getLastModifiedTime(path).toMillis)
+      // Compute the sort key exactly once per file.
+      candidates
+        .map(p => savepointSortKey(p) -> p)
+        .sortBy(_._1)
         .lastOption
+        .map(_._2)
+    }
 
   private def ensureEmptyDirectory(directory: Path): Unit = {
     if (Files.exists(directory)) {

--- a/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBToS3ExportSavepointsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/alternator/DynamoDBToS3ExportSavepointsTest.scala
@@ -110,13 +110,13 @@ class DynamoDBToS3ExportSavepointsTest extends MigratorSuiteWithDynamoDBLocal {
   private val savepointNamePattern =
     """^savepoint_(\d+)(?:_(\d+))?\.yaml$""".r
 
-  /** Sort key for a savepoint file. Uses the filename timestamp + counter for files produced by
-    * the current `SavepointsManager`, and falls back to the last-modified time for unknown
-    * files. This selection is independent of filesystem mtime granularity (which was the root
-    * cause of issue #347).
+  /** Sort key for a savepoint file. Uses the filename timestamp + counter for files produced by the
+    * current `SavepointsManager`, and falls back to the last-modified time for unknown files. This
+    * selection is independent of filesystem mtime granularity (which was the root cause of issue
+    * #347).
     *
-    * Defensive: overflow-long or otherwise hostile filenames must not crash the sort; treat them
-    * as unknown and fall through to mtime.
+    * Defensive: overflow-long or otherwise hostile filenames must not crash the sort; treat them as
+    * unknown and fall through to mtime.
     */
   private def savepointSortKey(path: Path): (Long, Long) =
     path.getFileName.toString match {

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetMigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetMigratorSuite.scala
@@ -115,10 +115,10 @@ abstract class ParquetMigratorSuite extends MigratorSuite(sourcePort = 0) {
   private val savepointNamePattern =
     """^savepoint_(\d+)(?:_(\d+))?\.yaml$""".r
 
-  /** Sort key for a savepoint file. Uses the filename timestamp + counter for files produced by
-    * the current `SavepointsManager`, and falls back to the last-modified time for legacy files
-    * written by older versions. The filename-based key is preferred because it is independent of
-    * filesystem mtime granularity and immune to wall-clock adjustments.
+  /** Sort key for a savepoint file. Uses the filename timestamp + counter for files produced by the
+    * current `SavepointsManager`, and falls back to the last-modified time for legacy files written
+    * by older versions. The filename-based key is preferred because it is independent of filesystem
+    * mtime granularity and immune to wall-clock adjustments.
     *
     * Defensive: an attacker who can write into the savepoints directory could drop a file whose
     * numeric component overflows `Long`. `parseLong` on such a string throws

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetMigratorSuite.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetMigratorSuite.scala
@@ -109,20 +109,70 @@ abstract class ParquetMigratorSuite extends MigratorSuite(sourcePort = 0) {
         .toSet
     }
 
+  // Matches:
+  //   new format: savepoint_<epochMillis>_<counter>.yaml
+  //   legacy:     savepoint_<epochSeconds>.yaml
+  private val savepointNamePattern =
+    """^savepoint_(\d+)(?:_(\d+))?\.yaml$""".r
+
+  /** Sort key for a savepoint file. Uses the filename timestamp + counter for files produced by
+    * the current `SavepointsManager`, and falls back to the last-modified time for legacy files
+    * written by older versions. The filename-based key is preferred because it is independent of
+    * filesystem mtime granularity and immune to wall-clock adjustments.
+    *
+    * Defensive: an attacker who can write into the savepoints directory could drop a file whose
+    * numeric component overflows `Long`. `parseLong` on such a string throws
+    * `NumberFormatException`, which would crash the whole sort (denial-of-service on resume) if
+    * left uncaught. Treat overflow as an unknown filename and fall through to mtime so a hostile
+    * name cannot hijack or break the selection.
+    */
+  private def savepointSortKey(path: Path): (Long, Long) = {
+    val name = path.getFileName.toString
+    name match {
+      case savepointNamePattern(head, tailOrNull) =>
+        try
+          if (tailOrNull == null) {
+            // Legacy: `savepoint_<epochSeconds>.yaml`. Scale up to millis and treat counter as -1
+            // so a legacy file always sorts before a new-format file with the same wall-clock
+            // time.
+            (java.lang.Math.multiplyExact(java.lang.Long.parseLong(head), 1000L), -1L)
+          } else {
+            (java.lang.Long.parseLong(head), java.lang.Long.parseLong(tailOrNull))
+          }
+        catch {
+          case _: NumberFormatException | _: ArithmeticException =>
+            (Files.getLastModifiedTime(path).toMillis, -1L)
+        }
+      case _ =>
+        // Unknown format: fall back to mtime with a neutral counter.
+        (Files.getLastModifiedTime(path).toMillis, -1L)
+    }
+  }
+
   def findLatestSavepoint(directory: Path): Option[Path] =
     if (!Files.exists(directory)) None
-    else
-      Using
-        .resource(Files.list(directory)) { stream =>
+    else {
+      val candidates =
+        Using.resource(Files.list(directory)) { stream =>
           stream
             .iterator()
             .asScala
             .filter(path => Files.isRegularFile(path))
-            .filter(_.getFileName.toString.startsWith("savepoint_"))
+            .filter { path =>
+              val name = path.getFileName.toString
+              // Exclude temp files produced by the atomic-rename write path.
+              name.startsWith("savepoint_") && name.endsWith(".yaml")
+            }
             .toSeq
         }
-        .sortBy(path => Files.getLastModifiedTime(path).toMillis)
+      // Materialize the sort key once per file so the legacy-fallback branch does not issue an
+      // `Files.getLastModifiedTime` syscall per comparison.
+      candidates
+        .map(p => savepointSortKey(p) -> p)
+        .sortBy(_._1)
         .lastOption
+        .map(_._2)
+    }
 
   private def ensureEmptyDirectory(directory: Path): Unit = {
     if (Files.exists(directory)) {


### PR DESCRIPTION
Root cause analysis (issue: https://github.com/scylladb/scylla-migrator/issues/347)
----------------------

Savepoint filenames were minted as savepoint_<epochSeconds>.yaml. In the ParquetResumeIntegrationTest setup, three events contend within the same wall-clock second:

1. The SavepointsManager scheduled tick (periodic dump).
2. The driver's explicit "final" / "completed" dump (outside the scheduler).
3. The last bytes of the writer closing.

Combined with the test helper picking the "latest" savepoint by Files.getLastModifiedTime, three bugs fed the flakiness:

- Filename collision: two files written in the same second shared a name, so the scheduled tick could overwrite the terminal dump.
- No dump serialization: the scheduled task and the driver dump raced, and a later-started scheduled tick could finish its write after the terminal dump, with a stale snapshot.
- mtime-based "latest": on filesystems with second-granularity mtime (or when mtime equalled the terminal dump), the test picked the wrong file.

Solution in the PR
----------------------

1. Serialize dumps and await scheduler
2. Monotonic filenames + sort by filename

After the changes
----------------------

- Filename format changed. Any operator or script that parses savepoint_<seconds>.yaml must be updated, but it should not be a problem in practice because of the scenarios when users use the migrator, I don't expect migrator users to switch migrator version in the middle. New regex ^savepoint_\d{13}_\d{10}\.yaml$. Docs updated to match. Hostile or malformed filenames in the directory no longer crash the sort on resume; they fall through to mtime and are naturally outranked by legitimate new savepoints.
- ls <savepoints-dir> | tail -n 1 now works. With zero-padding, lexicographical order == chronological order. Previously the heuristic "pick largest timestamp" could be wrong on mixed-length second filenames. Pass the alphabetically last filename to resume.
- Legacy savepoints still readable. The migrator reads old savepoint_<seconds>.yaml files to seed its state, and new savepoints written during a resumed migration follow the new format.
- Resume across JVM restarts is now safe from clock drift. Previously, restarting on a host whose wall clock drifted backwards could make new savepoints sort before existing ones; the startup seed (#14) pins the monotonic invariant across restarts.
- close() takes 5-30 s where previously it returned instantly. Noticeable in very short runs; tolerable for any real migration.
- Operator signal contract strengthened. First SIGINT/SIGTERM/USR2 always triggers sys.exit(0) even if the savepoint dump itself fails (errors are logged, not swallowed silently). A second signal during an in-flight dump is a fast-path exit.
- Non-English default JVM locales no longer break migrations. Before this PR, a JVM defaulting to ar-SA or th-TH produced non-ASCII digits in the filename and couldn't resume itself.
- No changes to YAML schema or config surface. Savepoints(path, intervalSeconds) settings are unchanged.