### PR TITLE
Harden secret handling and endpoint validation

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/AwsUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/AwsUtils.scala
@@ -84,6 +84,8 @@ object AwsUtils {
 
 /** Bare AWS credentials */
 case class AWSCredentials(accessKey: String, secretKey: String, maybeSessionToken: Option[String]) {
+  override def toString: String =
+    s"AWSCredentials(<redacted>, <redacted>, ${maybeSessionToken.map(_ => "<redacted>")})"
 
   /** Convenient method to use our credentials with the AWS SDK */
   def toProvider: AwsCredentialsProvider = {

--- a/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/DynamoUtils.scala
@@ -7,6 +7,7 @@ import com.scylladb.migrator.config.{
   AlternatorSettings,
   DynamoDBEndpoint,
   SourceSettings,
+  SparkSecretRedaction,
   TargetSettings
 }
 import org.apache.hadoop.conf.{ Configurable, Configuration }
@@ -500,7 +501,8 @@ object DynamoUtils {
     maybeMaxMapTasks: Option[Int],
     maybeAwsCredentials: Option[AWSCredentials],
     removeConsumedCapacity: Boolean = false,
-    alternatorSettings: Option[AlternatorSettings] = None
+    alternatorSettings: Option[AlternatorSettings] = None,
+    redactionRegex: Option[String] = None
   ): Unit = {
     for (region <- maybeRegion) {
       log.info(s"Using AWS region: ${region}")
@@ -513,6 +515,18 @@ object DynamoUtils {
     setOptionalConf(jobConf, DynamoDBConstants.SCAN_SEGMENTS, maybeScanSegments.map(_.toString))
     setOptionalConf(jobConf, DynamoDBConstants.MAX_MAP_TASKS, maybeMaxMapTasks.map(_.toString))
     for (credentials <- maybeAwsCredentials) {
+      val credentialKeys = Seq(
+        DynamoDBConstants.DYNAMODB_ACCESS_KEY_CONF,
+        DynamoDBConstants.DYNAMODB_SECRET_KEY_CONF
+      ) ++ credentials.maybeSessionToken
+        .map(_ => DynamoDBConstants.DYNAMODB_SESSION_TOKEN_CONF)
+        .toSeq
+
+      SparkSecretRedaction.ensureKeysRedacted(
+        redactionRegex,
+        credentialKeys,
+        "DynamoDB Hadoop job configuration"
+      )
       jobConf.set(DynamoDBConstants.DYNAMODB_ACCESS_KEY_CONF, credentials.accessKey)
       jobConf.set(DynamoDBConstants.DYNAMODB_SECRET_KEY_CONF, credentials.secretKey)
       for (sessionToken <- credentials.maybeSessionToken)

--- a/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
@@ -5,14 +5,19 @@ import com.scylladb.migrator.config._
 import com.scylladb.migrator.scylla.ScyllaMigrator
 import org.apache.logging.log4j.{ Level, LogManager }
 import org.apache.logging.log4j.core.config.Configurator
+import org.apache.spark.SparkConf
 import org.apache.spark.sql._
 
 object Migrator {
   val log = LogManager.getLogger("com.scylladb.migrator")
 
   def main(args: Array[String]): Unit = {
+    val sparkConf = new SparkConf()
+    SparkSecretRedaction.ensureMigratorRedactionRegex(sparkConf)
+
     implicit val spark: SparkSession = SparkSession
       .builder()
+      .config(sparkConf)
       .appName("scylla-migrator")
       .config("spark.task.maxFailures", "1024")
       .config("spark.stage.maxConsecutiveAttempts", "60")

--- a/migrator/src/main/scala/com/scylladb/migrator/Validator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Validator.scala
@@ -1,10 +1,16 @@
 package com.scylladb.migrator
 
 import com.scylladb.migrator.alternator.AlternatorValidator
-import com.scylladb.migrator.config.{ MigratorConfig, SourceSettings, TargetSettings }
+import com.scylladb.migrator.config.{
+  MigratorConfig,
+  SourceSettings,
+  SparkSecretRedaction,
+  TargetSettings
+}
 import com.scylladb.migrator.validation.RowComparisonFailure
 import org.apache.logging.log4j.{ Level, LogManager }
 import org.apache.logging.log4j.core.config.Configurator
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 import com.scylladb.migrator.scylla.{ MySQLToScyllaValidator, ScyllaValidator }
 
@@ -32,8 +38,12 @@ object Validator {
     }
 
   def main(args: Array[String]): Unit = {
+    val sparkConf = new SparkConf()
+    SparkSecretRedaction.ensureMigratorRedactionRegex(sparkConf)
+
     implicit val spark = SparkSession
       .builder()
+      .config(sparkConf)
       .appName("scylla-validator")
       .config("spark.task.maxFailures", "1024")
       .config("spark.stage.maxConsecutiveAttempts", "60")

--- a/migrator/src/main/scala/com/scylladb/migrator/config/AWSCredentials.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/AWSCredentials.scala
@@ -4,7 +4,8 @@ import io.circe.{ Decoder, Encoder }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 
 case class AWSCredentials(accessKey: String, secretKey: String, assumeRole: Option[AWSAssumeRole]) {
-  override def toString: String = s"AWSCredentials(${accessKey.take(3)}..., <redacted>)"
+  override def toString: String =
+    s"AWSCredentials(<redacted>, <redacted>, ${assumeRole.map(_ => "<configured>")})"
 }
 object AWSCredentials {
   implicit val decoder: Decoder[AWSCredentials] = deriveDecoder

--- a/migrator/src/main/scala/com/scylladb/migrator/config/Credentials.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/Credentials.scala
@@ -3,7 +3,9 @@ package com.scylladb.migrator.config
 import io.circe.{ Decoder, Encoder }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 
-case class Credentials(username: String, password: String)
+case class Credentials(username: String, password: String) {
+  override def toString: String = s"Credentials($username,<redacted>)"
+}
 object Credentials {
   implicit val encoder: Encoder[Credentials] = deriveEncoder[Credentials]
   implicit val decoder: Decoder[Credentials] = deriveDecoder[Credentials]

--- a/migrator/src/main/scala/com/scylladb/migrator/config/HostValidation.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/HostValidation.scala
@@ -5,6 +5,7 @@ package com.scylladb.migrator.config
   * avoid duplication.
   */
 object HostValidation {
+  private val UrlMetaCharacters = Set('/', '?', '#', '&', '@')
 
   /** Matches a hostname or IPv4 address: alphanumeric segments separated by dots or hyphens. Must
     * start with an alphanumeric character to avoid matching dot-only or hyphen-only strings.
@@ -47,4 +48,91 @@ object HostValidation {
       case _: Exception => false
     }
   }
+
+  def validatePort(label: String, port: Int): List[String] =
+    if (port < 1 || port > 65535)
+      List(s"$label port must be between 1 and 65535, got: $port")
+    else Nil
+
+  def validateHostOrIp(label: String, host: String): List[String] = {
+    val trimmed = host.trim
+    if (trimmed.isEmpty)
+      List(s"$label host must not be empty")
+    else if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      val inner = trimmed.slice(1, trimmed.length - 1)
+      if (!inner.contains(':'))
+        List(s"$label IPv4 addresses must not be wrapped in brackets. Use '$inner' instead.")
+      else if (isValidIPv6Host(trimmed)) Nil
+      else List(invalidHostMessage(label, trimmed))
+    } else if (isValidHostname(trimmed) || isValidIPv6Host(trimmed)) Nil
+    else List(invalidHostMessage(label, trimmed))
+  }
+
+  def validateEndpoint(label: String, host: String, port: Int): List[String] =
+    validateEndpointHost(label, host) ++ validatePort(label, port)
+
+  def renderEndpointHost(host: String): String = {
+    val trimmed = host.trim.stripSuffix("/")
+    splitHttpScheme(trimmed) match {
+      case Some((scheme, authority)) => s"$scheme${bracketBareIPv6(authority)}"
+      case None                      => s"http://${bracketBareIPv6(trimmed)}"
+    }
+  }
+
+  private def splitHttpScheme(host: String): Option[(String, String)] = {
+    val lower = host.toLowerCase(java.util.Locale.ROOT)
+    if (lower.startsWith("http://"))
+      Some(host.take("http://".length) -> host.drop("http://".length))
+    else if (lower.startsWith("https://"))
+      Some(host.take("https://".length) -> host.drop("https://".length))
+    else None
+  }
+
+  private def bracketBareIPv6(host: String): String =
+    if (host.contains(':') && !host.startsWith("[") && isValidIPv6Host(host)) s"[$host]"
+    else host
+
+  private def validateEndpointHost(label: String, host: String): List[String] = {
+    val trimmed = host.trim
+    if (trimmed.isEmpty)
+      return List(s"$label endpoint host must not be empty")
+
+    val (authority, hadScheme) = splitHttpScheme(trimmed) match {
+      case Some((_, remainder)) => remainder.stripSuffix("/") -> true
+      case None                 => trimmed.stripSuffix("/")   -> false
+    }
+
+    if (
+      authority.isEmpty ||
+      authority.exists(UrlMetaCharacters.contains)
+    )
+      return List(
+        s"$label endpoint host must be a bare hostname/IP, or an http(s) URL without userinfo, path, query, or fragment"
+      )
+
+    if (authority.startsWith("[") && authority.endsWith("]")) {
+      if (isValidIPv6Host(authority)) Nil
+      else List(invalidEndpointHostMessage(label, host))
+    } else if (authority.contains(':')) {
+      if (!hadScheme && isValidIPv6Host(authority)) Nil
+      else
+        List(
+          s"$label endpoint host must not include a port because 'port' is configured separately"
+        )
+    } else if (isValidHostname(authority)) Nil
+    else List(invalidEndpointHostMessage(label, host))
+  }
+
+  private def invalidHostMessage(label: String, host: String): String = {
+    val rejectedHost =
+      if (host.exists(UrlMetaCharacters.contains)) ""
+      else s" '$host'"
+
+    s"Invalid $label host$rejectedHost: must be a hostname, IPv4, or IPv6 address. " +
+      "URL metacharacters (/, ?, #, &, @) are not allowed."
+  }
+
+  private def invalidEndpointHostMessage(label: String, host: String): String =
+    s"Invalid $label endpoint host '$host': must be a hostname, IPv4, or IPv6 address, " +
+      "optionally prefixed with http:// or https://. URL metacharacters (/, ?, #, &, @) are not allowed."
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
@@ -22,6 +22,7 @@ case class MigratorConfig(
 ) {
   def render: String = this.asJson.asYaml.spaces2
   def renderRedacted: String = MigratorConfig.redactSecrets(this.asJson).asYaml.spaces2
+  override def toString: String = renderRedacted
 
   def getRenamesOrNil: List[Rename] = renames.getOrElse(Nil)
 
@@ -125,12 +126,9 @@ object MigratorConfig {
       )
     }
 
-  private def isMySQLSourceObject(obj: JsonObject): Boolean =
-    obj("type").flatMap(_.asString).contains("mysql")
-
-  private def shouldRedactValue(key: String, value: Json, obj: JsonObject): Boolean =
+  private def shouldRedactValue(key: String, value: Json): Boolean =
     value.isString && (SensitiveKeys
-      .isSensitiveKey(key) || (key == "where" && isMySQLSourceObject(obj)))
+      .isSensitiveKey(key) || key == "where")
 
   private[config] def redactSecrets(json: Json): Json =
     json.arrayOrObject(
@@ -140,7 +138,7 @@ object MigratorConfig {
         Json.fromJsonObject(
           obj.toIterable.foldLeft(JsonObject.empty) { case (acc, (key, value)) =>
             val updatedValue =
-              if (shouldRedactValue(key, value, obj))
+              if (shouldRedactValue(key, value))
                 Json.fromString(RedactedValue)
               else
                 redactSecrets(value)

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SSLOptions.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SSLOptions.scala
@@ -14,7 +14,20 @@ case class SSLOptions(
   trustStorePassword: Option[String],
   trustStorePath: Option[String],
   trustStoreType: Option[String]
-)
+) {
+  override def toString: String =
+    "SSLOptions(" +
+      s"$clientAuthEnabled," +
+      s"$enabled," +
+      s"$enabledAlgorithms," +
+      s"${keyStorePassword.map(_ => "<redacted>")}," +
+      s"$keyStorePath," +
+      s"$keyStoreType," +
+      s"$protocol," +
+      s"${trustStorePassword.map(_ => "<redacted>")}," +
+      s"$trustStorePath," +
+      s"$trustStoreType)"
+}
 
 object SSLOptions {
   implicit val encoder: Encoder[SSLOptions] = deriveEncoder[SSLOptions]

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
@@ -30,20 +30,20 @@ import scala.util.Try
   */
 case class DynamoDBEndpoint(host: String, port: Int) {
   def renderEndpoint: String = {
-    val trimmedHost = host.stripSuffix("/")
-    val lowerHost = trimmedHost.toLowerCase(java.util.Locale.ROOT)
-    val endpointHost =
-      if (lowerHost.startsWith("http://") || lowerHost.startsWith("https://"))
-        trimmedHost
-      else
-        s"http://${trimmedHost}"
+    val errors = HostValidation.validateEndpoint("DynamoDB", host, port)
+    require(errors.isEmpty, errors.mkString("; "))
+    val endpointHost = HostValidation.renderEndpointHost(host)
     s"${endpointHost}:${port}"
   }
 }
 
 object DynamoDBEndpoint {
   implicit val encoder: Encoder[DynamoDBEndpoint] = deriveEncoder[DynamoDBEndpoint]
-  implicit val decoder: Decoder[DynamoDBEndpoint] = deriveDecoder[DynamoDBEndpoint]
+  implicit val decoder: Decoder[DynamoDBEndpoint] =
+    deriveDecoder[DynamoDBEndpoint].emap { endpoint =>
+      val errors = HostValidation.validateEndpoint("DynamoDB", endpoint.host, endpoint.port)
+      Either.cond(errors.isEmpty, endpoint, errors.mkString("; "))
+    }
 }
 
 sealed trait SourceSettings
@@ -443,10 +443,24 @@ object SourceSettings {
     errors.result()
   }
 
+  private def validateCassandraSource(s: Cassandra): List[String] =
+    HostValidation.validateHostOrIp("Cassandra source", s.host) ++
+      HostValidation.validatePort("Cassandra source", s.port)
+
   implicit val decoder: Decoder[SourceSettings] = Decoder.instance { cursor =>
     cursor.get[String]("type").flatMap {
       case "cassandra" | "scylla" =>
-        deriveDecoder[Cassandra].apply(cursor)
+        deriveDecoder[Cassandra].apply(cursor).flatMap { c =>
+          val allErrors = validateCassandraSource(c)
+          if (allErrors.nonEmpty)
+            Left(
+              DecodingFailure(
+                s"Source type 'cassandra': ${allErrors.mkString("; ")}",
+                cursor.history
+              )
+            )
+          else Right(c)
+        }
       case "parquet" =>
         deriveDecoder[Parquet].apply(cursor)
       case "dynamo" | "dynamodb" =>

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SparkSecretRedaction.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SparkSecretRedaction.scala
@@ -1,0 +1,98 @@
+package com.scylladb.migrator.config
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+
+import java.util.regex.Pattern
+import scala.util.Try
+
+object SparkSecretRedaction {
+  val RedactionRegexConfKey: String = "spark.redaction.regex"
+  private[config] val SparkDefaultRedactionRegex: String =
+    "(?i)secret|password|token|access[.]?key"
+
+  private def configuredRedactionRegex(regex: Option[String]): Option[String] =
+    regex.map(_.trim).filter(_.nonEmpty)
+
+  def ensureMigratorRedactionRegex(sparkConf: SparkConf): Unit =
+    if (configuredRedactionRegex(sparkConf.getOption(RedactionRegexConfKey)).isEmpty)
+      sparkConf.set(RedactionRegexConfKey, SensitiveKeys.DefaultRedactionRegex)
+
+  private def installMigratorRedactionRegex(sparkConf: SparkConf): String = {
+    sparkConf.set(RedactionRegexConfKey, SensitiveKeys.DefaultRedactionRegex)
+    SensitiveKeys.DefaultRedactionRegex
+  }
+
+  private def sparkContextRedactionRegex(spark: SparkSession): Option[String] =
+    configuredRedactionRegex(spark.sparkContext.getConf.getOption(RedactionRegexConfKey))
+
+  private def sparkSessionRedactionRegex(spark: SparkSession): Option[String] =
+    configuredRedactionRegex(spark.conf.getAll.get(RedactionRegexConfKey))
+
+  def redactionRegex(spark: SparkSession): Option[String] = {
+    val sparkConfRegex = sparkContextRedactionRegex(spark)
+    val sessionRegex = sparkSessionRedactionRegex(spark)
+
+    sparkConfRegex
+      .orElse {
+        sessionRegex.filter(_ == SparkDefaultRedactionRegex)
+      }
+      .orElse {
+        sessionRegex.foreach { regex =>
+          throw new IllegalStateException(
+            s"$RedactionRegexConfKey must be configured on SparkConf before SparkSession creation; " +
+              s"runtime SparkSession value '$regex' is not verified for Spark and Hadoop redaction"
+          )
+        }
+        Some(SparkDefaultRedactionRegex)
+      }
+  }
+
+  def redactionRegex(sparkConf: SparkConf): Option[String] =
+    Some(
+      configuredRedactionRegex(sparkConf.getOption(RedactionRegexConfKey))
+        .getOrElse(installMigratorRedactionRegex(sparkConf))
+    )
+
+  def sensitiveKeys(keys: Iterable[String]): Seq[String] =
+    keys.toSeq.distinct.filter(SensitiveKeys.isSensitiveKey)
+
+  def redactionRegexCoversKeys(
+    regex: String,
+    keys: Seq[String]
+  ): Boolean =
+    Try(Pattern.compile(regex)).toOption.exists { pattern =>
+      keys.forall(key => pattern.matcher(key).find())
+    }
+
+  def ensureKeysRedacted(
+    redactionRegex: Option[String],
+    optionKeys: Iterable[String],
+    context: String
+  ): Unit = {
+    val keys = sensitiveKeys(optionKeys)
+    if (keys.nonEmpty) {
+      val regex = redactionRegex
+        .getOrElse(SensitiveKeys.DefaultRedactionRegex)
+
+      require(
+        redactionRegexCoversKeys(regex, keys),
+        s"Refusing to create $context because $RedactionRegexConfKey does not redact all sensitive option keys: ${keys.mkString(", ")}"
+      )
+    }
+  }
+
+  def ensureKeysRedacted(
+    spark: SparkSession,
+    optionKeys: Iterable[String],
+    context: String
+  ): Unit =
+    ensureKeysRedacted(redactionRegex(spark), optionKeys, context)
+
+  def ensureKeysRedacted(
+    sparkConf: SparkConf,
+    optionKeys: Iterable[String],
+    context: String
+  ): Unit =
+    ensureKeysRedacted(redactionRegex(sparkConf), optionKeys, context)
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/TargetSettings.scala
@@ -110,11 +110,25 @@ object TargetSettings {
     errors.result()
   }
 
+  private def validateScyllaTarget(t: Scylla): List[String] =
+    HostValidation.validateHostOrIp("Scylla target", t.host) ++
+      HostValidation.validatePort("Scylla target", t.port)
+
   implicit val decoder: Decoder[TargetSettings] =
     Decoder.instance { cursor =>
       cursor.get[String]("type").flatMap {
         case "scylla" | "cassandra" =>
-          deriveDecoder[Scylla].apply(cursor)
+          deriveDecoder[Scylla].apply(cursor).flatMap { s =>
+            val allErrors = validateScyllaTarget(s)
+            if (allErrors.nonEmpty)
+              Left(
+                DecodingFailure(
+                  s"Target type 'scylla': ${allErrors.mkString("; ")}",
+                  cursor.history
+                )
+              )
+            else Right(s)
+          }
         case "dynamodb" | "dynamo" =>
           AlternatorSettings.guardDynamoDBType(cursor, "Target").flatMap { _ =>
             deriveDecoder[DynamoDB].apply(cursor).flatMap { d =>

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/DynamoDB.scala
@@ -2,7 +2,12 @@ package com.scylladb.migrator.readers
 
 import com.scylladb.migrator.{ AWSCredentials, DynamoUtils }
 import com.scylladb.migrator.DynamoUtils.{ setDynamoDBJobConf, setOptionalConf }
-import com.scylladb.migrator.config.{ AlternatorSettings, DynamoDBEndpoint, SourceSettings }
+import com.scylladb.migrator.config.{
+  AlternatorSettings,
+  DynamoDBEndpoint,
+  SourceSettings,
+  SparkSecretRedaction
+}
 import org.apache.hadoop.dynamodb.read.DynamoDBInputFormat
 import org.apache.hadoop.dynamodb.{ DynamoDBConstants, DynamoDBItemWritable }
 import org.apache.hadoop.io.Text
@@ -145,7 +150,8 @@ object DynamoDB {
       maxMapTasks,
       credentials,
       removeConsumedCapacity,
-      alternatorSettings
+      alternatorSettings,
+      SparkSecretRedaction.redactionRegex(spark)
     )
     jobConf.set(DynamoDBConstants.INPUT_TABLE_NAME, table)
     setOptionalConf(jobConf, DynamoDBConstants.ITEM_COUNT, maybeItemCount.map(_.toString))

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/MySQL.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/MySQL.scala
@@ -1,6 +1,11 @@
 package com.scylladb.migrator.readers
 
-import com.scylladb.migrator.config.{ HostValidation, SensitiveKeys, SourceSettings }
+import com.scylladb.migrator.config.{
+  HostValidation,
+  SensitiveKeys,
+  SourceSettings,
+  SparkSecretRedaction
+}
 import com.scylladb.migrator.scylla.SourceDataFrame
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{
@@ -68,29 +73,15 @@ object MySQL {
   private[readers] def redactionRegexCoversKeys(
     regex: String,
     keys: Seq[String]
-  ): Boolean = {
-    val pattern = regex.r.pattern
-    keys.forall(key => pattern.matcher(key).find())
-  }
+  ): Boolean =
+    SparkSecretRedaction.redactionRegexCoversKeys(regex, keys)
 
   private[readers] def ensureSensitiveReaderOptionsAreRedacted(
     spark: SparkSession,
     optionKeys: Seq[String],
     context: String
-  ): Unit = {
-    val sensitiveKeys = optionKeys.distinct.filter(isSensitiveOptionKey)
-    if (sensitiveKeys.nonEmpty) {
-      val redactionRegex = spark.conf
-        .getOption("spark.redaction.regex")
-        .filter(_.trim.nonEmpty)
-        .getOrElse(DefaultSensitiveRedactionRegex)
-
-      require(
-        redactionRegexCoversKeys(redactionRegex, sensitiveKeys),
-        s"Refusing to create $context because spark.redaction.regex does not redact all sensitive option keys: ${sensitiveKeys.mkString(", ")}"
-      )
-    }
-  }
+  ): Unit =
+    SparkSecretRedaction.ensureKeysRedacted(spark, optionKeys, context)
 
   private def normalizedPartitionColumnName(column: String): String =
     if (column.startsWith("`") && column.endsWith("`"))

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
@@ -1,6 +1,11 @@
 package com.scylladb.migrator.readers
 
-import com.scylladb.migrator.config.{ MigratorConfig, SourceSettings, TargetSettings }
+import com.scylladb.migrator.config.{
+  MigratorConfig,
+  SourceSettings,
+  SparkSecretRedaction,
+  TargetSettings
+}
 import com.scylladb.migrator.scylla.{ ScyllaMigrator, ScyllaParquetMigrator, SourceDataFrame }
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.sql.{ AnalysisException, SparkSession }
@@ -92,6 +97,9 @@ object Parquet {
 
         ScyllaParquetMigrator.migrate(config, target, sourceDF, savepointsManager)
 
+        // Listener events can trail the completed Spark action; a successful write means every
+        // selected file was consumed, so make the final savepoint deterministic.
+        filesToProcess.foreach(savepointsManager.markFileAsProcessed)
         savepointsManager.dumpMigrationState("completed")
 
         log.info(
@@ -161,12 +169,26 @@ object Parquet {
     source: SourceSettings.Parquet
   ): Unit =
     source.finalCredentials.foreach { credentials =>
+      val credentialOptions =
+        Seq(
+          "fs.s3a.access.key" -> credentials.accessKey,
+          "fs.s3a.secret.key" -> credentials.secretKey
+        ) ++ credentials.maybeSessionToken.toSeq.map { sessionToken =>
+          "fs.s3a.session.token" -> sessionToken
+        }
+
+      SparkSecretRedaction.ensureKeysRedacted(
+        spark,
+        credentialOptions.map(_._1),
+        "Parquet S3A Hadoop configuration"
+      )
       log.info("Loaded AWS credentials from config file")
       source.region.foreach { region =>
         spark.sparkContext.hadoopConfiguration.set("fs.s3a.endpoint.region", region)
       }
-      spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", credentials.accessKey)
-      spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", credentials.secretKey)
+      credentialOptions.foreach { case (key, value) =>
+        spark.sparkContext.hadoopConfiguration.set(key, value)
+      }
       credentials.maybeSessionToken.foreach { sessionToken =>
         spark.sparkContext.hadoopConfiguration.set(
           "fs.s3a.aws.credentials.provider",

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/DynamoDB.scala
@@ -2,7 +2,7 @@ package com.scylladb.migrator.writers
 
 import com.scylladb.migrator.DynamoUtils
 import com.scylladb.migrator.DynamoUtils.{ setDynamoDBJobConf, setOptionalConf }
-import com.scylladb.migrator.config.TargetSettings
+import com.scylladb.migrator.config.{ SparkSecretRedaction, TargetSettings }
 import org.apache.hadoop.dynamodb.{ DynamoDBConstants, DynamoDBItemWritable }
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapred.JobConf
@@ -93,7 +93,8 @@ object DynamoDB {
       maybeMaxMapTasks  = None,
       target.finalCredentials,
       target.removeConsumedCapacity,
-      target.alternatorSettings
+      target.alternatorSettings,
+      SparkSecretRedaction.redactionRegex(spark)
     )
     jobConf.set(DynamoDBConstants.OUTPUT_TABLE_NAME, target.table)
     val writeThroughput =

--- a/tests/src/test/scala/com/scylladb/migrator/ValidatorLoggingTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/ValidatorLoggingTest.scala
@@ -1,14 +1,79 @@
 package com.scylladb.migrator
 
 import com.scylladb.migrator.config.{
+  AWSCredentials => ConfigAWSCredentials,
+  AlternatorSettings,
   Credentials,
+  DynamoDBEndpoint,
   MigratorConfig,
+  SSLOptions,
   Savepoints,
   SourceSettings,
   TargetSettings
 }
 
 class ValidatorLoggingTest extends munit.FunSuite {
+  private val syntheticTargetPassword = "TEST_ONLY_TARGET_PASSWORD"
+  private val syntheticTruststorePassword = "TEST_ONLY_TRUSTSTORE_PASSWORD"
+
+  private val syntheticCassandraToScyllaConfig = MigratorConfig(
+    source = SourceSettings.Cassandra(
+      host               = "source.cassandra.test.invalid",
+      port               = 9042,
+      localDC            = None,
+      credentials        = None,
+      sslOptions         = None,
+      keyspace           = "keyspace1",
+      table              = "standard1",
+      splitCount         = Some(96),
+      connections        = Some(16),
+      fetchSize          = 1000,
+      preserveTimestamps = true,
+      where              = None,
+      consistencyLevel   = "QUORUM"
+    ),
+    target = TargetSettings.Scylla(
+      host        = "target.scylla.test.invalid",
+      port        = 19142,
+      localDC     = None,
+      credentials = Some(Credentials("scylla", syntheticTargetPassword)),
+      sslOptions = Some(
+        SSLOptions(
+          clientAuthEnabled  = false,
+          enabled            = true,
+          enabledAlgorithms  = None,
+          keyStorePassword   = None,
+          keyStorePath       = None,
+          keyStoreType       = None,
+          protocol           = None,
+          trustStorePassword = Some(syntheticTruststorePassword),
+          trustStorePath     = Some("truststore.jks"),
+          trustStoreType     = None
+        )
+      ),
+      keyspace                      = "keyspace1",
+      table                         = "standard1",
+      connections                   = Some(16),
+      stripTrailingZerosForDecimals = false,
+      writeTTLInS                   = None,
+      writeWritetimestampInuS       = None,
+      consistencyLevel              = "QUORUM"
+    ),
+    renames          = Some(List()),
+    savepoints       = Savepoints(300, "gs://example-redaction-fixture/savepoints"),
+    skipTokenRanges  = Some(Set()),
+    skipSegments     = None,
+    skipParquetFiles = None,
+    validation       = None
+  )
+
+  private def assertSecretsAbsent(rendered: String, secrets: Seq[String]): Unit =
+    secrets.zipWithIndex.foreach { case (secret, index) =>
+      assert(
+        !rendered.contains(secret),
+        s"rendered config must not contain secret at index $index"
+      )
+    }
 
   test("loadedConfigLogMessage redacts source and target secrets") {
     val config = MigratorConfig(
@@ -57,5 +122,228 @@ class ValidatorLoggingTest extends munit.FunSuite {
     assert(!logMessage.contains("scylla-secret"))
     assert(!logMessage.contains("tls-secret"))
     assert(!logMessage.contains("user@example.com"))
+  }
+
+  test("loadedConfigLogMessage covers reported Cassandra to Scylla credential leak") {
+    val logMessage = Validator.loadedConfigLogMessage(syntheticCassandraToScyllaConfig)
+
+    assert(logMessage.startsWith("Loaded config:\n"))
+    assert(logMessage.contains("<redacted>"))
+    assertSecretsAbsent(logMessage, Seq(syntheticTargetPassword, syntheticTruststorePassword))
+  }
+
+  test("MigratorConfig toString is redacted as a fallback for accidental case-class logging") {
+    val rendered = syntheticCassandraToScyllaConfig.toString
+
+    assert(rendered.contains("<redacted>"))
+    assertSecretsAbsent(rendered, Seq(syntheticTargetPassword, syntheticTruststorePassword))
+  }
+
+  test("renderRedacted redacts secrets for every source and target type") {
+    val s3ExportDescription = SourceSettings.DynamoDBS3Export.TableDescription(
+      attributeDefinitions = Seq(
+        SourceSettings.DynamoDBS3Export.AttributeDefinition(
+          "id",
+          SourceSettings.DynamoDBS3Export.AttributeType.S
+        )
+      ),
+      keySchema = Seq(
+        SourceSettings.DynamoDBS3Export.KeySchema(
+          "id",
+          SourceSettings.DynamoDBS3Export.KeyType.Hash
+        )
+      )
+    )
+
+    val configsAndSecrets = Seq(
+      syntheticCassandraToScyllaConfig -> Seq(syntheticTargetPassword, syntheticTruststorePassword),
+      MigratorConfig(
+        source = SourceSettings.Cassandra(
+          host        = "cassandra",
+          port        = 9042,
+          localDC     = Some("dc1"),
+          credentials = Some(Credentials("src-user", "SRC_CQL_PASS_123")),
+          sslOptions = Some(
+            SSLOptions(
+              clientAuthEnabled  = true,
+              enabled            = true,
+              enabledAlgorithms  = None,
+              keyStorePassword   = Some("SRC_CQL_KEYSTORE_PASS_123"),
+              keyStorePath       = Some("source-keystore.jks"),
+              keyStoreType       = None,
+              protocol           = None,
+              trustStorePassword = Some("SRC_CQL_TRUSTSTORE_PASS_123"),
+              trustStorePath     = Some("source-truststore.jks"),
+              trustStoreType     = None
+            )
+          ),
+          keyspace           = "ks",
+          table              = "tbl",
+          splitCount         = Some(16),
+          connections        = Some(4),
+          fetchSize          = 1000,
+          preserveTimestamps = false,
+          where              = Some("email = 'cql-user@example.com'"),
+          consistencyLevel   = "LOCAL_QUORUM"
+        ),
+        target = TargetSettings.Scylla(
+          host        = "scylla",
+          port        = 9042,
+          localDC     = Some("dc1"),
+          credentials = Some(Credentials("target-user", "TGT_SCYLLA_PASS_123")),
+          sslOptions = Some(
+            SSLOptions(
+              clientAuthEnabled  = false,
+              enabled            = true,
+              enabledAlgorithms  = None,
+              keyStorePassword   = Some("TGT_SCYLLA_KEYSTORE_PASS_123"),
+              keyStorePath       = Some("target-keystore.jks"),
+              keyStoreType       = None,
+              protocol           = None,
+              trustStorePassword = Some("TGT_SCYLLA_TRUSTSTORE_PASS_123"),
+              trustStorePath     = Some("target-truststore.jks"),
+              trustStoreType     = None
+            )
+          ),
+          keyspace                      = "ks",
+          table                         = "tbl",
+          connections                   = Some(4),
+          stripTrailingZerosForDecimals = false,
+          writeTTLInS                   = None,
+          writeWritetimestampInuS       = None,
+          consistencyLevel              = "LOCAL_QUORUM"
+        ),
+        renames          = None,
+        savepoints       = Savepoints(300, "/tmp/savepoints"),
+        skipTokenRanges  = None,
+        skipSegments     = None,
+        skipParquetFiles = None,
+        validation       = None
+      ) -> Seq(
+        "SRC_CQL_PASS_123",
+        "SRC_CQL_KEYSTORE_PASS_123",
+        "SRC_CQL_TRUSTSTORE_PASS_123",
+        "TGT_SCYLLA_PASS_123",
+        "TGT_SCYLLA_KEYSTORE_PASS_123",
+        "TGT_SCYLLA_TRUSTSTORE_PASS_123",
+        "cql-user@example.com"
+      ),
+      MigratorConfig(
+        source = SourceSettings.Parquet(
+          path = "s3a://bucket/path",
+          credentials =
+            Some(ConfigAWSCredentials("PARQUET_ACCESS_123", "PARQUET_SECRET_123", None)),
+          endpoint = Some(DynamoDBEndpoint("s3", 9000)),
+          region   = Some("us-east-1")
+        ),
+        target           = TargetSettings.Parquet(path = "s3a://target/path"),
+        renames          = None,
+        savepoints       = Savepoints(300, "/tmp/savepoints"),
+        skipTokenRanges  = None,
+        skipSegments     = None,
+        skipParquetFiles = None,
+        validation       = None
+      ) -> Seq("PARQUET_ACCESS_123", "PARQUET_SECRET_123"),
+      MigratorConfig(
+        source = SourceSettings.DynamoDB(
+          endpoint = Some(DynamoDBEndpoint("dynamodb", 8000)),
+          region   = Some("us-east-1"),
+          credentials =
+            Some(ConfigAWSCredentials("DDB_SRC_ACCESS_123", "DDB_SRC_SECRET_123", None)),
+          table                 = "src",
+          scanSegments          = Some(4),
+          readThroughput        = Some(100),
+          throughputReadPercent = Some(0.5f),
+          maxMapTasks           = Some(4)
+        ),
+        target = TargetSettings.DynamoDB(
+          endpoint = Some(DynamoDBEndpoint("dynamodb-target", 8000)),
+          region   = Some("us-east-1"),
+          credentials =
+            Some(ConfigAWSCredentials("DDB_TGT_ACCESS_123", "DDB_TGT_SECRET_123", None)),
+          table                       = "dst",
+          writeThroughput             = Some(100),
+          throughputWritePercent      = Some(0.5f),
+          streamChanges               = false,
+          skipInitialSnapshotTransfer = None
+        ),
+        renames          = None,
+        savepoints       = Savepoints(300, "/tmp/savepoints"),
+        skipTokenRanges  = None,
+        skipSegments     = None,
+        skipParquetFiles = None,
+        validation       = None
+      ) -> Seq(
+        "DDB_SRC_ACCESS_123",
+        "DDB_SRC_SECRET_123",
+        "DDB_TGT_ACCESS_123",
+        "DDB_TGT_SECRET_123"
+      ),
+      MigratorConfig(
+        source = SourceSettings.Alternator(
+          alternatorEndpoint = DynamoDBEndpoint("http://alternator-source", 8000),
+          region             = Some("us-east-1"),
+          credentials =
+            Some(ConfigAWSCredentials("ALT_SRC_ACCESS_123", "ALT_SRC_SECRET_123", None)),
+          table                  = "src",
+          scanSegments           = Some(4),
+          readThroughput         = Some(100),
+          throughputReadPercent  = Some(0.5f),
+          maxMapTasks            = Some(4),
+          removeConsumedCapacity = true,
+          alternatorConfig       = AlternatorSettings(datacenter = Some("dc1"))
+        ),
+        target = TargetSettings.Alternator(
+          alternatorEndpoint = DynamoDBEndpoint("http://alternator-target", 8000),
+          region             = Some("us-east-1"),
+          credentials =
+            Some(ConfigAWSCredentials("ALT_TGT_ACCESS_123", "ALT_TGT_SECRET_123", None)),
+          table                       = "dst",
+          writeThroughput             = Some(100),
+          throughputWritePercent      = Some(0.5f),
+          streamChanges               = false,
+          skipInitialSnapshotTransfer = None,
+          removeConsumedCapacity      = true,
+          billingMode                 = None,
+          alternatorConfig            = AlternatorSettings(datacenter = Some("dc1"))
+        ),
+        renames          = None,
+        savepoints       = Savepoints(300, "/tmp/savepoints"),
+        skipTokenRanges  = None,
+        skipSegments     = None,
+        skipParquetFiles = None,
+        validation       = None
+      ) -> Seq(
+        "ALT_SRC_ACCESS_123",
+        "ALT_SRC_SECRET_123",
+        "ALT_TGT_ACCESS_123",
+        "ALT_TGT_SECRET_123"
+      ),
+      MigratorConfig(
+        source = SourceSettings.DynamoDBS3Export(
+          bucket           = "bucket",
+          manifestKey      = "manifest.json",
+          tableDescription = s3ExportDescription,
+          endpoint         = Some(DynamoDBEndpoint("s3", 9000)),
+          region           = Some("us-east-1"),
+          credentials =
+            Some(ConfigAWSCredentials("S3EXPORT_SRC_ACCESS_123", "S3EXPORT_SRC_SECRET_123", None)),
+          usePathStyleAccess = Some(true)
+        ),
+        target           = TargetSettings.DynamoDBS3Export(path = "s3a://bucket/export"),
+        renames          = None,
+        savepoints       = Savepoints(300, "/tmp/savepoints"),
+        skipTokenRanges  = None,
+        skipSegments     = None,
+        skipParquetFiles = None,
+        validation       = None
+      ) -> Seq("S3EXPORT_SRC_ACCESS_123", "S3EXPORT_SRC_SECRET_123")
+    )
+
+    configsAndSecrets.foreach { case (config, secrets) =>
+      val rendered = config.renderRedacted
+      assert(rendered.contains("<redacted>"), "expected redaction marker in rendered config")
+      assertSecretsAbsent(rendered, secrets)
+    }
   }
 }

--- a/tests/src/test/scala/com/scylladb/migrator/config/SecurityHardeningTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/SecurityHardeningTest.scala
@@ -1,0 +1,177 @@
+package com.scylladb.migrator.config
+
+import io.circe.yaml
+import org.apache.spark.SparkConf
+
+class SecurityHardeningTest extends munit.FunSuite {
+
+  test("SparkSecretRedaction covers S3A and DynamoDB secret option keys by default") {
+    SparkSecretRedaction.ensureKeysRedacted(
+      None,
+      Seq(
+        "fs.s3a.access.key",
+        "fs.s3a.secret.key",
+        "fs.s3a.session.token",
+        "dynamodb.awsAccessKeyId",
+        "dynamodb.awsSecretAccessKey",
+        "dynamodb.awsSessionToken",
+        "fs.s3a.api.key",
+        "aws.credentials.file",
+        "spark.cassandra.auth.password",
+        "spark.cassandra.connection.ssl.trustStore.password"
+      ),
+      "test options"
+    )
+  }
+
+  test("SparkSecretRedaction rejects custom regex that misses sensitive option keys") {
+    intercept[IllegalArgumentException] {
+      SparkSecretRedaction.ensureKeysRedacted(
+        Some("(?i)token"),
+        Seq("fs.s3a.secret.key"),
+        "test options"
+      )
+    }
+  }
+
+  test(
+    "SparkSecretRedaction rejects local-only sensitive keys under explicit Spark default regex"
+  ) {
+    val error = intercept[IllegalArgumentException] {
+      SparkSecretRedaction.ensureKeysRedacted(
+        Some(SparkSecretRedaction.SparkDefaultRedactionRegex),
+        Seq("fs.s3a.api.key", "aws.credentials.file"),
+        "test options"
+      )
+    }
+
+    assert(error.getMessage.contains("fs.s3a.api.key"))
+    assert(error.getMessage.contains("aws.credentials.file"))
+  }
+
+  test("SparkSecretRedaction installs migrator regex into SparkConf before Spark starts") {
+    val sparkConf = new SparkConf(false)
+
+    SparkSecretRedaction.ensureKeysRedacted(
+      sparkConf,
+      Seq("fs.s3a.api.key", "aws.credentials.file"),
+      "test options"
+    )
+
+    assertEquals(
+      sparkConf.get(SparkSecretRedaction.RedactionRegexConfKey),
+      SensitiveKeys.DefaultRedactionRegex
+    )
+  }
+
+  test("SparkSecretRedaction keeps user-provided SparkConf regex") {
+    val sparkConf = new SparkConf(false)
+      .set(SparkSecretRedaction.RedactionRegexConfKey, "(?i)token")
+
+    intercept[IllegalArgumentException] {
+      SparkSecretRedaction.ensureKeysRedacted(
+        sparkConf,
+        Seq("fs.s3a.secret.key"),
+        "test options"
+      )
+    }
+
+    assertEquals(sparkConf.get(SparkSecretRedaction.RedactionRegexConfKey), "(?i)token")
+  }
+
+  test("Cassandra source host validation rejects URL metacharacters") {
+    val result = parseConfig(
+      """source:
+        |  type: cassandra
+        |  host: bad/host
+        |  port: 9042
+        |  keyspace: ks
+        |  table: tbl
+        |  splitCount: 16
+        |  connections: 4
+        |  fetchSize: 1000
+        |  preserveTimestamps: false
+        |  consistencyLevel: LOCAL_QUORUM
+        |target:
+        |  type: parquet
+        |  path: /tmp/out
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+    )
+
+    assert(result.isLeft, s"Expected invalid config, got: $result")
+    assert(result.left.exists(_.getMessage.contains("Source type 'cassandra'")))
+  }
+
+  test("Scylla target host validation rejects URL metacharacters") {
+    val result = parseConfig(
+      """source:
+        |  type: parquet
+        |  path: /tmp/in
+        |target:
+        |  type: scylla
+        |  host: bad?host
+        |  port: 9042
+        |  keyspace: ks
+        |  table: tbl
+        |  stripTrailingZerosForDecimals: false
+        |  consistencyLevel: LOCAL_QUORUM
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+    )
+
+    assert(result.isLeft, s"Expected invalid config, got: $result")
+    assert(result.left.exists(_.getMessage.contains("Target type 'scylla'")))
+  }
+
+  test("DynamoDB endpoint validation rejects URL paths and embedded ports") {
+    val withPath = parseConfig(
+      """source:
+        |  type: dynamodb
+        |  table: Src
+        |  endpoint:
+        |    host: http://dynamodb/private
+        |    port: 8000
+        |target:
+        |  type: dynamodb
+        |  table: Dest
+        |  streamChanges: false
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+    )
+    val withPort = parseConfig(
+      """source:
+        |  type: dynamodb
+        |  table: Src
+        |  endpoint:
+        |    host: http://dynamodb:8000
+        |    port: 8000
+        |target:
+        |  type: dynamodb
+        |  table: Dest
+        |  streamChanges: false
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+    )
+
+    assert(withPath.isLeft, s"Expected invalid endpoint path, got: $withPath")
+    assert(withPort.isLeft, s"Expected invalid embedded endpoint port, got: $withPort")
+  }
+
+  test("DynamoDB endpoint render safely wraps bare IPv6 hosts") {
+    val endpoint = DynamoDBEndpoint("2001:db8::1", 8000)
+
+    assertEquals(endpoint.renderEndpoint, "http://[2001:db8::1]:8000")
+  }
+
+  private def parseConfig(config: String): Either[io.circe.Error, MigratorConfig] =
+    yaml.parser.parse(config).flatMap(_.as[MigratorConfig])
+}

--- a/tests/src/test/scala/com/scylladb/migrator/readers/MySQLReaderTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/MySQLReaderTest.scala
@@ -1,18 +1,29 @@
 package com.scylladb.migrator.readers
 
-import com.scylladb.migrator.config.{ Credentials, HostValidation, SourceSettings }
+import com.scylladb.migrator.config.{
+  Credentials,
+  HostValidation,
+  SourceSettings,
+  SparkSecretRedaction
+}
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 
 import java.util.Locale
 
 class MySQLReaderTest extends munit.FunSuite {
 
-  private lazy val spark: SparkSession = SparkSession
-    .builder()
-    .master("local[1]")
-    .appName("MySQLReaderTest")
-    .config("spark.ui.enabled", "false")
-    .getOrCreate()
+  private lazy val spark: SparkSession = {
+    val sparkConf = new SparkConf(false)
+    SparkSecretRedaction.ensureMigratorRedactionRegex(sparkConf)
+    SparkSession
+      .builder()
+      .config(sparkConf)
+      .master("local[1]")
+      .appName("MySQLReaderTest")
+      .config("spark.ui.enabled", "false")
+      .getOrCreate()
+  }
 
   override def afterAll(): Unit = {
     spark.stop()


### PR DESCRIPTION
## Summary
Harden config handling around secrets and endpoint inputs.

Related issue: #358. This PR implements the security-focused reusable items from that proposal: secret-safe config logging, shared host/IP validation, and Spark option redaction guards.

## Security features brought in
- Redacted config rendering is now default for `MigratorConfig.toString` and loaded-config logging.
- Secret-bearing case classes hide passwords, AWS keys, session tokens, and SSL store passwords in `toString`.
- Spark redaction is installed before SparkSession creation for migrator and validator entrypoints.
- Runtime guard refuses to set sensitive Spark/Hadoop options unless `spark.redaction.regex` covers their keys.
- Shared host, endpoint, and port validation rejects empty hosts, URL metacharacters, embedded ports where `port` is configured separately, invalid bracketed IPv4, and unsafe DynamoDB endpoint paths/query/userinfo fragments.
- DynamoDB endpoint rendering safely brackets bare IPv6 addresses.
- Rendered config redacts `where` filters plus sensitive credential, TLS, and AWS values.
- Successful Parquet-to-Scylla runs finalize file-level savepoints deterministically after Spark listener events, fixing the failing Scylla integration check.

## Readers/Writers covered
- Cassandra/Scylla source and Scylla target: host and port validation, config/log redaction for credentials, SSL options, and `where`.
- MySQL reader: shared host validation, JDBC sensitive option-key redaction checks, and rendered config redaction for credentials, connection-property secrets, and `where`.
- Parquet reader: S3A AWS access key, secret key, and session token checked before writing Hadoop configuration.
- DynamoDB reader and Alternator reader path: AWS credential keys checked before Hadoop job config; endpoints use shared validation.
- DynamoDB writer and Alternator writer path: AWS credential keys checked before Hadoop job config; endpoints use shared validation.
- DynamoDB S3 export source/target: AWS credentials and endpoint values covered by config/log redaction and endpoint validation.

## Testing
- `sbt scalafmtCheckAll`
- `sbt "tests/testOnly com.scylladb.migrator.readers.FileCompletionListenerTest"`
- Previous compile and targeted/config tests passed.