### PR TITLE
let source explicitly say whether durable resume is supported

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
@@ -45,7 +45,19 @@ object Migrator {
     * This is the programmatic entry point used by integration tests (in-process Spark) and by
     * `main` (spark-submit). The caller is responsible for creating and stopping the SparkSession.
     */
-  def migrate(config: MigratorConfig)(implicit spark: SparkSession): Unit =
+  def migrate(config: MigratorConfig)(implicit spark: SparkSession): Unit = {
+    // Backend-neutral warning. Any source whose `supportsSavepoints` is `false` (MySQL, DynamoDB
+    // S3 export, future non-resumable backends) gets the same up-front notice without per-source
+    // `case` branches. Source-specific reader caveats (e.g. MySQL JDBC partitioning semantics)
+    // are emitted from the reader itself.
+    if (!config.source.supportsSavepoints) {
+      log.warn(
+        "Source does not support savepoints; any configured savepoints settings are ignored. " +
+          "If this migration is interrupted, it must be restarted from scratch. " +
+          "Ensure the target table supports idempotent writes."
+      )
+    }
+
     (config.source, config.target) match {
       case (cqlSource: SourceSettings.Cassandra, scyllaTarget: TargetSettings.Scylla) =>
         val sourceDF = readers.Cassandra.readDataframe(
@@ -57,13 +69,6 @@ object Migrator {
         ScyllaMigrator.migrate(config, scyllaTarget, sourceDF)
       case (mysqlSource: SourceSettings.MySQL, scyllaTarget: TargetSettings.Scylla) =>
         log.info("Starting MySQL to ScyllaDB migration")
-        log.warn(
-          "MySQL source does not support savepoints; any configured savepoints settings are ignored. " +
-            "MySQL reads use Spark JDBC jobs that do not expose durable per-range progress, and " +
-            "partitioned reads use multiple independent JDBC statements instead of one resumable snapshot. " +
-            "If this migration is interrupted, it must be restarted from scratch. " +
-            "Ensure the target table supports idempotent writes."
-        )
         val sourceDF = readers.MySQL.readDataframe(spark, mysqlSource)
         ScyllaMigrator.migrate(config, scyllaTarget, sourceDF)
       case (parquetSource: SourceSettings.Parquet, scyllaTarget: TargetSettings.Scylla) =>
@@ -88,5 +93,6 @@ object Migrator {
             s"${source.getClass.getSimpleName} -> ${target.getClass.getSimpleName}"
         )
     }
+  }
 
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala
@@ -40,9 +40,9 @@ object AlternatorMigrator {
       sourceRDD,
       sourceTableDesc,
       maybeStreamedSource,
+      source,
       target,
-      migratorConfig,
-      hadoopPartitionedSource = true
+      migratorConfig
     )
   }
 
@@ -73,6 +73,10 @@ object AlternatorMigrator {
     target: TargetSettings.DynamoDBLike,
     migratorConfig: MigratorConfig
   )(implicit spark: SparkSession): Unit = {
+    log.info(
+      "S3 export source uses ParallelCollectionPartitions (not DynamoDBSplits); " +
+        "scan-segment savepoint tracking is not available for this path."
+    )
     val (sourceRDD, sourceTableDesc) = readers.DynamoDBS3Export.readRDD(source)(spark.sparkContext)
     // Adapt the decoded items to the format expected by the EMR Hadoop connector
     val normalizedRDD =
@@ -83,9 +87,9 @@ object AlternatorMigrator {
       normalizedRDD,
       sourceTableDesc,
       None,
+      source,
       target,
-      migratorConfig,
-      hadoopPartitionedSource = false
+      migratorConfig
     )
   }
 
@@ -95,15 +99,13 @@ object AlternatorMigrator {
     *   Description of the table to replicate on the target database
     * @param maybeStreamedSource
     *   Settings of the source table in case `streamChanges` was `true`
+    * @param source
+    *   The original `SourceSettings`. Used to consult `supportsSavepoints` so the RDD path follows
+    *   the same backend-neutral predicate as the DataFrame paths in `ScyllaMigrator`.
     * @param target
     *   Target table settings
     * @param migratorConfig
     *   The complete original configuration
-    * @param hadoopPartitionedSource
-    *   Whether the source RDD uses `HadoopPartition`s (from the DynamoDB Hadoop connector)
-    *   containing `DynamoDBSplit`s. When `true`, scan segment progress is tracked via
-    *   `DynamoDbSavepointsManager`. Must be `false` for source types whose RDDs use other partition
-    *   types (e.g., `ParallelCollectionPartition` from S3 exports).
     * @param spark
     *   Spark session
     */
@@ -111,9 +113,9 @@ object AlternatorMigrator {
     sourceRDD: RDD[(Text, DynamoDBItemWritable)],
     sourceTableDesc: TableDescription,
     maybeStreamedSource: Option[SourceSettings.DynamoDB],
+    source: SourceSettings,
     target: TargetSettings.DynamoDBLike,
-    migratorConfig: MigratorConfig,
-    hadoopPartitionedSource: Boolean
+    migratorConfig: MigratorConfig
   )(implicit spark: SparkSession): Unit = {
 
     log.info("We need to transfer: " + sourceRDD.getNumPartitions + " partitions in total")
@@ -136,7 +138,12 @@ object AlternatorMigrator {
       if (maybeStreamedSource.isDefined && target.skipInitialSnapshotTransfer.contains(true)) {
         log.info("Skip transferring table snapshot")
       } else {
-        if (hadoopPartitionedSource) {
+        // Backend-neutral gating: any `SourceSettings` subtype with `supportsSavepoints = true`
+        // (DynamoDB, Alternator) is wrapped in `DynamoDbSavepointsManager` to track scan-segment
+        // progress; sources with `supportsSavepoints = false` (DynamoDB S3 export, future
+        // non-resumable RDD sources) skip the manager and emit the generic "no savepoints"
+        // warning from `Migrator.migrate` instead of a per-source `log.warn` here.
+        if (source.supportsSavepoints) {
           Using.resource(
             DynamoDbSavepointsManager(migratorConfig, sourceRDD, spark.sparkContext)
           ) { _ =>
@@ -145,10 +152,6 @@ object AlternatorMigrator {
               .writeRDD(target, migratorConfig.renamesMap, sourceRDD, targetTableDesc)
           }
         } else {
-          log.warn(
-            "Savepoints are not supported when the source is a DynamoDB S3 export. " +
-              "If the migration is interrupted, it will reprocess all data on restart."
-          )
           log.info("Starting write...")
           writers.DynamoDB.writeRDD(target, migratorConfig.renamesMap, sourceRDD, targetTableDesc)
         }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
@@ -59,15 +59,16 @@ object MigratorConfig {
     Decoder.instance { cursor =>
       deriveConfiguredDecoder[MigratorConfig].apply(cursor).flatMap { decoded =>
         val savepointsProvided = cursor.downField("savepoints").success.isDefined
-        val savepointsRequired = decoded.source match {
-          case _: SourceSettings.MySQL => false
-          case _                       => true
-        }
+        // Backend-neutral: each `SourceSettings` subtype declares its own capability via
+        // `supportsSavepoints`. Adding a new non-resumable source does not require editing
+        // this decoder.
+        val savepointsRequired = decoded.source.supportsSavepoints
 
         if (!savepointsProvided && savepointsRequired)
           Left(
             DecodingFailure(
-              "Missing required field: savepoints. This field is optional only for MySQL migrations.",
+              "Missing required field: savepoints. This field is optional only for sources " +
+                "that do not support savepoints.",
               cursor.history
             )
           )
@@ -105,10 +106,12 @@ object MigratorConfig {
     }
   implicit val migratorConfigEncoder: Encoder[MigratorConfig] =
     Encoder.instance { migratorConfig =>
-      val savepointsField = migratorConfig.source match {
-        case _: SourceSettings.MySQL => Nil
-        case _                       => List("savepoints" -> migratorConfig.savepoints.asJson)
-      }
+      // Mirror of the decoder: sources that do not support savepoints omit the field on
+      // round-trip rather than emitting an unused block.
+      val savepointsField =
+        if (migratorConfig.source.supportsSavepoints)
+          List("savepoints" -> migratorConfig.savepoints.asJson)
+        else Nil
 
       Json.obj(
         (

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
@@ -46,7 +46,22 @@ object DynamoDBEndpoint {
     }
 }
 
-sealed trait SourceSettings
+sealed trait SourceSettings {
+
+  /** Whether this source supports durable resume via savepoints.
+    *
+    * Single source of truth consulted by:
+    *   - `MigratorConfig` decoder (whether the `savepoints` block is required) and encoder (whether
+    *     to emit it),
+    *   - `Migrator.migrate` (whether to log the generic "no durable resume" warning before
+    *     dispatch),
+    *   - `readers.MySQL` / `readers.Cassandra` (derive `SourceDataFrame.savepointsSupported`),
+    *   - `AlternatorMigrator.migrate` (whether to wrap the write in `DynamoDbSavepointsManager`).
+    *
+    * New non-resumable sources should override to `false`; no central code edit is required.
+    */
+  def supportsSavepoints: Boolean
+}
 object SourceSettings {
   case class Cassandra(
     host: String,
@@ -63,7 +78,9 @@ object SourceSettings {
     where: Option[String],
     consistencyLevel: String,
     cloud: Option[CloudConfig] = None
-  ) extends SourceSettings
+  ) extends SourceSettings {
+    val supportsSavepoints: Boolean = true
+  }
 
   /** When `cloud` is set, the connector will reach the cluster through the Astra SNI proxy
     * described by the secure-connect bundle. In that mode the `host` and `port` fields are
@@ -202,6 +219,10 @@ object SourceSettings {
     def alternatorSettings: Option[AlternatorSettings]
     lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
       AwsUtils.computeFinalCredentials(credentials, endpoint, region)
+
+    // Both AWS DynamoDB and Scylla Alternator readers track scan-segment progress via
+    // `DynamoDbSavepointsManager`, so the capability is shared by both subtypes.
+    val supportsSavepoints: Boolean = true
   }
 
   case class DynamoDB(
@@ -242,6 +263,11 @@ object SourceSettings {
   ) extends SourceSettings {
     lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
       AwsUtils.computeFinalCredentials(credentials, endpoint, region)
+
+    // File-level resume is available via `ParquetSavepointsManager`. The user-facing toggle
+    // `savepoints.enableParquetFileTracking` decides whether to use it for a given run, but the
+    // *capability* of the source is "supported".
+    val supportsSavepoints: Boolean = true
   }
 
   case class MySQL(
@@ -259,7 +285,14 @@ object SourceSettings {
     fetchSize: Int = MySQL.DefaultFetchSize,
     where: Option[String],
     connectionProperties: Option[Map[String, String]]
-  ) extends SourceSettings
+  ) extends SourceSettings {
+
+    // MySQL reads use Spark JDBC jobs that do not expose durable per-range progress, and
+    // partitioned reads use multiple independent JDBC statements/connections instead of one
+    // resumable snapshot. Hence: no savepoints. The MySQL reader emits the user-facing log
+    // describing this; the central code only consults this flag.
+    val supportsSavepoints: Boolean = false
+  }
 
   object MySQL {
     val DefaultFetchSize: Int = 1000
@@ -462,6 +495,12 @@ object SourceSettings {
   ) extends SourceSettings {
     lazy val finalCredentials: Option[com.scylladb.migrator.AWSCredentials] =
       AwsUtils.computeFinalCredentials(credentials, endpoint, region)
+
+    // S3 export RDDs use `ParallelCollectionPartition`s rather than the EMR Hadoop connector's
+    // `DynamoDBSplit`s, so per-segment savepoint progress is not tracked. The AlternatorMigrator
+    // consults this flag (instead of a separate `hadoopPartitionedSource` Boolean) to decide
+    // whether to construct `DynamoDbSavepointsManager`.
+    val supportsSavepoints: Boolean = false
   }
 
   object DynamoDBS3Export {

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -375,7 +375,7 @@ object Cassandra {
     val rawDataframe = spark.createDataFrame(rdd, selection.schema)
 
     if (skipExplosion) {
-      SourceDataFrame(rawDataframe, selection.timestampColumns, true)
+      SourceDataFrame(rawDataframe, selection.timestampColumns, source.supportsSavepoints)
     } else {
       val resultingDataframe = adjustDataframeForTimestampPreservation(
         spark,
@@ -384,7 +384,7 @@ object Cassandra {
         origSchema,
         tableDef
       )
-      SourceDataFrame(resultingDataframe, selection.timestampColumns, true)
+      SourceDataFrame(resultingDataframe, selection.timestampColumns, source.supportsSavepoints)
     }
   }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/MySQL.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/MySQL.scala
@@ -555,16 +555,35 @@ object MySQL {
       "quiesce or otherwise freeze the source table before starting the migration or validation."
 
   def readDataframe(spark: SparkSession, source: SourceSettings.MySQL): SourceDataFrame = {
+    // MySQL-specific caveat lives in the reader, not in the central dispatcher. The generic
+    // "no savepoints" warning is emitted by `Migrator.migrate` for any source whose
+    // `supportsSavepoints` is `false`; this log adds the JDBC-specific detail that operators
+    // expect when reading MySQL run logs.
+    log.info(
+      "MySQL reads use Spark JDBC jobs that do not expose durable per-range progress, and " +
+        "partitioned reads use multiple independent JDBC statements instead of one resumable " +
+        "snapshot."
+    )
     val df = readDataframeRaw(spark, source)
     MySQLSchemaLogger.logSchemaInfo(df)
     log.info(
       s"Number of partitions: ${df.queryExecution.executedPlan.execute().getNumPartitions}"
     )
-    sourceDataFrame(df)
+    sourceDataFrame(df, source)
   }
 
-  private[readers] def sourceDataFrame(df: DataFrame): SourceDataFrame =
-    SourceDataFrame(df, timestampColumns = None, savepointsSupported = false)
+  // Derive `savepointsSupported` from the setting so the two flags cannot drift. Today this is
+  // always `false` for MySQL; expressing it via `source.supportsSavepoints` keeps the runtime
+  // path consistent with the config-time predicate.
+  private[readers] def sourceDataFrame(
+    df: DataFrame,
+    source: SourceSettings.MySQL
+  ): SourceDataFrame =
+    SourceDataFrame(
+      df,
+      timestampColumns    = None,
+      savepointsSupported = source.supportsSavepoints
+    )
 
   private[readers] def buildJdbcUrl(
     source: SourceSettings.MySQL,

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
@@ -88,6 +88,12 @@ object Parquet {
           val renamed = TimestampColumns.renameFromParquet(df)
           val (explodedDf, timestampColumns) =
             Cassandra.explodeDataframeFromPerColumnMeta(spark, renamed)
+          // `savepointsSupported = false` is hardcoded here on purpose: although Parquet sources
+          // *do* support savepoints (`SourceSettings.Parquet.supportsSavepoints == true`), the
+          // resume mechanism is the external `ParquetSavepointsManager` injected via
+          // `ScyllaParquetMigrator.externalSavepointsManager`. Marking the DataFrame as
+          // unsupported tells `ScyllaMigratorBase.createSavepointsManager` not to spin up an
+          // internal CQL manager that would race with the external one.
           SourceDataFrame(explodedDf, Some(timestampColumns), savepointsSupported = false)
         } else {
           SourceDataFrame(df, None, savepointsSupported = false)

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/ParquetWithoutSavepoints.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/ParquetWithoutSavepoints.scala
@@ -16,6 +16,11 @@ object ParquetWithoutSavepoints {
     val df = spark.read.parquet(source.path)
     log.info(s"Loaded Parquet DataFrame with ${df.rdd.getNumPartitions} partitions")
 
+    // This path is selected by `savepoints.enableParquetFileTracking = false`. Even though
+    // `SourceSettings.Parquet.supportsSavepoints == true`, the user has explicitly opted out of
+    // file-level tracking for this run, so the DataFrame is marked unsupported to keep
+    // `ScyllaMigratorBase.createSavepointsManager` from spinning up a CQL manager that has no
+    // accumulator to consume Parquet progress.
     if (TimestampColumns.hasPerColumnMetaInParquet(df.schema)) {
       log.info(
         "Detected per-column CQL timestamp metadata in Parquet schema. " +

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/CqlSavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/CqlSavepointsManager.scala
@@ -1,9 +1,12 @@
 package com.scylladb.migrator.scylla
 
+import com.datastax.spark.connector.rdd.partitioner.{ CassandraPartition, CqlTokenRange }
 import com.datastax.spark.connector.rdd.partitioner.dht.Token
 import com.datastax.spark.connector.writer.TokenRangeAccumulator
 import com.scylladb.migrator.SavepointsManager
 import com.scylladb.migrator.config.MigratorConfig
+
+import scala.util.control.NonFatal
 
 /** Manage CQL-based migrations by tracking the migrated token ranges.
   */
@@ -17,6 +20,62 @@ class CqlSavepointsManager(migratorConfig: MigratorConfig, val accumulator: Toke
       skipTokenRanges =
         Some(migratorConfig.getSkipTokenRangesOrEmptySet ++ tokenRanges(accumulator))
     )
+
+  /** Log how many token ranges the source DataFrame covers and how many remain after subtracting
+    * the savepoint set. Previously emitted from `ScyllaMigratorBase.migrate` gated by
+    * `isInstanceOf[SourceSettings.Cassandra]`; moved here so the central `migrate` method is
+    * backend-neutral and the Cassandra-specific `CassandraPartition` cast lives next to the only
+    * manager that knows how to consume it.
+    *
+    * Defensive: if a future caller wires in a non-Cassandra DataFrame by mistake, the cast would
+    * `ClassCastException`. Swallow that and log a warning rather than failing the migration — this
+    * is a diagnostic, not a correctness path.
+    */
+  def logTokenRangeCoverage(
+    sourceDF: SourceDataFrame,
+    skipTokenRanges: Option[Set[(Token[_], Token[_])]]
+  ): Unit =
+    try {
+      val partitions = sourceDF.dataFrame.rdd.partitions
+      val cassandraPartitions = partitions.map(p => p.asInstanceOf[CassandraPartition[_, _]])
+      val allTokenRangesBuilder = Set.newBuilder[(Token[_], Token[_])]
+      cassandraPartitions.foreach(p =>
+        p.tokenRanges
+          .asInstanceOf[Vector[CqlTokenRange[_, _]]]
+          .foreach { tr =>
+            val range: (Token[_], Token[_]) =
+              (tr.range.start.asInstanceOf[Token[_]], tr.range.end.asInstanceOf[Token[_]])
+            allTokenRangesBuilder += range
+          }
+      )
+      val allTokenRanges = allTokenRangesBuilder.result()
+
+      log.info("All token ranges extracted from partitions size:" + allTokenRanges.size)
+
+      if (skipTokenRanges.isDefined) {
+        log.info(
+          "Savepoints array defined, size of the array: " + skipTokenRanges.fold(0)(_.size)
+        )
+
+        val diff = allTokenRanges.diff(skipTokenRanges.getOrElse(Set.empty))
+        log.info("Diff ... total diff of full ranges to savepoints is: " + diff.size)
+        if (log.isDebugEnabled) {
+          val sample = diff.take(20)
+          log.debug(s"Sample of missing tokens (${sample.size} of ${diff.size}): $sample")
+        }
+      }
+    } catch {
+      case _: ClassCastException =>
+        log.warn(
+          "Source DataFrame partitions are not CassandraPartitions; skipping token-range " +
+            "coverage diagnostic. This is unexpected for a CqlSavepointsManager and may indicate " +
+            "an incorrectly wired source."
+        )
+      case NonFatal(t) =>
+        log.warn(
+          s"Failed to log token-range coverage diagnostic: ${Option(t.getMessage).getOrElse(t.toString)}"
+        )
+    }
 
   private def tokenRanges(accumulator: TokenRangeAccumulator): Set[(Token[_], Token[_])] =
     accumulator.value.get.map(range =>

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
@@ -1,7 +1,5 @@
 package com.scylladb.migrator.scylla
 
-import com.datastax.spark.connector.rdd.partitioner.{ CassandraPartition, CqlTokenRange }
-import com.datastax.spark.connector.rdd.partitioner.dht.Token
 import com.datastax.spark.connector.writer.TokenRangeAccumulator
 import com.scylladb.migrator.SavepointsManager
 import com.scylladb.migrator.config.{ MigratorConfig, SourceSettings, TargetSettings }
@@ -48,34 +46,10 @@ trait ScyllaMigratorBase {
       "We need to transfer: " + sourceDF.dataFrame.rdd.getNumPartitions + " partitions in total"
     )
 
-    if (migratorConfig.source.isInstanceOf[SourceSettings.Cassandra]) {
-      val partitions = sourceDF.dataFrame.rdd.partitions
-      val cassandraPartitions = partitions.map(p => p.asInstanceOf[CassandraPartition[_, _]])
-      val allTokenRangesBuilder = Set.newBuilder[(Token[_], Token[_])]
-      cassandraPartitions.foreach(p =>
-        p.tokenRanges
-          .asInstanceOf[Vector[CqlTokenRange[_, _]]]
-          .foreach { tr =>
-            val range: (Token[_], Token[_]) =
-              (tr.range.start.asInstanceOf[Token[_]], tr.range.end.asInstanceOf[Token[_]])
-            allTokenRangesBuilder += range
-          }
-      )
-      val allTokenRanges = allTokenRangesBuilder.result()
-
-      log.info("All token ranges extracted from partitions size:" + allTokenRanges.size)
-
-      if (migratorConfig.skipTokenRanges.isDefined) {
-        log.info(
-          "Savepoints array defined, size of the array: " + migratorConfig.skipTokenRanges.size
-        )
-
-        val diff = allTokenRanges.diff(migratorConfig.getSkipTokenRangesOrEmptySet)
-        log.info("Diff ... total diff of full ranges to savepoints is: " + diff.size)
-        log.debug("Dump of the missing tokens: ")
-        log.debug(diff)
-      }
-    }
+    // Cassandra-specific token-range diff logging lives inside `CqlSavepointsManager` (invoked
+    // from `savepointsManagerForSource`) so this central `migrate` method has zero
+    // `isInstanceOf[SourceSettings.*]` checks. New source types do not need to be aware of, or
+    // edit, this method.
 
     log.info("Starting write...")
 
@@ -133,7 +107,13 @@ object ScyllaMigrator extends ScyllaMigratorBase {
     else {
       val tokenRangeAccumulator = TokenRangeAccumulator.empty
       spark.sparkContext.register(tokenRangeAccumulator, "Token ranges copied")
-      Some(CqlSavepointsManager(migratorConfig, tokenRangeAccumulator))
+      val manager = CqlSavepointsManager(migratorConfig, tokenRangeAccumulator)
+      // Cassandra-only diagnostic: was previously emitted from `ScyllaMigratorBase.migrate`
+      // gated by `isInstanceOf[SourceSettings.Cassandra]`. Moved here so the cast lives
+      // alongside the CQL-specific manager that owns the partition shape. Non-Cassandra
+      // DataFrame sources never construct this manager and never invoke this log call.
+      manager.logTokenRangeCoverage(sourceDF, migratorConfig.skipTokenRanges)
+      Some(manager)
     }
 
   protected override def createSavepointsManager(

--- a/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigTest.scala
@@ -365,6 +365,102 @@ class MigratorConfigTest extends munit.FunSuite {
     assert(cfg.target.asInstanceOf[TargetSettings.DynamoDB].streamChanges)
   }
 
+  test("MySQL config round-trips without savepoints block (supportsSavepoints = false)") {
+    val config = MigratorConfig(
+      source = SourceSettings.MySQL(
+        host                 = "mysql.example.com",
+        port                 = 3306,
+        database             = "testdb",
+        table                = "t",
+        credentials          = Credentials("user", "pass"),
+        primaryKey           = None,
+        partitionColumn      = None,
+        numPartitions        = None,
+        lowerBound           = None,
+        upperBound           = None,
+        zeroDateTimeBehavior = SourceSettings.MySQL.ZeroDateTimeBehavior.Exception,
+        fetchSize            = SourceSettings.MySQL.DefaultFetchSize,
+        where                = None,
+        connectionProperties = None
+      ),
+      target = TargetSettings.Scylla(
+        host                          = "scylla.example.com",
+        port                          = 9042,
+        localDC                       = Some("dc1"),
+        credentials                   = None,
+        sslOptions                    = None,
+        keyspace                      = "ks",
+        table                         = "t",
+        connections                   = None,
+        stripTrailingZerosForDecimals = false,
+        writeTTLInS                   = None,
+        writeWritetimestampInuS       = None,
+        consistencyLevel              = "LOCAL_QUORUM"
+      ),
+      renames          = None,
+      savepoints       = Savepoints(intervalSeconds = 300, path = "/tmp/savepoints"),
+      skipTokenRanges  = None,
+      skipSegments     = None,
+      skipParquetFiles = None,
+      validation       = None
+    )
+    val rendered = config.render
+    assert(!rendered.contains("savepoints"), "Encoder should omit savepoints for MySQL")
+    val parsed = yaml.parser.parse(rendered).flatMap(_.as[MigratorConfig])
+    assert(parsed.isRight, s"Round-trip failed: ${parsed}")
+    val roundTripped = parsed.toOption.get
+    assertEquals(roundTripped.source, config.source)
+    assertEquals(roundTripped.target, config.target)
+  }
+
+  test(
+    "DynamoDBS3Export config round-trips without savepoints block (supportsSavepoints = false)"
+  ) {
+    val config = MigratorConfig(
+      source = SourceSettings.DynamoDBS3Export(
+        bucket      = "exports",
+        manifestKey = "manifest.json",
+        tableDescription = SourceSettings.DynamoDBS3Export.TableDescription(
+          attributeDefinitions = Seq(
+            SourceSettings.DynamoDBS3Export
+              .AttributeDefinition("pk", SourceSettings.DynamoDBS3Export.AttributeType.S)
+          ),
+          keySchema = Seq(
+            SourceSettings.DynamoDBS3Export
+              .KeySchema("pk", SourceSettings.DynamoDBS3Export.KeyType.Hash)
+          )
+        ),
+        endpoint           = None,
+        region             = Some("us-east-1"),
+        credentials        = None,
+        usePathStyleAccess = None
+      ),
+      target = TargetSettings.DynamoDB(
+        endpoint                    = None,
+        region                      = None,
+        credentials                 = None,
+        table                       = "DstTable",
+        writeThroughput             = None,
+        throughputWritePercent      = None,
+        streamChanges               = false,
+        skipInitialSnapshotTransfer = None
+      ),
+      renames          = None,
+      savepoints       = Savepoints(intervalSeconds = 300, path = "/tmp/savepoints"),
+      skipTokenRanges  = None,
+      skipSegments     = None,
+      skipParquetFiles = None,
+      validation       = None
+    )
+    val rendered = config.render
+    assert(!rendered.contains("savepoints"), "Encoder should omit savepoints for DynamoDBS3Export")
+    val parsed = yaml.parser.parse(rendered).flatMap(_.as[MigratorConfig])
+    assert(parsed.isRight, s"Round-trip failed: ${parsed}")
+    val roundTripped = parsed.toOption.get
+    assertEquals(roundTripped.source, config.source)
+    assertEquals(roundTripped.target, config.target)
+  }
+
   test("MigratorConfig roundtrip with skipTokenRanges containing LongToken and BigIntToken") {
     val config = MigratorConfig(
       source = SourceSettings.DynamoDB(

--- a/tests/src/test/scala/com/scylladb/migrator/config/SourceSettingsCapabilityTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/SourceSettingsCapabilityTest.scala
@@ -1,0 +1,116 @@
+package com.scylladb.migrator.config
+
+import com.scylladb.migrator.config.SourceSettings.DynamoDBS3Export.{
+  AttributeDefinition,
+  AttributeType,
+  KeySchema,
+  KeyType,
+  TableDescription
+}
+
+/** Backend-neutral checks for `SourceSettings.supportsSavepoints`.
+  *
+  * Acts as the single source of truth that the rest of the migrator (config decoder/encoder,
+  * Migrator dispatcher, readers, alternator RDD path) trusts. If a new source is added without
+  * declaring its capability, the trait's abstract `def` would not compile -- these tests pin the
+  * intent of every existing subtype so a silent override drift fails fast.
+  */
+class SourceSettingsCapabilityTest extends munit.FunSuite {
+
+  test("Cassandra supports savepoints (CQL token-range resume)") {
+    val source = SourceSettings.Cassandra(
+      host               = "cass.example.com",
+      port               = 9042,
+      localDC            = Some("dc1"),
+      credentials        = None,
+      sslOptions         = None,
+      keyspace           = "ks",
+      table              = "t",
+      splitCount         = None,
+      connections        = None,
+      fetchSize          = 1000,
+      preserveTimestamps = false,
+      where              = None,
+      consistencyLevel   = "LOCAL_QUORUM"
+    )
+    assert(source.supportsSavepoints)
+  }
+
+  test("DynamoDB supports savepoints (scan-segment resume)") {
+    val source = SourceSettings.DynamoDB(
+      endpoint              = None,
+      region                = Some("us-east-1"),
+      credentials           = None,
+      table                 = "t",
+      scanSegments          = None,
+      readThroughput        = None,
+      throughputReadPercent = None,
+      maxMapTasks           = None
+    )
+    assert(source.supportsSavepoints)
+  }
+
+  test("Alternator supports savepoints (scan-segment resume)") {
+    val source = SourceSettings.Alternator(
+      alternatorEndpoint    = DynamoDBEndpoint("http://10.0.0.1", 8000),
+      region                = None,
+      credentials           = None,
+      table                 = "t",
+      scanSegments          = None,
+      readThroughput        = None,
+      throughputReadPercent = None,
+      maxMapTasks           = None
+    )
+    assert(source.supportsSavepoints)
+  }
+
+  test("Parquet supports savepoints (file-level resume capability is available)") {
+    // The runtime decision between savepoint-tracked and untracked Parquet reads is the
+    // user-facing `savepoints.enableParquetFileTracking` toggle, NOT the source capability.
+    val source = SourceSettings.Parquet(
+      path        = "s3a://bucket/data/",
+      credentials = None,
+      endpoint    = None,
+      region      = None
+    )
+    assert(source.supportsSavepoints)
+  }
+
+  test("MySQL does not support savepoints (JDBC reads have no durable per-range progress)") {
+    val source = SourceSettings.MySQL(
+      host                 = "mysql.example.com",
+      port                 = 3306,
+      database             = "db",
+      table                = "t",
+      credentials          = Credentials("u", "p"),
+      primaryKey           = None,
+      partitionColumn      = None,
+      numPartitions        = None,
+      lowerBound           = None,
+      upperBound           = None,
+      zeroDateTimeBehavior = SourceSettings.MySQL.ZeroDateTimeBehavior.Exception,
+      fetchSize            = SourceSettings.MySQL.DefaultFetchSize,
+      where                = None,
+      connectionProperties = None
+    )
+    assert(!source.supportsSavepoints)
+  }
+
+  test(
+    "DynamoDBS3Export does not support savepoints (RDD partition shape lacks segment tracking)"
+  ) {
+    val source = SourceSettings.DynamoDBS3Export(
+      bucket      = "exports",
+      manifestKey = "manifest.json",
+      tableDescription = TableDescription(
+        attributeDefinitions = Seq(AttributeDefinition("pk", AttributeType.S)),
+        keySchema            = Seq(KeySchema("pk", KeyType.Hash))
+      ),
+      endpoint           = None,
+      region             = Some("us-east-1"),
+      credentials        = None,
+      usePathStyleAccess = None
+    )
+    assert(!source.supportsSavepoints)
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/readers/MySQLReaderTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/MySQLReaderTest.scala
@@ -364,7 +364,7 @@ class MySQLReaderTest extends munit.FunSuite {
   }
 
   test("MySQL source dataframes do not support savepoints") {
-    val sourceDF = MySQL.sourceDataFrame(spark.emptyDataFrame)
+    val sourceDF = MySQL.sourceDataFrame(spark.emptyDataFrame, mysqlSource())
 
     assert(!sourceDF.savepointsSupported)
     assertEquals(sourceDF.timestampColumns, None)


### PR DESCRIPTION
## Goal

Resolve "Savepoint capability flag" item from [scylla-migrator#358](https://github.com/scylladb/scylla-migrator/issues/358). After this change, every "should we attempt durable resume?" decision in the codebase consults the same predicate: `source.supportsSavepoints`. No `isInstanceOf[SourceSettings.*]` remains in central migrate/config code. Existing behavior is unchanged for MySQL, Cassandra, DynamoDB, Alternator, Parquet, and DynamoDB S3 export.

## Design: capability lives on `SourceSettings`

Single abstract member on the sealed trait. Each subtype declares its own answer. Central code never pattern-matches by source type for savepoints.

```scala
sealed trait SourceSettings {
  def supportsSavepoints: Boolean
}
```

Per-subtype in [SourceSettings.scala](migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala):

- `Cassandra` -> `true` (CQL token range resume)
- `DynamoDBLike` -> `true` (default on the trait; `DynamoDB` + `Alternator` inherit)
- `Parquet` -> `true` (file-level resume via `ParquetSavepointsManager`; the off-by-toggle path is selected by `savepoints.enableParquetFileTracking`, orthogonal to capability)
- `MySQL` -> `false`
- `DynamoDBS3Export` -> `false`

## Changes

### 1) [migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala](migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala)

- Add `def supportsSavepoints: Boolean` on the sealed trait.
- Override per subtype as above. `DynamoDBLike` sets `val supportsSavepoints: Boolean = true` in the trait body so both concrete classes inherit.

### 2) [migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala](migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala)

Decoder (replace lines 62-65):

```scala
val savepointsRequired = decoded.source.supportsSavepoints
```

Encoder (replace lines 108-111):

```scala
val savepointsField =
  if (migratorConfig.source.supportsSavepoints)
    List("savepoints" -> migratorConfig.savepoints.asJson)
  else Nil
```

Decoder error message becomes source-agnostic: "Missing required field: savepoints. This field is optional only for sources that do not support savepoints."

### 3) [migrator/src/main/scala/com/scylladb/migrator/Migrator.scala](migrator/src/main/scala/com/scylladb/migrator/Migrator.scala)

Generic pre-dispatch warning:

```scala
if (!config.source.supportsSavepoints) {
  log.warn(
    "Source does not support savepoints; any configured savepoints settings are ignored. " +
      "If this migration is interrupted, it must be restarted from scratch. " +
      "Ensure the target table supports idempotent writes."
  )
}
```

Drop the MySQL `case`'s bespoke `log.warn` block (lines 60-66). MySQL-specific reader caveats ("JDBC statements per partition", "no global snapshot") move into `readers.MySQL.readDataframe` so they remain visible without leaking into the dispatcher.

### 4) Drift guard in readers

- [readers/MySQL.scala:567](migrator/src/main/scala/com/scylladb/migrator/readers/MySQL.scala): `savepointsSupported = source.supportsSavepoints`.
- [readers/Cassandra.scala:378, 387](migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala): `savepointsSupported = source.supportsSavepoints`.
- [readers/Parquet.scala:91, 93](migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala) + [readers/ParquetWithoutSavepoints.scala:27, 29](migrator/src/main/scala/com/scylladb/migrator/readers/ParquetWithoutSavepoints.scala): keep hardcoded `false` with a comment — Parquet uses an external manager wired via `ScyllaParquetMigrator.externalSavepointsManager`, so the internal-manager flag must stay false regardless of trait capability.

### 5) RDD path unification (#3) — [AlternatorMigrator.scala](migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorMigrator.scala)

Drop the `hadoopPartitionedSource: Boolean` param. Pass the `SourceSettings` instead so the same capability predicate runs:

```scala
def migrate(
  sourceRDD: RDD[(Text, DynamoDBItemWritable)],
  sourceTableDesc: TableDescription,
  maybeStreamedSource: Option[SourceSettings.DynamoDB],
  source: SourceSettings,           // NEW: lets us read supportsSavepoints
  target: TargetSettings.DynamoDBLike,
  migratorConfig: MigratorConfig
)(implicit spark: SparkSession): Unit = {
  ...
  if (source.supportsSavepoints) {
    Using.resource(DynamoDbSavepointsManager(migratorConfig, sourceRDD, spark.sparkContext)) { _ =>
      writers.DynamoDB.writeRDD(target, migratorConfig.renamesMap, sourceRDD, targetTableDesc)
    }
  } else {
    writers.DynamoDB.writeRDD(target, migratorConfig.renamesMap, sourceRDD, targetTableDesc)
  }
}
```

- `migrateFromDynamoDB` passes `source` (`DynamoDBLike`, `supportsSavepoints=true`) — same behavior as today.
- `migrateFromS3Export` passes `source` (`DynamoDBS3Export`, `supportsSavepoints=false`) — same behavior as today (no manager). The local `log.warn("Savepoints are not supported when the source is a DynamoDB S3 export ...")` is removed; the generic warning in `Migrator.migrate` covers it.
- `migrateToS3Export` is unchanged: source is `DynamoDB` (capable), manager always created — no capability check needed at that call site, and no source-type check there anyway.

Note: this is a `private` signature change inside the alternator package; no external tests call `AlternatorMigrator.migrate` directly (verified — no test file references `hadoopPartitionedSource` or invokes `AlternatorMigrator.migrate` directly).

### 6) Cassandra token-range logging move (#4) — [ScyllaMigrator.scala](migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala)

Remove the `if (migratorConfig.source.isInstanceOf[SourceSettings.Cassandra]) { ... }` block (lines 51-78) from `ScyllaMigratorBase.migrate`.

Relocate the diagnostic into [CqlSavepointsManager.scala](migrator/src/main/scala/com/scylladb/migrator/scylla/CqlSavepointsManager.scala) as a method `logTokenRangeCoverage(sourceDF: SourceDataFrame, skipTokenRanges: Option[Set[(Token[_], Token[_])]]): Unit`, invoked from `ScyllaMigrator.savepointsManagerForSource` right after manager construction:

```scala
private[migrator] def savepointsManagerForSource(
  migratorConfig: MigratorConfig,
  sourceDF: SourceDataFrame
)(implicit spark: SparkSession): Option[SavepointsManager] =
  if (!sourceDF.savepointsSupported) None
  else {
    val tokenRangeAccumulator = TokenRangeAccumulator.empty
    spark.sparkContext.register(tokenRangeAccumulator, "Token ranges copied")
    val manager = CqlSavepointsManager(migratorConfig, tokenRangeAccumulator)
    manager.logTokenRangeCoverage(sourceDF, migratorConfig.skipTokenRanges)
    Some(manager)
  }
```

The cast `partitions.map(_.asInstanceOf[CassandraPartition[_, _]])` lives inside `CqlSavepointsManager` — local and natural, since that manager is Cassandra-by-construction. After this, `ScyllaMigratorBase.migrate` contains zero `isInstanceOf[SourceSettings.*]`.

Behavioral note: log line still appears, just shortly earlier (manager construction time rather than mid-migrate). No log-string assertions exist in the test suite to break (verified).

### 7) Tests

- New `SourceSettingsCapabilityTest` (or extend `MigratorConfigTest`):
  - `SourceSettings.MySQL(...).supportsSavepoints == false`
  - `SourceSettings.Cassandra(...).supportsSavepoints == true`
  - `SourceSettings.DynamoDB(...).supportsSavepoints == true`
  - `SourceSettings.Alternator(...).supportsSavepoints == true`
  - `SourceSettings.Parquet(...).supportsSavepoints == true`
  - `SourceSettings.DynamoDBS3Export(...).supportsSavepoints == false`
- `MigratorConfigTest`:
  - decoder rejects missing `savepoints` for Cassandra/DynamoDB; accepts for MySQL/DynamoDBS3Export.
  - encoder omits `savepoints` for MySQL/DynamoDBS3Export; includes for Cassandra/DynamoDB.
- `MySQLSavepointsTest` — still asserts `manager == None`, still passes.
- `ParquetSavepointsTest`, `DynamoDBToS3ExportSavepointsTest` — sanity-check compile + pass (Parquet uses external manager via `ScyllaParquetMigrator`, unaffected; S3-export test now goes through the unified `if (source.supportsSavepoints)` branch with the same result).
- Add a small `AlternatorMigratorRddCapabilityTest` (or extend `DynamoDBToS3ExportSavepointsTest`) confirming S3-export path does not construct `DynamoDbSavepointsManager` after the refactor.