### PR TITLE
Update Scylla Spark connector to 4.1.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val awsSdkVersion = "2.23.19"
 val sparkVersion = "4.0.2"
 val hadoopVersion = "3.4.1"
 val circeVersion = "0.14.7"
-val connectorVersion = "4.1.2"
+val connectorVersion = "4.1.3"
 val dynamodbStreamsKinesisAdapterVersion =
   "1.5.4" // Note This version still depends on AWS SDK 1.x, but there is no more recent version that supports AWS SDK v2.
 

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -128,7 +128,7 @@ object Scylla {
     *
     * We drop them from the DataFrame before writing so that both sides agree on the column count.
     */
-  // Mirrors the private TableWriter.InternalColumns from spark-scylladb-connector 4.1.2.
+  // Mirrors the private TableWriter.InternalColumns from spark-scylladb-connector 4.1.3.
   // If the connector version changes, verify this set is still in sync.
   private[writers] val InternalColumns: Set[String] = Set("solr_query")
 


### PR DESCRIPTION
### What changed
- Bumped `spark-scylladb-connector` from `4.1.2` to `4.1.3`.
- Updated the `Scylla.scala` comment so the mirrored internal-column note matches the new connector version.

### Why
- Pull in the latest ScyllaDB Spark connector release.
- The connector still treats `solr_query` as an internal column, so no behavior change is expected here.

### Validation
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH sbt 'tests/testOnly com.scylladb.migrator.writers.ScyllaInternalColumnsTest com.scylladb.migrator.scylla.ScyllaSparkConnectionOptionsTest'`