### PR TITLE
Update Scylla Spark connector to 4.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val awsSdkVersion = "2.23.19"
 val sparkVersion = "4.0.2"
 val hadoopVersion = "3.4.1"
 val circeVersion = "0.14.7"
-val connectorVersion = "4.1.0"
+val connectorVersion = "4.1.1"
 val dynamodbStreamsKinesisAdapterVersion =
   "1.5.4" // Note This version still depends on AWS SDK 1.x, but there is no more recent version that supports AWS SDK v2.
 

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -128,7 +128,7 @@ object Scylla {
     *
     * We drop them from the DataFrame before writing so that both sides agree on the column count.
     */
-  // Mirrors the private TableWriter.InternalColumns from spark-scylladb-connector 4.1.0.
+  // Mirrors the private TableWriter.InternalColumns from spark-scylladb-connector 4.1.1.
   // If the connector version changes, verify this set is still in sync.
   private[writers] val InternalColumns: Set[String] = Set("solr_query")
 


### PR DESCRIPTION
## Summary
- Bump spark-scylladb-connector from 4.1.0 to 4.1.1
- Update the version-specific internal-column compatibility comment

## Verification
- repo-ci fast attempted locally; blocked because the learned build command invoked sbt with Java 8 while the project requires -release:17
- GitHub CI completed: formatting, build, unit tests, DynamoDB integration, DynamoDB tutorial migration, and Cassandra 5.x integration passed
- GitHub CI failed: Cassandra 2.x integration, Cassandra 3.x integration, and Scylla integration

## CI Notes
The failed jobs all hit connector scan-path runtime errors after the 4.1.1 bump. Cassandra 2.x/3.x fail with `ServerError: java.lang.IndexOutOfBoundsException` from `CassandraTableScanRDD`; Scylla fails with `Unexpected unset value for bind variable 1`. Connector 4.1.1 changed token-range scans to reuse a prepared statement across ranges in a Spark partition, while token ranges can produce different CQL bind counts.