### PR TITLE
address the connection reset issue against Astra by adding extra logic path supporting cloud mode and SCB security bundle, along with the test and doc changes

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -44,6 +44,35 @@ source:
   # Optional condition to filter source table data that will be migrated
   # where: race_start_date = '2015-05-27' AND race_end_date = '2015-05-27'
 
+  # Optional - Connect via a DataStax Astra Cloud Secure Connect bundle.
+  # When this block is present the 'host', 'port', 'localDC' and 'sslOptions' fields above must
+  # NOT be set: they are carried by the bundle and would conflict with it. Authentication
+  # credentials must still be supplied via the 'credentials' block.
+  # The 'secureBundlePath' must be readable on the driver and on every Spark executor that opens
+  # a CQL session — typically an absolute path that exists identically on every node, or an
+  # https/s3/s3a URL reachable from every node. Relative paths and plain HTTP URLs are rejected.
+  # Do not include credentials or signed-token query strings in the URL because configs may be
+  # logged or saved. Relative paths are NOT auto-resolved via SparkFiles.get because the resolved
+  # path differs between driver and executors.
+  #cloud:
+  #  secureBundlePath: /opt/migrator/secure-connect-mycluster.zip
+
+# Example for connecting to a DataStax Astra source via a Cloud Secure Connect bundle:
+# source:
+#   type: cassandra
+#   cloud:
+#     secureBundlePath: /opt/migrator/secure-connect-mycluster.zip
+#   credentials:
+#     username: <client-id>
+#     password: <client-secret>
+#   keyspace: <keyspace>
+#   table: <table>
+#   consistencyLevel: LOCAL_QUORUM
+#   preserveTimestamps: true
+#   splitCount: 256
+#   connections: 8
+#   fetchSize: 1000
+
 # Example for loading from Parquet:
 # source:
 #   type: parquet
@@ -194,6 +223,33 @@ target:
   #writeTTLInS: 7776000
   # writetime in microseconds (sample 1640998861000 is Saturday, January 1, 2022 2:01:01 AM GMT+01:00 )
   #writeWritetimestampInuS: 1640998861000
+
+  # Optional - Connect via a DataStax Astra Cloud Secure Connect bundle.
+  # When this block is present the 'host', 'port', 'localDC' and 'sslOptions' fields above must
+  # NOT be set: they are carried by the bundle and would conflict with it. Authentication
+  # credentials must still be supplied via the 'credentials' block.
+  # The 'secureBundlePath' must be readable on the driver and on every Spark executor that opens
+  # a CQL session — typically an absolute path that exists identically on every node, or an
+  # https/s3/s3a URL reachable from every node. Relative paths and plain HTTP URLs are rejected.
+  # Do not include credentials or signed-token query strings in the URL because configs may be
+  # logged or saved. Relative paths are NOT auto-resolved via SparkFiles.get because the resolved
+  # path differs between driver and executors.
+  #cloud:
+  #  secureBundlePath: /opt/migrator/secure-connect-mycluster.zip
+
+# Example for loading into a DataStax Astra target via a Cloud Secure Connect bundle:
+# target:
+#   type: scylla
+#   cloud:
+#     secureBundlePath: /opt/migrator/secure-connect-mycluster.zip
+#   credentials:
+#     username: <client-id>
+#     password: <client-secret>
+#   keyspace: <keyspace>
+#   table: <table>
+#   consistencyLevel: LOCAL_QUORUM
+#   connections: 16
+#   stripTrailingZerosForDecimals: false
 
 # Example for loading into a DynamoDB target (for example, Scylla's Alternator):
 # target:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -48,12 +48,19 @@ source:
   # When this block is present the 'host', 'port', 'localDC' and 'sslOptions' fields above must
   # NOT be set: they are carried by the bundle and would conflict with it. Authentication
   # credentials must still be supplied via the 'credentials' block.
-  # The 'secureBundlePath' must be readable on the driver and on every Spark executor that opens
-  # a CQL session — typically an absolute path that exists identically on every node, or an
-  # https/s3/s3a URL reachable from every node. Relative paths and plain HTTP URLs are rejected.
-  # Do not include credentials or signed-token query strings in the URL because configs may be
-  # logged or saved. Relative paths are NOT auto-resolved via SparkFiles.get because the resolved
-  # path differs between driver and executors.
+  #
+  # Accepted secureBundlePath forms:
+  #   - Absolute local path: /opt/migrator/secure-connect-mycluster.zip
+  #     (auto-converted to file:// URL at runtime; must exist on every node)
+  #   - https:// URL reachable from every node
+  #   - Bare filename: secure-connect-mycluster.zip
+  #     (for bundles distributed via spark-submit --files; resolved via SparkFiles.get)
+  #   - s3:// or s3a:// URL — works in standard Spark environments where Hadoop URL handlers
+  #     are registered. For maximum reliability, prefer --files instead:
+  #       spark-submit --files s3://bucket/bundle.zip ...
+  #     then set secureBundlePath to just the filename: bundle.zip
+  #
+  # Do not embed credentials or signed-token query strings in the URL.
   #cloud:
   #  secureBundlePath: /opt/migrator/secure-connect-mycluster.zip
 
@@ -72,6 +79,16 @@ source:
 #   splitCount: 256
 #   connections: 8
 #   fetchSize: 1000
+#
+# Alternative: distribute the bundle via --files (recommended for S3-hosted bundles):
+#   spark-submit --files s3://my-bucket/secure-connect-mycluster.zip \
+#     --class com.scylladb.migrator.Migrator migrator.jar
+# then use a bare filename in the config:
+# source:
+#   type: cassandra
+#   cloud:
+#     secureBundlePath: secure-connect-mycluster.zip
+#   ...
 
 # Example for loading from MySQL:
 # source:
@@ -315,15 +332,7 @@ target:
   #writeWritetimestampInuS: 1640998861000
 
   # Optional - Connect via a DataStax Astra Cloud Secure Connect bundle.
-  # When this block is present the 'host', 'port', 'localDC' and 'sslOptions' fields above must
-  # NOT be set: they are carried by the bundle and would conflict with it. Authentication
-  # credentials must still be supplied via the 'credentials' block.
-  # The 'secureBundlePath' must be readable on the driver and on every Spark executor that opens
-  # a CQL session — typically an absolute path that exists identically on every node, or an
-  # https/s3/s3a URL reachable from every node. Relative paths and plain HTTP URLs are rejected.
-  # Do not include credentials or signed-token query strings in the URL because configs may be
-  # logged or saved. Relative paths are NOT auto-resolved via SparkFiles.get because the resolved
-  # path differs between driver and executors.
+  # Same path rules as the source cloud block above. See source section for details.
   #cloud:
   #  secureBundlePath: /opt/migrator/secure-connect-mycluster.zip
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -135,13 +135,14 @@ credentials are not embedded in the bundle and must still be supplied via ``cred
     cloud:
       # Path or URL to the Astra secure-connect bundle (zip).
       # The path must be readable from the Spark driver and from every Spark executor that
-      # opens a CQL session. Use one of:
-      #   - an absolute filesystem path that exists identically on every node
-      #     (e.g. baked into the worker image, or on a shared mount), or
-      #   - an https://, s3://, or s3a:// URL reachable from every node.
-      # Plain HTTP URLs, relative paths, URL user-info credentials, and query strings are rejected.
-      # Relative paths are NOT auto-resolved via SparkFiles.get because the resolved path is
-      # computed on the driver and would be incorrect on executors.
+      # opens a CQL session. Accepted forms:
+      #   - Absolute filesystem path (auto-converted to file:// URL at runtime):
+      #       /opt/migrator/secure-connect-mycluster.zip
+      #   - https:// URL reachable from every node
+      #   - Bare filename (for bundles distributed via spark-submit --files):
+      #       secure-connect-mycluster.zip
+      #   - s3:// or s3a:// URL (works in standard Spark environments; for maximum
+      #     reliability prefer --files instead — see below)
       secureBundlePath: /opt/migrator/secure-connect-mycluster.zip
     credentials:
       username: <client-id>
@@ -153,6 +154,23 @@ credentials are not embedded in the bundle and must still be supplied via ``cred
     splitCount: 256
     connections: 8
     fetchSize: 1000
+
+**Using ``--files`` for S3-hosted bundles** (recommended): instead of placing the ``s3://``
+URL directly in ``secureBundlePath``, distribute the bundle through Spark's ``--files``
+mechanism and refer to it by bare filename:
+
+.. code-block:: bash
+
+  spark-submit --files s3://my-bucket/secure-connect-prod.zip \
+    --class com.scylladb.migrator.Migrator migrator.jar
+
+.. code-block:: yaml
+
+  cloud:
+    secureBundlePath: secure-connect-prod.zip
+
+Spark downloads the file once per executor before any task runs, so the connector always
+finds a local copy — no dependency on Hadoop URL handlers or repeated S3 fetches.
 
 This setting is also accepted on a Cassandra target. See :ref:`config-cassandra-cloud-target`.
 
@@ -381,7 +399,9 @@ DataStax Astra (Cloud Secure Connect bundle)
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Same semantics as :ref:`config-cassandra-cloud-source` but on the target side. ``host``, ``port``,
-``localDC`` and ``sslOptions`` must not be set when ``cloud`` is provided.
+``localDC`` and ``sslOptions`` must not be set when ``cloud`` is provided. The same
+``secureBundlePath`` forms (absolute path, ``https://``, bare filename via ``--files``, ``s3://``)
+are accepted.
 
 .. code-block:: yaml
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -114,6 +114,46 @@ A source of type ``cassandra`` can be used together with a target of type ``cass
     # Optional - Condition to filter data that will be migrated
     where: race_start_date = '2015-05-27' AND race_end_date = '2015-05-27'
 
+.. _config-cassandra-cloud-source:
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+DataStax Astra (Cloud Secure Connect bundle)
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Set the ``cloud`` block to migrate from a managed cluster (DataStax Astra DB) that is reached
+through an SNI proxy. The bundle carries the contact points, the local datacenter and all the TLS
+material; therefore the ``host``, ``port``, ``localDC`` and ``sslOptions`` fields **must not** be
+set in the same source — the migrator rejects the configuration if they are. Authentication
+credentials are not embedded in the bundle and must still be supplied via ``credentials``.
+
+.. code-block:: yaml
+
+  source:
+    type: cassandra
+    cloud:
+      # Path or URL to the Astra secure-connect bundle (zip).
+      # The path must be readable from the Spark driver and from every Spark executor that
+      # opens a CQL session. Use one of:
+      #   - an absolute filesystem path that exists identically on every node
+      #     (e.g. baked into the worker image, or on a shared mount), or
+      #   - an https://, s3://, or s3a:// URL reachable from every node.
+      # Plain HTTP URLs, relative paths, URL user-info credentials, and query strings are rejected.
+      # Relative paths are NOT auto-resolved via SparkFiles.get because the resolved path is
+      # computed on the driver and would be incorrect on executors.
+      secureBundlePath: /opt/migrator/secure-connect-mycluster.zip
+    credentials:
+      username: <client-id>
+      password: <client-secret>
+    keyspace: <keyspace>
+    table: <table>
+    consistencyLevel: LOCAL_QUORUM
+    preserveTimestamps: true
+    splitCount: 256
+    connections: 8
+    fetchSize: 1000
+
+This setting is also accepted on a Cassandra target. See :ref:`config-cassandra-cloud-target`.
+
 ^^^^^^^^^^^^^^
 Parquet Source
 ^^^^^^^^^^^^^^
@@ -285,6 +325,30 @@ Apache Cassandra Target
        - TLS_RSA_WITH_AES_128_CBC_SHA
        - TLS_RSA_WITH_AES_256_CBC_SHA
       protocol: TLS
+
+.. _config-cassandra-cloud-target:
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+DataStax Astra (Cloud Secure Connect bundle)
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Same semantics as :ref:`config-cassandra-cloud-source` but on the target side. ``host``, ``port``,
+``localDC`` and ``sslOptions`` must not be set when ``cloud`` is provided.
+
+.. code-block:: yaml
+
+  target:
+    type: cassandra
+    cloud:
+      secureBundlePath: /opt/migrator/secure-connect-mycluster.zip
+    credentials:
+      username: <client-id>
+      password: <client-secret>
+    keyspace: <keyspace>
+    table: <table>
+    consistencyLevel: LOCAL_QUORUM
+    connections: 16
+    stripTrailingZerosForDecimals: false
 
 
 ^^^^^^^^^^^^^^^

--- a/migrator/src/main/scala/com/scylladb/migrator/Connectors.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Connectors.scala
@@ -210,12 +210,21 @@ object Connectors {
   /** Build a [[CloudBasedContactInfo]]. The driver opens the bundle on every node that creates a
     * session, so the path must be reachable from every executor — see [[CloudConfig]] for
     * deployment guidance.
+    *
+    * Absolute local paths (`/opt/...`) are normalized to `file:///opt/...` URLs because the
+    * connector's `DefaultConnectionFactory.maybeGetLocalFile` falls back to `new URL(path)`, which
+    * requires a scheme — bare absolute paths would throw `MalformedURLException`.
     */
-  private def cloudContactInfo(
+  private[migrator] def cloudContactInfo(
     cloud: CloudConfig,
     auth: com.datastax.spark.connector.cql.AuthConf
-  ): ContactInfo =
-    CloudBasedContactInfo(cloud.secureBundlePath, auth)
+  ): ContactInfo = {
+    val resolvedPath =
+      if (cloud.secureBundlePath.startsWith("/"))
+        new java.io.File(cloud.secureBundlePath).toURI.toString
+      else cloud.secureBundlePath
+    CloudBasedContactInfo(resolvedPath, auth)
+  }
 
   private def ipContactInfo(
     host: String,

--- a/migrator/src/main/scala/com/scylladb/migrator/Connectors.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Connectors.scala
@@ -182,6 +182,10 @@ object Connectors {
   def targetConnector(sparkConf: SparkConf, targetSettings: TargetSettings.Scylla) =
     new CassandraConnector(buildTargetConf(sparkConf, targetSettings))
 
+  /** Map optional credentials to the connector's auth model. Missing credentials become
+    * [[NoAuthConf]] rather than a parse-time error — Astra will reject unauthenticated sessions at
+    * connect time, and non-Astra cloud bundles may use mTLS-only auth embedded in the bundle.
+    */
   private def authConf(credentials: Option[Credentials]) =
     credentials match {
       case None                                  => NoAuthConf
@@ -231,10 +235,14 @@ object Connectors {
     port: Int,
     auth: com.datastax.spark.connector.cql.AuthConf,
     sslOptions: Option[SSLOptions]
-  ): ContactInfo =
+  ): ContactInfo = {
+    val resolvedHost =
+      if (host.startsWith("[") && host.endsWith("]")) host.slice(1, host.length - 1)
+      else host
     IpBasedContactInfo(
-      hosts            = Set(new InetSocketAddress(host, port)),
+      hosts            = Set(new InetSocketAddress(resolvedHost, port)),
       authConf         = auth,
       cassandraSSLConf = cassandraSSLConf(sslOptions)
     )
+  }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/Connectors.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Connectors.scala
@@ -1,85 +1,131 @@
 package com.scylladb.migrator
 
-import java.net.{ InetAddress, InetSocketAddress }
+import java.net.InetSocketAddress
 
 import com.datastax.spark.connector.cql.{
   CassandraConnector,
   CassandraConnectorConf,
+  CloudBasedContactInfo,
+  ContactInfo,
   IpBasedContactInfo,
   NoAuthConf,
   PasswordAuthConf
 }
-import com.scylladb.migrator.config.{ Credentials, SourceSettings, TargetSettings }
+import com.scylladb.migrator.config.{
+  CloudConfig,
+  Credentials,
+  SSLOptions,
+  SourceSettings,
+  TargetSettings
+}
 import org.apache.spark.SparkConf
 
 object Connectors {
-  def sourceConnector(sparkConf: SparkConf, sourceSettings: SourceSettings.Cassandra) =
-    new CassandraConnector(
-      CassandraConnectorConf(sparkConf).copy(
-        contactInfo = IpBasedContactInfo(
-          hosts = Set(new InetSocketAddress(sourceSettings.host, sourceSettings.port)),
-          authConf = sourceSettings.credentials match {
-            case None                                  => NoAuthConf
-            case Some(Credentials(username, password)) => PasswordAuthConf(username, password)
-          },
-          cassandraSSLConf = sourceSettings.sslOptions match {
-            case None => CassandraConnectorConf.DefaultCassandraSSLConf
-            case Some(sslOptions) =>
-              CassandraConnectorConf.CassandraSSLConf(
-                enabled            = sslOptions.enabled,
-                trustStorePath     = sslOptions.trustStorePath,
-                trustStorePassword = sslOptions.trustStorePassword,
-                trustStoreType     = sslOptions.trustStoreType.getOrElse("JKS"),
-                protocol           = sslOptions.protocol.getOrElse("TLS"),
-                enabledAlgorithms = sslOptions.enabledAlgorithms.getOrElse(
-                  Set("TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA")
-                ),
-                clientAuthEnabled = sslOptions.clientAuthEnabled,
-                keyStorePath      = sslOptions.keyStorePath,
-                keyStorePassword  = sslOptions.keyStorePassword,
-                keyStoreType      = sslOptions.keyStoreType.getOrElse("JKS")
-              )
-          }
-        ),
-        localDC                      = sourceSettings.localDC,
-        localConnectionsPerExecutor  = sourceSettings.connections,
-        remoteConnectionsPerExecutor = sourceSettings.connections,
-        queryRetryCount              = -1
-      )
+
+  /** Build a `CassandraConnectorConf` from a Cassandra source.
+    *
+    * Exposed as `private[migrator]` so unit tests can assert on the resulting `contactInfo` (cloud
+    * bundle vs IP+SSL) without spinning up a real `CassandraConnector` (which would try to open a
+    * session at construction time in some code paths).
+    */
+  private[migrator] def buildSourceConf(
+    sparkConf: SparkConf,
+    sourceSettings: SourceSettings.Cassandra
+  ): CassandraConnectorConf = {
+    val authConf = toAuthConf(sourceSettings.credentials)
+    val contact = sourceSettings.cloud match {
+      case Some(cloud) =>
+        cloudContactInfo(cloud, authConf)
+      case None =>
+        ipContactInfo(
+          sourceSettings.host,
+          sourceSettings.port,
+          authConf,
+          sourceSettings.sslOptions
+        )
+    }
+    CassandraConnectorConf(sparkConf).copy(
+      contactInfo = contact,
+      localDC     = if (sourceSettings.cloud.isDefined) None else sourceSettings.localDC,
+      localConnectionsPerExecutor  = sourceSettings.connections,
+      remoteConnectionsPerExecutor = sourceSettings.connections,
+      queryRetryCount              = -1
     )
+  }
+
+  /** Mirror of [[buildSourceConf]] for Scylla targets. */
+  private[migrator] def buildTargetConf(
+    sparkConf: SparkConf,
+    targetSettings: TargetSettings.Scylla
+  ): CassandraConnectorConf = {
+    val authConf = toAuthConf(targetSettings.credentials)
+    val contact = targetSettings.cloud match {
+      case Some(cloud) =>
+        cloudContactInfo(cloud, authConf)
+      case None =>
+        ipContactInfo(
+          targetSettings.host,
+          targetSettings.port,
+          authConf,
+          targetSettings.sslOptions
+        )
+    }
+    CassandraConnectorConf(sparkConf).copy(
+      contactInfo = contact,
+      localDC     = if (targetSettings.cloud.isDefined) None else targetSettings.localDC,
+      localConnectionsPerExecutor  = targetSettings.connections,
+      remoteConnectionsPerExecutor = targetSettings.connections,
+      queryRetryCount              = -1
+    )
+  }
+
+  def sourceConnector(sparkConf: SparkConf, sourceSettings: SourceSettings.Cassandra) =
+    new CassandraConnector(buildSourceConf(sparkConf, sourceSettings))
 
   def targetConnector(sparkConf: SparkConf, targetSettings: TargetSettings.Scylla) =
-    new CassandraConnector(
-      CassandraConnectorConf(sparkConf).copy(
-        contactInfo = IpBasedContactInfo(
-          hosts = Set(new InetSocketAddress(targetSettings.host, targetSettings.port)),
-          authConf = targetSettings.credentials match {
-            case None                                  => NoAuthConf
-            case Some(Credentials(username, password)) => PasswordAuthConf(username, password)
-          },
-          cassandraSSLConf = targetSettings.sslOptions match {
-            case None => CassandraConnectorConf.DefaultCassandraSSLConf
-            case Some(sslOptions) =>
-              CassandraConnectorConf.CassandraSSLConf(
-                enabled            = sslOptions.enabled,
-                clientAuthEnabled  = sslOptions.clientAuthEnabled,
-                trustStorePath     = sslOptions.trustStorePath,
-                trustStorePassword = sslOptions.trustStorePassword,
-                trustStoreType     = sslOptions.trustStoreType.getOrElse("JKS"),
-                protocol           = sslOptions.protocol.getOrElse("TLS"),
-                keyStorePath       = sslOptions.keyStorePath,
-                keyStorePassword   = sslOptions.keyStorePassword,
-                enabledAlgorithms = sslOptions.enabledAlgorithms.getOrElse(
-                  Set("TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA")
-                ),
-                keyStoreType = sslOptions.keyStoreType.getOrElse("JKS")
-              )
-          }
-        ),
-        localDC                      = targetSettings.localDC,
-        localConnectionsPerExecutor  = targetSettings.connections,
-        remoteConnectionsPerExecutor = targetSettings.connections,
-        queryRetryCount              = -1
-      )
+    new CassandraConnector(buildTargetConf(sparkConf, targetSettings))
+
+  private def toAuthConf(credentials: Option[Credentials]) = credentials match {
+    case None                                  => NoAuthConf
+    case Some(Credentials(username, password)) => PasswordAuthConf(username, password)
+  }
+
+  /** Build a [[CloudBasedContactInfo]]. The driver opens the bundle on every node that creates a
+    * session, so the path must be reachable from every executor — see [[CloudConfig]] for
+    * deployment guidance.
+    */
+  private def cloudContactInfo(
+    cloud: CloudConfig,
+    authConf: com.datastax.spark.connector.cql.AuthConf
+  ): ContactInfo =
+    CloudBasedContactInfo(cloud.secureBundlePath, authConf)
+
+  private def ipContactInfo(
+    host: String,
+    port: Int,
+    authConf: com.datastax.spark.connector.cql.AuthConf,
+    sslOptions: Option[SSLOptions]
+  ): ContactInfo =
+    IpBasedContactInfo(
+      hosts    = Set(new InetSocketAddress(host, port)),
+      authConf = authConf,
+      cassandraSSLConf = sslOptions match {
+        case None => CassandraConnectorConf.DefaultCassandraSSLConf
+        case Some(s) =>
+          CassandraConnectorConf.CassandraSSLConf(
+            enabled            = s.enabled,
+            trustStorePath     = s.trustStorePath,
+            trustStorePassword = s.trustStorePassword,
+            trustStoreType     = s.trustStoreType.getOrElse("JKS"),
+            protocol           = s.protocol.getOrElse("TLS"),
+            enabledAlgorithms = s.enabledAlgorithms.getOrElse(
+              Set("TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA")
+            ),
+            clientAuthEnabled = s.clientAuthEnabled,
+            keyStorePath      = s.keyStorePath,
+            keyStorePassword  = s.keyStorePassword,
+            keyStoreType      = s.keyStoreType.getOrElse("JKS")
+          )
+      }
     )
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/CloudConfig.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/CloudConfig.scala
@@ -1,0 +1,91 @@
+package com.scylladb.migrator.config
+
+import java.net.URI
+
+import io.circe.{ Decoder, DecodingFailure, Encoder }
+import io.circe.generic.semiauto.deriveEncoder
+
+import scala.util.Try
+
+/** Configuration for connecting to a Cassandra-compatible service via a Cloud Secure Connect bundle
+  * (DataStax Astra DB).
+  *
+  * The bundle is a zip file produced by Astra that contains the contact points, TLS material
+  * (certificates, keystore/truststore), metadata service URL and protocol settings required to
+  * reach a managed cluster behind an SNI proxy. When this configuration is present, the migrator
+  * delegates contact-point discovery, TLS and SNI handshake to the underlying connector and
+  * therefore the `host`, `port`, `localDC` and `sslOptions` fields of the source/target settings
+  * MUST NOT be specified — they would be ignored by the driver and conflict with the bundle.
+  *
+  * Authentication credentials must still be supplied via the `credentials` field of the enclosing
+  * source/target settings: the bundle does not embed Astra database credentials.
+  *
+  * @param secureBundlePath
+  *   Path to the secure-connect bundle. Must be readable from the Spark driver and from every Spark
+  *   executor that will open a CQL session. Supported forms:
+  *   - An absolute filesystem path that exists identically on every node (recommended for
+  *     standalone clusters: bake the bundle into the worker image, or place it on a shared mount).
+  *   - An `https://`, `s3://`, or `s3a://` URL accessible from every node.
+  *
+  * Note: relative paths are intentionally not auto-resolved via `SparkFiles.get` because the
+  * resolved path is computed on the driver and would be incorrect on executors. If you want to ship
+  * the bundle through `--files`, materialise it on a deterministic path on every node (e.g. via the
+  * entrypoint script) and pass that absolute path here.
+  */
+case class CloudConfig(secureBundlePath: String)
+
+object CloudConfig {
+  private val RemoteSchemes = Set("https", "s3", "s3a")
+
+  implicit val encoder: Encoder[CloudConfig] = deriveEncoder[CloudConfig]
+  implicit val decoder: Decoder[CloudConfig] = Decoder.instance { c =>
+    for {
+      rawPath <- c.get[String]("secureBundlePath")
+      path = rawPath.trim
+      _ <-
+        if (path.trim.isEmpty)
+          Left(
+            DecodingFailure(
+              "cloud.secureBundlePath must not be empty.",
+              c.history
+            )
+          )
+        else if (path.startsWith("/")) Right(())
+        else {
+          val uri = Try(new URI(path)).toOption
+          val scheme = uri.flatMap(u => Option(u.getScheme).map(_.toLowerCase))
+          scheme match {
+            case Some("http") =>
+              Left(
+                DecodingFailure(
+                  "cloud.secureBundlePath must not use plain HTTP; use an absolute local path, https://, s3://, or s3a://.",
+                  c.history
+                )
+              )
+            case Some(s) if RemoteSchemes.contains(s) && uri.exists(_.getUserInfo != null) =>
+              Left(
+                DecodingFailure(
+                  "cloud.secureBundlePath must not include URL user-info credentials.",
+                  c.history
+                )
+              )
+            case Some(s) if RemoteSchemes.contains(s) && uri.exists(_.getRawQuery != null) =>
+              Left(
+                DecodingFailure(
+                  "cloud.secureBundlePath must not include query string credentials.",
+                  c.history
+                )
+              )
+            case Some(s) if RemoteSchemes.contains(s) => Right(())
+            case _ =>
+              Left(
+                DecodingFailure(
+                  "cloud.secureBundlePath must be an absolute local path, https:// URL, s3:// URL, or s3a:// URL.",
+                  c.history
+                )
+              )
+          }
+        }
+    } yield CloudConfig(path)
+  }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/config/CloudConfig.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/CloudConfig.scala
@@ -23,27 +23,31 @@ import scala.util.Try
   * @param secureBundlePath
   *   Path to the secure-connect bundle. Must be readable from the Spark driver and from every Spark
   *   executor that will open a CQL session. Supported forms:
-  *   - An absolute filesystem path that exists identically on every node (recommended for
-  *     standalone clusters: bake the bundle into the worker image, or place it on a shared mount).
-  *   - An `https://`, `s3://`, or `s3a://` URL accessible from every node.
-  *
-  * Note: relative paths are intentionally not auto-resolved via `SparkFiles.get` because the
-  * resolved path is computed on the driver and would be incorrect on executors. If you want to ship
-  * the bundle through `--files`, materialise it on a deterministic path on every node (e.g. via the
-  * entrypoint script) and pass that absolute path here.
+  *   - An absolute filesystem path (e.g. `/opt/migrator/bundle.zip`) that exists identically on
+  *     every node. The migrator auto-converts this to a `file://` URL at runtime because the
+  *     connector resolves bundle paths via `new URL(path)`, which requires a scheme.
+  *   - An `https://` URL accessible from every node.
+  *   - A bare filename (e.g. `bundle.zip`) for bundles distributed via Spark's `--files` mechanism.
+  *     The connector resolves bare filenames through `SparkFiles.get` on each executor.
+  *   - `s3://` or `s3a://` URLs. '''Note:''' these rely on Hadoop's URL stream handler being
+  *     registered in the JVM (standard in most Spark environments). For maximum reliability, prefer
+  *     distributing the bundle with `--files s3://bucket/bundle.zip` and setting `secureBundlePath`
+  *     to the bare filename instead.
   */
 case class CloudConfig(secureBundlePath: String)
 
 object CloudConfig {
-  private val RemoteSchemes = Set("https", "s3", "s3a")
+  private val RemoteSchemes = Set("https", "s3", "s3a", "file")
 
   implicit val encoder: Encoder[CloudConfig] = deriveEncoder[CloudConfig]
+  private val BareFilenamePattern = "[a-zA-Z0-9][a-zA-Z0-9._-]*".r
+
   implicit val decoder: Decoder[CloudConfig] = Decoder.instance { c =>
     for {
       rawPath <- c.get[String]("secureBundlePath")
       path = rawPath.trim
       _ <-
-        if (path.trim.isEmpty)
+        if (path.isEmpty)
           Left(
             DecodingFailure(
               "cloud.secureBundlePath must not be empty.",
@@ -51,6 +55,7 @@ object CloudConfig {
             )
           )
         else if (path.startsWith("/")) Right(())
+        else if (BareFilenamePattern.matches(path) && !path.contains("/")) Right(())
         else {
           val uri = Try(new URI(path)).toOption
           val scheme = uri.flatMap(u => Option(u.getScheme).map(_.toLowerCase))
@@ -58,7 +63,8 @@ object CloudConfig {
             case Some("http") =>
               Left(
                 DecodingFailure(
-                  "cloud.secureBundlePath must not use plain HTTP; use an absolute local path, https://, s3://, or s3a://.",
+                  "cloud.secureBundlePath must not use plain HTTP; use an absolute local path, " +
+                    "an https://, s3://, or s3a:// URL, or a bare filename for --files.",
                   c.history
                 )
               )
@@ -80,7 +86,8 @@ object CloudConfig {
             case _ =>
               Left(
                 DecodingFailure(
-                  "cloud.secureBundlePath must be an absolute local path, https:// URL, s3:// URL, or s3a:// URL.",
+                  "cloud.secureBundlePath must be an absolute local path, an https://, s3://, " +
+                    "or s3a:// URL, or a bare filename (for Spark --files distribution).",
                   c.history
                 )
               )

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
@@ -31,8 +31,124 @@ object SourceSettings {
     fetchSize: Int,
     preserveTimestamps: Boolean,
     where: Option[String],
-    consistencyLevel: String
+    consistencyLevel: String,
+    cloud: Option[CloudConfig] = None
   ) extends SourceSettings
+
+  /** When `cloud` is set, the connector will reach the cluster through the Astra SNI proxy
+    * described by the secure-connect bundle. In that mode the `host` and `port` fields are
+    * meaningless (the bundle carries the contact points), so we make them optional in YAML and fall
+    * back to inert sentinels in the case class. The decoder rejects any combination that would
+    * silently ignore user input.
+    */
+  object Cassandra {
+    private val SentinelHost: String = ""
+    private val SentinelPort: Int = 0
+
+    implicit val decoder: Decoder[Cassandra] = Decoder.instance { c =>
+      val hasHost = c.get[Option[String]]("host").exists(_.isDefined)
+      val hasPort = c.get[Option[Int]]("port").exists(_.isDefined)
+      for {
+        cloud <- c.get[Option[CloudConfig]]("cloud")
+        _ <- (cloud.isDefined, hasHost, hasPort) match {
+               case (true, true, _) =>
+                 Left(
+                   DecodingFailure(
+                     "Cassandra source: 'cloud' is mutually exclusive with 'host'/'port'. " +
+                       "Remove 'host' and 'port' when using a secure-connect bundle.",
+                     c.history
+                   )
+                 )
+               case (true, _, true) =>
+                 Left(
+                   DecodingFailure(
+                     "Cassandra source: 'cloud' is mutually exclusive with 'host'/'port'. " +
+                       "Remove 'host' and 'port' when using a secure-connect bundle.",
+                     c.history
+                   )
+                 )
+               case (false, true, true) => Right(())
+               case (false, _, _) =>
+                 Left(
+                   DecodingFailure(
+                     "Cassandra source: 'host' and 'port' are required unless 'cloud' is set.",
+                     c.history
+                   )
+                 )
+               case (true, false, false) => Right(())
+             }
+        host               <- c.getOrElse[String]("host")(SentinelHost)
+        port               <- c.getOrElse[Int]("port")(SentinelPort)
+        localDC            <- c.get[Option[String]]("localDC")
+        credentials        <- c.get[Option[Credentials]]("credentials")
+        sslOptions         <- c.get[Option[SSLOptions]]("sslOptions")
+        keyspace           <- c.get[String]("keyspace")
+        table              <- c.get[String]("table")
+        splitCount         <- c.get[Option[Int]]("splitCount")
+        connections        <- c.get[Option[Int]]("connections")
+        fetchSize          <- c.get[Int]("fetchSize")
+        preserveTimestamps <- c.get[Boolean]("preserveTimestamps")
+        where              <- c.get[Option[String]]("where")
+        consistencyLevel   <- c.get[String]("consistencyLevel")
+        _ <- if (cloud.isDefined && localDC.isDefined)
+               Left(
+                 DecodingFailure(
+                   "Cassandra source: 'localDC' must not be set when using 'cloud' (the bundle " +
+                     "carries the local DC).",
+                   c.history
+                 )
+               )
+             else Right(())
+        _ <-
+          if (cloud.isDefined && sslOptions.isDefined)
+            Left(
+              DecodingFailure(
+                "Cassandra source: 'sslOptions' must not be set when using 'cloud' (the bundle " +
+                  "carries the TLS material).",
+                c.history
+              )
+            )
+          else Right(())
+      } yield Cassandra(
+        host,
+        port,
+        localDC,
+        credentials,
+        sslOptions,
+        keyspace,
+        table,
+        splitCount,
+        connections,
+        fetchSize,
+        preserveTimestamps,
+        where,
+        consistencyLevel,
+        cloud
+      )
+    }
+
+    implicit val encoder: Encoder.AsObject[Cassandra] = Encoder.AsObject.instance { c =>
+      val common = io.circe.JsonObject(
+        "localDC"            -> c.localDC.asJson,
+        "credentials"        -> c.credentials.asJson,
+        "sslOptions"         -> c.sslOptions.asJson,
+        "keyspace"           -> c.keyspace.asJson,
+        "table"              -> c.table.asJson,
+        "splitCount"         -> c.splitCount.asJson,
+        "connections"        -> c.connections.asJson,
+        "fetchSize"          -> c.fetchSize.asJson,
+        "preserveTimestamps" -> c.preserveTimestamps.asJson,
+        "where"              -> c.where.asJson,
+        "consistencyLevel"   -> c.consistencyLevel.asJson
+      )
+      c.cloud match {
+        case Some(cloud) =>
+          common.add("cloud", cloud.asJson)
+        case None =>
+          common.add("host", c.host.asJson).add("port", c.port.asJson)
+      }
+    }
+  }
   case class DynamoDB(
     endpoint: Option[DynamoDBEndpoint],
     region: Option[String],
@@ -154,7 +270,7 @@ object SourceSettings {
   implicit val decoder: Decoder[SourceSettings] = Decoder.instance { cursor =>
     cursor.get[String]("type").flatMap {
       case "cassandra" | "scylla" =>
-        deriveDecoder[Cassandra].apply(cursor)
+        Cassandra.decoder.apply(cursor)
       case "parquet" =>
         deriveDecoder[Parquet].apply(cursor)
       case "dynamo" | "dynamodb" =>
@@ -168,7 +284,7 @@ object SourceSettings {
 
   implicit val encoder: Encoder[SourceSettings] = Encoder.instance {
     case s: Cassandra =>
-      deriveEncoder[Cassandra]
+      Cassandra.encoder
         .encodeObject(s)
         .add("type", Json.fromString("cassandra"))
         .asJson

--- a/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
@@ -23,8 +23,119 @@ object TargetSettings {
     writeTTLInS: Option[Int],
     writeWritetimestampInuS: Option[Long],
     consistencyLevel: String,
-    dropNullPrimaryKeys: Option[Boolean] = None
+    dropNullPrimaryKeys: Option[Boolean] = None,
+    cloud: Option[CloudConfig] = None
   ) extends TargetSettings
+
+  /** Mirror of `SourceSettings.Cassandra` cloud handling. See the doc-comment on [[CloudConfig]]
+    * for why `host`/`port`/`localDC`/`sslOptions` are rejected when `cloud` is set.
+    */
+  object Scylla {
+    private val SentinelHost: String = ""
+    private val SentinelPort: Int = 0
+
+    implicit val decoder: Decoder[Scylla] = Decoder.instance { c =>
+      val hasHost = c.get[Option[String]]("host").exists(_.isDefined)
+      val hasPort = c.get[Option[Int]]("port").exists(_.isDefined)
+      for {
+        cloud <- c.get[Option[CloudConfig]]("cloud")
+        _ <- (cloud.isDefined, hasHost, hasPort) match {
+               case (true, true, _) =>
+                 Left(
+                   DecodingFailure(
+                     "Scylla target: 'cloud' is mutually exclusive with 'host'/'port'. " +
+                       "Remove 'host' and 'port' when using a secure-connect bundle.",
+                     c.history
+                   )
+                 )
+               case (true, _, true) =>
+                 Left(
+                   DecodingFailure(
+                     "Scylla target: 'cloud' is mutually exclusive with 'host'/'port'. " +
+                       "Remove 'host' and 'port' when using a secure-connect bundle.",
+                     c.history
+                   )
+                 )
+               case (false, true, true) => Right(())
+               case (false, _, _) =>
+                 Left(
+                   DecodingFailure(
+                     "Scylla target: 'host' and 'port' are required unless 'cloud' is set.",
+                     c.history
+                   )
+                 )
+               case (true, false, false) => Right(())
+             }
+        host                          <- c.getOrElse[String]("host")(SentinelHost)
+        port                          <- c.getOrElse[Int]("port")(SentinelPort)
+        localDC                       <- c.get[Option[String]]("localDC")
+        credentials                   <- c.get[Option[Credentials]]("credentials")
+        sslOptions                    <- c.get[Option[SSLOptions]]("sslOptions")
+        keyspace                      <- c.get[String]("keyspace")
+        table                         <- c.get[String]("table")
+        connections                   <- c.get[Option[Int]]("connections")
+        stripTrailingZerosForDecimals <- c.get[Boolean]("stripTrailingZerosForDecimals")
+        writeTTLInS                   <- c.get[Option[Int]]("writeTTLInS")
+        writeWritetimestampInuS       <- c.get[Option[Long]]("writeWritetimestampInuS")
+        consistencyLevel              <- c.get[String]("consistencyLevel")
+        dropNullPrimaryKeys           <- c.get[Option[Boolean]]("dropNullPrimaryKeys")
+        _ <- if (cloud.isDefined && localDC.isDefined)
+               Left(
+                 DecodingFailure(
+                   "Scylla target: 'localDC' must not be set when using 'cloud' (the bundle " +
+                     "carries the local DC).",
+                   c.history
+                 )
+               )
+             else Right(())
+        _ <- if (cloud.isDefined && sslOptions.isDefined)
+               Left(
+                 DecodingFailure(
+                   "Scylla target: 'sslOptions' must not be set when using 'cloud' (the bundle " +
+                     "carries the TLS material).",
+                   c.history
+                 )
+               )
+             else Right(())
+      } yield Scylla(
+        host,
+        port,
+        localDC,
+        credentials,
+        sslOptions,
+        keyspace,
+        table,
+        connections,
+        stripTrailingZerosForDecimals,
+        writeTTLInS,
+        writeWritetimestampInuS,
+        consistencyLevel,
+        dropNullPrimaryKeys,
+        cloud
+      )
+    }
+
+    implicit val encoder: Encoder.AsObject[Scylla] = Encoder.AsObject.instance { s =>
+      val common = io.circe.JsonObject(
+        "localDC"                       -> s.localDC.asJson,
+        "credentials"                   -> s.credentials.asJson,
+        "sslOptions"                    -> s.sslOptions.asJson,
+        "keyspace"                      -> s.keyspace.asJson,
+        "table"                         -> s.table.asJson,
+        "connections"                   -> s.connections.asJson,
+        "stripTrailingZerosForDecimals" -> s.stripTrailingZerosForDecimals.asJson,
+        "writeTTLInS"                   -> s.writeTTLInS.asJson,
+        "writeWritetimestampInuS"       -> s.writeWritetimestampInuS.asJson,
+        "consistencyLevel"              -> s.consistencyLevel.asJson,
+        "dropNullPrimaryKeys"           -> s.dropNullPrimaryKeys.asJson
+      )
+      s.cloud match {
+        case Some(cloud) => common.add("cloud", cloud.asJson)
+        case None =>
+          common.add("host", s.host.asJson).add("port", s.port.asJson)
+      }
+    }
+  }
 
   case class DynamoDB(
     endpoint: Option[DynamoDBEndpoint],
@@ -63,7 +174,7 @@ object TargetSettings {
     Decoder.instance { cursor =>
       cursor.get[String]("type").flatMap {
         case "scylla" | "cassandra" =>
-          deriveDecoder[Scylla].apply(cursor)
+          Scylla.decoder.apply(cursor)
         case "dynamodb" | "dynamo" =>
           deriveDecoder[DynamoDB].apply(cursor)
         case "parquet" =>
@@ -115,7 +226,7 @@ object TargetSettings {
   implicit val encoder: Encoder[TargetSettings] =
     Encoder.instance {
       case t: Scylla =>
-        deriveEncoder[Scylla].encodeObject(t).add("type", Json.fromString("scylla")).asJson
+        Scylla.encoder.encodeObject(t).add("type", Json.fromString("scylla")).asJson
 
       case t: DynamoDB =>
         deriveEncoder[DynamoDB].encodeObject(t).add("type", Json.fromString("dynamodb")).asJson

--- a/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
@@ -391,7 +391,11 @@ object TargetSettings {
   implicit val encoder: Encoder[TargetSettings] =
     Encoder.instance {
       case t: Scylla =>
-        Scylla.encoder.encodeObject(t).add("type", Json.fromString("scylla")).asJson
+        Scylla.encoder
+          .encodeObject(t)
+          .filter { case (_, v) => !v.isNull }
+          .add("type", Json.fromString("scylla"))
+          .asJson
 
       case t: DynamoDB =>
         deriveEncoder[DynamoDB]

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaSparkConnectionOptions.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaSparkConnectionOptions.scala
@@ -23,11 +23,22 @@ object ScyllaSparkConnectionOptions {
     *
     * These settings intentionally exclude table-selection properties so that credentials and SSL
     * secrets do not need to be passed through DataFrame reader options.
+    *
+    * '''Cloud mode is not supported''' through this helper — cloud targets use
+    * [[Connectors.buildTargetConf]] which directly constructs a `CloudBasedContactInfo`.
+    *
+    * @throws IllegalArgumentException
+    *   if `t.cloud` is defined
     */
   def sessionConfFromTargetSettings(
     t: TargetSettings.Scylla,
     cluster: String = MySQLValidatorCluster
   ): Map[String, String] = {
+    require(
+      t.cloud.isEmpty,
+      "ScyllaSparkConnectionOptions does not support cloud targets; " +
+        "use Connectors.buildTargetConf instead."
+    )
     val sessionConf =
       Connectors.sparkSessionOptions(Connectors.targetSessionOptions(t)) +
         (InputConsistencyLevel -> t.consistencyLevel)

--- a/tests/src/test/scala/com/scylladb/migrator/ConnectorsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/ConnectorsTest.scala
@@ -128,6 +128,28 @@ class ConnectorsTest extends munit.FunSuite {
   }
 
   // ---------------------------------------------------------------------------
+  // ipContactInfo: IPv6 bracket stripping
+  // ---------------------------------------------------------------------------
+
+  test("source: bracketed IPv6 host has brackets stripped for InetSocketAddress") {
+    val source = baseCassandraSource.copy(
+      host  = "[2001:db8::1]",
+      port  = 9042,
+      cloud = None
+    )
+
+    val conf = Connectors.buildSourceConf(new SparkConf(false), source)
+
+    conf.contactInfo match {
+      case ip: IpBasedContactInfo =>
+        val one = ip.hosts.head
+        assert(!one.getHostString.contains("["), s"brackets not stripped: ${one.getHostString}")
+        assertEquals(one.getPort, 9042)
+      case other => fail(s"Expected IpBasedContactInfo, got $other")
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // cloudContactInfo: path normalization
   // ---------------------------------------------------------------------------
 

--- a/tests/src/test/scala/com/scylladb/migrator/ConnectorsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/ConnectorsTest.scala
@@ -29,7 +29,7 @@ class ConnectorsTest extends munit.FunSuite {
 
     conf.contactInfo match {
       case CloudBasedContactInfo(path, PasswordAuthConf(u, p)) =>
-        assertEquals(path, "/opt/bundle.zip")
+        assertEquals(path, "file:/opt/bundle.zip")
         assertEquals(u, "client-id")
         assertEquals(p, "client-secret")
       case other =>
@@ -50,7 +50,7 @@ class ConnectorsTest extends munit.FunSuite {
 
     conf.contactInfo match {
       case CloudBasedContactInfo(path, NoAuthConf) =>
-        assertEquals(path, "/opt/bundle.zip")
+        assertEquals(path, "file:/opt/bundle.zip")
       case other =>
         fail(s"Expected CloudBasedContactInfo with NoAuthConf, got $other")
     }
@@ -99,7 +99,7 @@ class ConnectorsTest extends munit.FunSuite {
 
     conf.contactInfo match {
       case CloudBasedContactInfo(path, PasswordAuthConf(u, p)) =>
-        assertEquals(path, "/opt/bundle.zip")
+        assertEquals(path, "file:/opt/bundle.zip")
         assertEquals(u, "u")
         assertEquals(p, "p")
       case other => fail(s"Expected CloudBasedContactInfo, got $other")
@@ -125,6 +125,58 @@ class ConnectorsTest extends munit.FunSuite {
       case other => fail(s"Expected IpBasedContactInfo, got $other")
     }
     assertEquals(conf.localDC, Some("dc1"))
+  }
+
+  // ---------------------------------------------------------------------------
+  // cloudContactInfo: path normalization
+  // ---------------------------------------------------------------------------
+
+  test("cloudContactInfo: absolute path is normalized to file: URL via File.toURI") {
+    val info = Connectors.cloudContactInfo(CloudConfig("/opt/bundle.zip"), NoAuthConf)
+    info match {
+      case CloudBasedContactInfo(path, _) =>
+        assertEquals(path, "file:/opt/bundle.zip")
+      case other => fail(s"Expected CloudBasedContactInfo, got $other")
+    }
+  }
+
+  test("cloudContactInfo: absolute path with spaces is percent-encoded") {
+    val info = Connectors.cloudContactInfo(CloudConfig("/opt/my bundle.zip"), NoAuthConf)
+    info match {
+      case CloudBasedContactInfo(path, _) =>
+        assertEquals(path, "file:/opt/my%20bundle.zip")
+      case other => fail(s"Expected CloudBasedContactInfo, got $other")
+    }
+  }
+
+  test("cloudContactInfo: https:// URL is passed through unchanged") {
+    val url = "https://storage.example.com/bundle.zip"
+    val info = Connectors.cloudContactInfo(CloudConfig(url), NoAuthConf)
+    info match {
+      case CloudBasedContactInfo(path, _) =>
+        assertEquals(path, url)
+      case other => fail(s"Expected CloudBasedContactInfo, got $other")
+    }
+  }
+
+  test("cloudContactInfo: s3:// URL is passed through unchanged") {
+    val url = "s3://my-bucket/bundle.zip"
+    val info = Connectors.cloudContactInfo(CloudConfig(url), NoAuthConf)
+    info match {
+      case CloudBasedContactInfo(path, _) =>
+        assertEquals(path, url)
+      case other => fail(s"Expected CloudBasedContactInfo, got $other")
+    }
+  }
+
+  test("cloudContactInfo: bare filename (--files) is passed through unchanged") {
+    val filename = "secure-connect-prod.zip"
+    val info = Connectors.cloudContactInfo(CloudConfig(filename), NoAuthConf)
+    info match {
+      case CloudBasedContactInfo(path, _) =>
+        assertEquals(path, filename)
+      case other => fail(s"Expected CloudBasedContactInfo, got $other")
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/tests/src/test/scala/com/scylladb/migrator/ConnectorsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/ConnectorsTest.scala
@@ -1,0 +1,167 @@
+package com.scylladb.migrator
+
+import com.datastax.spark.connector.cql.{
+  CloudBasedContactInfo,
+  IpBasedContactInfo,
+  NoAuthConf,
+  PasswordAuthConf
+}
+import com.scylladb.migrator.config.{ CloudConfig, Credentials, SourceSettings, TargetSettings }
+import org.apache.spark.SparkConf
+
+class ConnectorsTest extends munit.FunSuite {
+
+  // ---------------------------------------------------------------------------
+  // Source: cassandra
+  // ---------------------------------------------------------------------------
+
+  test("source: cloud bundle produces CloudBasedContactInfo with creds, no localDC") {
+    val source = baseCassandraSource.copy(
+      host        = "",
+      port        = 0,
+      localDC     = None, // already None; just being explicit
+      sslOptions  = None,
+      credentials = Some(Credentials("client-id", "client-secret")),
+      cloud       = Some(CloudConfig("/opt/bundle.zip"))
+    )
+
+    val conf = Connectors.buildSourceConf(new SparkConf(false), source)
+
+    conf.contactInfo match {
+      case CloudBasedContactInfo(path, PasswordAuthConf(u, p)) =>
+        assertEquals(path, "/opt/bundle.zip")
+        assertEquals(u, "client-id")
+        assertEquals(p, "client-secret")
+      case other =>
+        fail(s"Expected CloudBasedContactInfo, got $other")
+    }
+    assertEquals(conf.localDC, None)
+  }
+
+  test("source: cloud bundle without credentials uses NoAuthConf") {
+    val source = baseCassandraSource.copy(
+      host        = "",
+      port        = 0,
+      credentials = None,
+      cloud       = Some(CloudConfig("/opt/bundle.zip"))
+    )
+
+    val conf = Connectors.buildSourceConf(new SparkConf(false), source)
+
+    conf.contactInfo match {
+      case CloudBasedContactInfo(path, NoAuthConf) =>
+        assertEquals(path, "/opt/bundle.zip")
+      case other =>
+        fail(s"Expected CloudBasedContactInfo with NoAuthConf, got $other")
+    }
+  }
+
+  test("source: legacy host/port produces IpBasedContactInfo and preserves localDC") {
+    val source = baseCassandraSource.copy(
+      host        = "1.2.3.4",
+      port        = 9042,
+      localDC     = Some("dc1"),
+      cloud       = None,
+      credentials = Some(Credentials("u", "p"))
+    )
+
+    val conf = Connectors.buildSourceConf(new SparkConf(false), source)
+
+    conf.contactInfo match {
+      case ip: IpBasedContactInfo =>
+        val one = ip.hosts.head
+        assertEquals(one.getHostString, "1.2.3.4")
+        assertEquals(one.getPort, 9042)
+        ip.authConf match {
+          case PasswordAuthConf(u, p) =>
+            assertEquals(u, "u"); assertEquals(p, "p")
+          case other => fail(s"Expected PasswordAuthConf, got $other")
+        }
+      case other => fail(s"Expected IpBasedContactInfo, got $other")
+    }
+    assertEquals(conf.localDC, Some("dc1"))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Target: scylla
+  // ---------------------------------------------------------------------------
+
+  test("target: cloud bundle produces CloudBasedContactInfo, drops localDC") {
+    val target = baseScyllaTarget.copy(
+      host        = "",
+      port        = 0,
+      sslOptions  = None,
+      credentials = Some(Credentials("u", "p")),
+      cloud       = Some(CloudConfig("/opt/bundle.zip"))
+    )
+
+    val conf = Connectors.buildTargetConf(new SparkConf(false), target)
+
+    conf.contactInfo match {
+      case CloudBasedContactInfo(path, PasswordAuthConf(u, p)) =>
+        assertEquals(path, "/opt/bundle.zip")
+        assertEquals(u, "u")
+        assertEquals(p, "p")
+      case other => fail(s"Expected CloudBasedContactInfo, got $other")
+    }
+    assertEquals(conf.localDC, None)
+  }
+
+  test("target: legacy host/port produces IpBasedContactInfo") {
+    val target = baseScyllaTarget.copy(
+      host    = "5.6.7.8",
+      port    = 9042,
+      localDC = Some("dc1"),
+      cloud   = None
+    )
+
+    val conf = Connectors.buildTargetConf(new SparkConf(false), target)
+
+    conf.contactInfo match {
+      case ip: IpBasedContactInfo =>
+        val one = ip.hosts.head
+        assertEquals(one.getHostString, "5.6.7.8")
+        assertEquals(one.getPort, 9042)
+      case other => fail(s"Expected IpBasedContactInfo, got $other")
+    }
+    assertEquals(conf.localDC, Some("dc1"))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Fixtures
+  // ---------------------------------------------------------------------------
+
+  private val baseCassandraSource = SourceSettings.Cassandra(
+    host               = "host",
+    port               = 9042,
+    localDC            = None,
+    credentials        = None,
+    sslOptions         = None,
+    keyspace           = "ks",
+    table              = "tbl",
+    splitCount         = None,
+    connections        = None,
+    fetchSize          = 1000,
+    preserveTimestamps = false,
+    where              = None,
+    consistencyLevel   = "LOCAL_QUORUM",
+    cloud              = None
+  )
+
+  private val baseScyllaTarget = TargetSettings.Scylla(
+    host                          = "host",
+    port                          = 9042,
+    localDC                       = None,
+    credentials                   = None,
+    sslOptions                    = None,
+    keyspace                      = "ks",
+    table                         = "tbl",
+    connections                   = None,
+    stripTrailingZerosForDecimals = false,
+    writeTTLInS                   = None,
+    writeWritetimestampInuS       = None,
+    consistencyLevel              = "LOCAL_QUORUM",
+    dropNullPrimaryKeys           = None,
+    cloud                         = None
+  )
+}

--- a/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
@@ -138,8 +138,9 @@ object SparkUtils {
 
   private def remapForLocalExecution(config: MigratorConfig): MigratorConfig = {
     val newSource = config.source match {
-      case c: SourceSettings.Cassandra =>
+      case c: SourceSettings.Cassandra if c.cloud.isEmpty =>
         c.copy(host = "localhost", port = cqlHostPortMap.getOrElse(c.host, c.port))
+      case c: SourceSettings.Cassandra => c
       case d: SourceSettings.DynamoDB =>
         d.copy(endpoint = d.endpoint.map(remapEndpoint))
       case p: SourceSettings.Parquet =>
@@ -151,8 +152,9 @@ object SparkUtils {
         s.copy(endpoint = s.endpoint.map(remapEndpoint))
     }
     val newTarget = config.target match {
-      case s: TargetSettings.Scylla =>
+      case s: TargetSettings.Scylla if s.cloud.isEmpty =>
         s.copy(host = "localhost", port = cqlHostPortMap.getOrElse(s.host, s.port))
+      case s: TargetSettings.Scylla => s
       case d: TargetSettings.DynamoDB =>
         d.copy(endpoint = d.endpoint.map(remapEndpoint))
       case p: TargetSettings.Parquet =>

--- a/tests/src/test/scala/com/scylladb/migrator/config/CassandraCloudConfigTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/CassandraCloudConfigTest.scala
@@ -533,6 +533,36 @@ class CassandraCloudConfigTest extends munit.FunSuite {
     )
   }
 
+  test("target scylla: encoder filters null optional fields") {
+    import io.circe.syntax._
+    val target: TargetSettings = TargetSettings.Scylla(
+      host                          = "h",
+      port                          = 9042,
+      localDC                       = None,
+      credentials                   = None,
+      sslOptions                    = None,
+      keyspace                      = "ks",
+      table                         = "tbl",
+      connections                   = None,
+      stripTrailingZerosForDecimals = false,
+      writeTTLInS                   = None,
+      writeWritetimestampInuS       = None,
+      consistencyLevel              = "LOCAL_QUORUM",
+      dropNullPrimaryKeys           = None,
+      cloud                         = None
+    )
+    val json = target.asJson
+    val obj = json.asObject.get
+    assert(!obj.contains("localDC"), s"localDC should be absent: ${json.noSpaces}")
+    assert(!obj.contains("sslOptions"), s"sslOptions should be absent: ${json.noSpaces}")
+    assert(!obj.contains("writeTTLInS"), s"writeTTLInS should be absent: ${json.noSpaces}")
+    assert(
+      !obj.contains("dropNullPrimaryKeys"),
+      s"dropNullPrimaryKeys should be absent: ${json.noSpaces}"
+    )
+    assert(!obj.contains("connections"), s"connections should be absent: ${json.noSpaces}")
+  }
+
   test("target scylla: round-trip preserves cloud and omits host/port") {
     val original = TargetSettings.Scylla(
       host                          = "",

--- a/tests/src/test/scala/com/scylladb/migrator/config/CassandraCloudConfigTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/CassandraCloudConfigTest.scala
@@ -225,7 +225,7 @@ class CassandraCloudConfigTest extends munit.FunSuite {
     assertEquals(parsed.cloud.map(_.secureBundlePath), Some("/opt/bundle.zip"))
   }
 
-  test("source cassandra: cloud with relative secureBundlePath is rejected") {
+  test("source cassandra: cloud with bare filename (--files pattern) is accepted") {
     val config =
       """type: cassandra
         |cloud:
@@ -237,10 +237,83 @@ class CassandraCloudConfigTest extends munit.FunSuite {
         |fetchSize: 1000
         |""".stripMargin
 
+    val parsed = parseSourceCassandra(config)
+    assertEquals(parsed.cloud.map(_.secureBundlePath), Some("secure-connect.zip"))
+  }
+
+  test("source cassandra: cloud with relative path containing slash is rejected") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: some/path/bundle.zip
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
     val ex = intercept[DecodingFailure](parseSourceCassandra(config))
     assert(
-      ex.getMessage.contains("absolute local path"),
+      ex.getMessage.contains("absolute local path") || ex.getMessage.contains("bare filename"),
       s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("source cassandra: cloud with https:// secureBundlePath is accepted") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: https://storage.example.com/secure-connect.zip
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val parsed = parseSourceCassandra(config)
+    assertEquals(
+      parsed.cloud.map(_.secureBundlePath),
+      Some("https://storage.example.com/secure-connect.zip")
+    )
+  }
+
+  test("source cassandra: cloud with s3:// secureBundlePath is accepted") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: s3://my-bucket/bundles/secure-connect.zip
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val parsed = parseSourceCassandra(config)
+    assertEquals(
+      parsed.cloud.map(_.secureBundlePath),
+      Some("s3://my-bucket/bundles/secure-connect.zip")
+    )
+  }
+
+  test("source cassandra: cloud with file:// secureBundlePath is accepted") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: file:/opt/migrator/secure-connect.zip
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val parsed = parseSourceCassandra(config)
+    assertEquals(
+      parsed.cloud.map(_.secureBundlePath),
+      Some("file:/opt/migrator/secure-connect.zip")
     )
   }
 

--- a/tests/src/test/scala/com/scylladb/migrator/config/CassandraCloudConfigTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/CassandraCloudConfigTest.scala
@@ -1,0 +1,516 @@
+package com.scylladb.migrator.config
+
+import io.circe.{ yaml, DecodingFailure }
+import io.circe.syntax._
+
+class CassandraCloudConfigTest extends munit.FunSuite {
+
+  // ---------------------------------------------------------------------------
+  // Source: cassandra
+  // ---------------------------------------------------------------------------
+
+  test("source cassandra: parses with cloud bundle, no host/port") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: /opt/migrator/secure-connect-mycluster.zip
+        |credentials:
+        |  username: client-id
+        |  password: client-secret
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val parsed = parseSourceCassandra(config)
+    assertEquals(
+      parsed.cloud.map(_.secureBundlePath),
+      Some("/opt/migrator/secure-connect-mycluster.zip")
+    )
+    assertEquals(parsed.host, "")
+    assertEquals(parsed.port, 0)
+    assertEquals(parsed.credentials.map(_.username), Some("client-id"))
+    assertEquals(parsed.localDC, None)
+    assertEquals(parsed.sslOptions, None)
+  }
+
+  test("source cassandra: rejects cloud + host (mutual exclusion)") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: /opt/bundle.zip
+        |host: some-host
+        |port: 9042
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseSourceCassandra(config))
+    assert(
+      ex.getMessage.contains("mutually exclusive"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("source cassandra: rejects neither cloud nor host") {
+    val config =
+      """type: cassandra
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseSourceCassandra(config))
+    assert(
+      ex.getMessage.contains("required"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("source cassandra: rejects host without port") {
+    val config =
+      """type: cassandra
+        |host: 127.0.0.1
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseSourceCassandra(config))
+    assert(
+      ex.getMessage.contains("host") && ex.getMessage.contains("port"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("source cassandra: rejects port without host") {
+    val config =
+      """type: cassandra
+        |port: 9042
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseSourceCassandra(config))
+    assert(
+      ex.getMessage.contains("host") && ex.getMessage.contains("port"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("source cassandra: rejects cloud + sslOptions") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: /opt/bundle.zip
+        |sslOptions:
+        |  clientAuthEnabled: false
+        |  enabled: true
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseSourceCassandra(config))
+    assert(
+      ex.getMessage.contains("sslOptions"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("source cassandra: rejects cloud + localDC") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: /opt/bundle.zip
+        |localDC: dc1
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseSourceCassandra(config))
+    assert(
+      ex.getMessage.contains("localDC"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("source cassandra: cloud with host:null (YAML implicit null) is accepted") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: /opt/bundle.zip
+        |host: null
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val parsed = parseSourceCassandra(config)
+    assertEquals(parsed.cloud.map(_.secureBundlePath), Some("/opt/bundle.zip"))
+    assertEquals(parsed.host, "")
+    assertEquals(parsed.port, 0)
+  }
+
+  test("source cassandra: cloud with empty secureBundlePath is rejected") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: ""
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseSourceCassandra(config))
+    assert(
+      ex.getMessage.contains("secureBundlePath must not be empty"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("source cassandra: cloud with whitespace-only secureBundlePath is rejected") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: "  "
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseSourceCassandra(config))
+    assert(
+      ex.getMessage.contains("secureBundlePath must not be empty"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("source cassandra: cloud secureBundlePath is trimmed before storing") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: " /opt/bundle.zip "
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val parsed = parseSourceCassandra(config)
+    assertEquals(parsed.cloud.map(_.secureBundlePath), Some("/opt/bundle.zip"))
+  }
+
+  test("source cassandra: cloud with relative secureBundlePath is rejected") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: secure-connect.zip
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseSourceCassandra(config))
+    assert(
+      ex.getMessage.contains("absolute local path"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("source cassandra: cloud with plain HTTP secureBundlePath is rejected") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: http://example.com/secure-connect.zip
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseSourceCassandra(config))
+    assert(
+      ex.getMessage.contains("plain HTTP"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("source cassandra: cloud with URL user-info is rejected") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: https://user:pass@example.com/secure-connect.zip
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseSourceCassandra(config))
+    assert(
+      ex.getMessage.contains("user-info"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("source cassandra: cloud with URL query string is rejected") {
+    val config =
+      """type: cassandra
+        |cloud:
+        |  secureBundlePath: https://example.com/secure-connect.zip?token=secret
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseSourceCassandra(config))
+    assert(
+      ex.getMessage.contains("query string"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("source cassandra: legacy host/port still parses") {
+    val config =
+      """type: cassandra
+        |host: 127.0.0.1
+        |port: 9042
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |preserveTimestamps: true
+        |fetchSize: 1000
+        |""".stripMargin
+
+    val parsed = parseSourceCassandra(config)
+    assertEquals(parsed.cloud, None)
+    assertEquals(parsed.host, "127.0.0.1")
+    assertEquals(parsed.port, 9042)
+  }
+
+  test("source cassandra: round-trip preserves cloud and omits host/port") {
+    val original = SourceSettings.Cassandra(
+      host               = "",
+      port               = 0,
+      localDC            = None,
+      credentials        = Some(Credentials("client-id", "client-secret")),
+      sslOptions         = None,
+      keyspace           = "ks",
+      table              = "tbl",
+      splitCount         = Some(256),
+      connections        = Some(8),
+      fetchSize          = 1000,
+      preserveTimestamps = true,
+      where              = None,
+      consistencyLevel   = "LOCAL_QUORUM",
+      cloud              = Some(CloudConfig("/opt/bundle.zip"))
+    )
+
+    val rendered = (original: SourceSettings).asJson.noSpaces
+    assert(!rendered.contains("\"host\""), s"unexpected host in: $rendered")
+    assert(!rendered.contains("\"port\""), s"unexpected port in: $rendered")
+    assert(rendered.contains("\"cloud\""))
+
+    val roundTrip = io.circe.parser
+      .parse(rendered)
+      .flatMap(_.as[SourceSettings])
+      .toOption
+      .collect { case c: SourceSettings.Cassandra => c }
+
+    assertEquals(roundTrip, Some(original))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Target: scylla
+  // ---------------------------------------------------------------------------
+
+  test("target scylla: parses with cloud bundle") {
+    val config =
+      """type: scylla
+        |cloud:
+        |  secureBundlePath: /opt/bundle.zip
+        |credentials:
+        |  username: u
+        |  password: p
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |stripTrailingZerosForDecimals: false
+        |""".stripMargin
+
+    val parsed = parseTargetScylla(config)
+    assertEquals(parsed.cloud.map(_.secureBundlePath), Some("/opt/bundle.zip"))
+    assertEquals(parsed.host, "")
+    assertEquals(parsed.port, 0)
+  }
+
+  test("target scylla: cloud with host:null is accepted") {
+    val config =
+      """type: scylla
+        |cloud:
+        |  secureBundlePath: /opt/bundle.zip
+        |host: null
+        |credentials:
+        |  username: u
+        |  password: p
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |stripTrailingZerosForDecimals: false
+        |""".stripMargin
+
+    val parsed = parseTargetScylla(config)
+    assertEquals(parsed.cloud.map(_.secureBundlePath), Some("/opt/bundle.zip"))
+    assertEquals(parsed.host, "")
+    assertEquals(parsed.port, 0)
+  }
+
+  test("target scylla: rejects cloud + host") {
+    val config =
+      """type: scylla
+        |cloud:
+        |  secureBundlePath: /opt/bundle.zip
+        |host: scylla
+        |port: 9042
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |stripTrailingZerosForDecimals: false
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseTargetScylla(config))
+    assert(ex.getMessage.contains("mutually exclusive"))
+  }
+
+  test("target scylla: rejects neither cloud nor host") {
+    val config =
+      """type: scylla
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |stripTrailingZerosForDecimals: false
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseTargetScylla(config))
+    assert(ex.getMessage.contains("required"))
+  }
+
+  test("target scylla: rejects host without port") {
+    val config =
+      """type: scylla
+        |host: scylla
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |stripTrailingZerosForDecimals: false
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseTargetScylla(config))
+    assert(
+      ex.getMessage.contains("host") && ex.getMessage.contains("port"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("target scylla: rejects port without host") {
+    val config =
+      """type: scylla
+        |port: 9042
+        |keyspace: ks
+        |table: tbl
+        |consistencyLevel: LOCAL_QUORUM
+        |stripTrailingZerosForDecimals: false
+        |""".stripMargin
+
+    val ex = intercept[DecodingFailure](parseTargetScylla(config))
+    assert(
+      ex.getMessage.contains("host") && ex.getMessage.contains("port"),
+      s"unexpected error: ${ex.getMessage}"
+    )
+  }
+
+  test("target scylla: round-trip preserves cloud and omits host/port") {
+    val original = TargetSettings.Scylla(
+      host                          = "",
+      port                          = 0,
+      localDC                       = None,
+      credentials                   = Some(Credentials("u", "p")),
+      sslOptions                    = None,
+      keyspace                      = "ks",
+      table                         = "tbl",
+      connections                   = Some(16),
+      stripTrailingZerosForDecimals = false,
+      writeTTLInS                   = None,
+      writeWritetimestampInuS       = None,
+      consistencyLevel              = "LOCAL_QUORUM",
+      dropNullPrimaryKeys           = None,
+      cloud                         = Some(CloudConfig("/opt/bundle.zip"))
+    )
+
+    val rendered = (original: TargetSettings).asJson.noSpaces
+    assert(!rendered.contains("\"host\""), s"unexpected host in: $rendered")
+    assert(!rendered.contains("\"port\""), s"unexpected port in: $rendered")
+    assert(rendered.contains("\"cloud\""))
+
+    val roundTrip = io.circe.parser
+      .parse(rendered)
+      .flatMap(_.as[TargetSettings])
+      .toOption
+      .collect { case s: TargetSettings.Scylla => s }
+
+    assertEquals(roundTrip, Some(original))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private def parseSourceCassandra(yamlContent: String): SourceSettings.Cassandra =
+    yaml.parser
+      .parse(yamlContent)
+      .flatMap(_.as[SourceSettings]) match {
+      case Left(error)                        => throw error
+      case Right(c: SourceSettings.Cassandra) => c
+      case Right(other)                       => fail(s"Expected Cassandra, got $other")
+    }
+
+  private def parseTargetScylla(yamlContent: String): TargetSettings.Scylla =
+    yaml.parser
+      .parse(yamlContent)
+      .flatMap(_.as[TargetSettings]) match {
+      case Left(error)                     => throw error
+      case Right(s: TargetSettings.Scylla) => s
+      case Right(other)                    => fail(s"Expected Scylla, got $other")
+    }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaSparkConnectionOptionsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ScyllaSparkConnectionOptionsTest.scala
@@ -2,7 +2,7 @@ package com.scylladb.migrator.scylla
 
 import com.datastax.spark.connector.datasource.CassandraSourceUtil
 import com.scylladb.migrator.Connectors
-import com.scylladb.migrator.config.{ Credentials, SSLOptions, TargetSettings }
+import com.scylladb.migrator.config.{ CloudConfig, Credentials, SSLOptions, TargetSettings }
 import org.apache.spark.SparkConf
 
 class ScyllaSparkConnectionOptionsTest extends munit.FunSuite {
@@ -163,6 +163,17 @@ class ScyllaSparkConnectionOptionsTest extends munit.FunSuite {
     assertEquals(consolidated.get("spark.cassandra.connection.host"), "scylla-host")
     assertEquals(consolidated.get("spark.cassandra.connection.port"), "9042")
     assertEquals(consolidated.get("spark.cassandra.query.retry.count"), "-1")
+  }
+
+  test("cloud target is rejected with IllegalArgumentException") {
+    val cloudTarget = baseTarget.copy(
+      host  = "",
+      port  = 0,
+      cloud = Some(CloudConfig("/opt/bundle.zip"))
+    )
+    intercept[IllegalArgumentException] {
+      ScyllaSparkConnectionOptions.sessionConfFromTargetSettings(cloudTarget)
+    }
   }
 
   test("helper reuses the production target connector session defaults") {


### PR DESCRIPTION
This PR is to address the issue https://github.com/scylladb/scylla-migrator/issues/98

Root cause:
Connectors.sourceConnector in migrator/src/main/scala/com/scylladb/migrator/Connectors.scala lines 16-49 always uses contactInfo with IpBasedContactInfo (forcing ip-based mode) which works for Cassandra, while Astra requires to use the CloudBasedContactInfo with the passed-in SCB.

Solution:
Add an optional cloud block to SourceSettings.Cassandra and TargetSettings.Scylla, then branch on it in Connectors:

- cloud.secureBundlePath: String (local path or dbfs: / s3a: / classpath via spark.files).
- In Connectors.{source,target}Connector, when cloud is set, build CloudBasedContactInfo(path, authConf) from the connector lib and skip the host/port/sslOptions branches.
- Document executor distribution: bundle must be reachable from every executor; recommend --conf spark.files=secure-connect.zip and resolving via SparkFiles.get on the driver before passing to CloudBasedContactInfo.
- Update config.yaml.example with an Astra example and add a docs page.

Added the related test cases and updated the documentation and sample correspondingly.