### PR TITLE
Update Scylla Spark connector to 4.1.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val awsSdkVersion = "2.23.19"
 val sparkVersion = "4.0.2"
 val hadoopVersion = "3.4.1"
 val circeVersion = "0.14.7"
-val connectorVersion = "4.1.0"
+val connectorVersion = "4.1.2"
 val dynamodbStreamsKinesisAdapterVersion =
   "1.5.4" // Note This version still depends on AWS SDK 1.x, but there is no more recent version that supports AWS SDK v2.
 

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -128,7 +128,7 @@ object Scylla {
     *
     * We drop them from the DataFrame before writing so that both sides agree on the column count.
     */
-  // Mirrors the private TableWriter.InternalColumns from spark-scylladb-connector 4.1.0.
+  // Mirrors the private TableWriter.InternalColumns from spark-scylladb-connector 4.1.2.
   // If the connector version changes, verify this set is still in sync.
   private[writers] val InternalColumns: Set[String] = Set("solr_query")
 


### PR DESCRIPTION
## Summary

- Update `spark-scylladb-connector` from `4.1.0` to `4.1.2`.
- Update the local comment that tracks the connector `TableWriter.InternalColumns` implementation.

## Verification

- Confirmed `spark-scylladb-connector_2.13` `4.1.2` is published in Maven metadata.
- Confirmed `TableWriter.InternalColumns` is still `Set("solr_query")` in the `4.1.2` source jar.
- `repo-ci run --mode fast` could not complete locally because repo-ci invokes sbt with Java 8 while this build uses `-release:17`:
  - `welcome to sbt 1.9.9 (Amazon.com Inc. Java 1.8.0_452)`
  - `'17' is not a valid choice for '-release'`
  - `bad option: '-release:17'`
