### PR TITLE
wide cql timestamp backing data type

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -10,7 +10,16 @@ import com.scylladb.migrator.config.{ CopyType, SourceSettings }
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.cassandra.{ CassandraSQLRow, DataTypeConverter }
-import org.apache.spark.sql.types.{ IntegerType, LongType, StructField, StructType }
+import org.apache.spark.sql.types.{
+  ArrayType,
+  DataType,
+  IntegerType,
+  LongType,
+  MapType,
+  StructField,
+  StructType,
+  TimestampType
+}
 import org.apache.spark.sql.{ DataFrame, Encoders, Row, SparkSession }
 import org.apache.spark.unsafe.types.UTF8String
 import com.scylladb.migrator.ConsistencyLevelUtils
@@ -173,6 +182,46 @@ object Cassandra {
     case ab: ArrayBuffer[_] => ab.map(convertValue)
     case udt: UDTValue      => Row.fromSeq(udt.columnValues.map(convertValue))
     case tuple: TupleValue  => Row.fromSeq(tuple.values.map(convertValue))
+    case x                  => x
+  }
+
+  /** CQL `timestamp` is a 64-bit signed integer of milliseconds since epoch, so its range is
+    * `[Long.MinValue, Long.MaxValue]` ms. Spark's `TimestampType` is encoded internally as
+    * microseconds since epoch (also Long), so building a `TimestampType` column from a row whose
+    * millis value lies outside `±(Long.MaxValue / 1000)` overflows in
+    * `DateTimeUtils.millisToMicros` (`Math.multiplyExact(millis, 1000)`). To migrate the full CQL
+    * range losslessly, replace `TimestampType` with `LongType` (epoch millis) in the source schema.
+    * Recurses into UDT (`StructType`), list/set (`ArrayType`), and map (`MapType`).
+    */
+  def widenCqlTimestamps(dataType: DataType): DataType = dataType match {
+    case TimestampType => LongType
+    case s: StructType =>
+      StructType(s.fields.map(f => f.copy(dataType = widenCqlTimestamps(f.dataType))))
+    case a: ArrayType =>
+      a.copy(elementType = widenCqlTimestamps(a.elementType))
+    case m: MapType =>
+      m.copy(keyType = widenCqlTimestamps(m.keyType), valueType = widenCqlTimestamps(m.valueType))
+    case other => other
+  }
+
+  /** Recursively convert any `java.sql.Timestamp`/`java.util.Date`/`java.time.Instant` produced by
+    * the Spark Cassandra connector to its epoch-millisecond `Long` value. Pairs with
+    * [[widenCqlTimestamps]] so each row's runtime value matches the widened schema. The Scylla
+    * writer (`saveToCassandra` via `SqlRowWriter`) accepts `Long` as millis for CQL `timestamp`
+    * columns via the connector's `TypeConverter`, so the round-trip stays lossless.
+    */
+  val widenTimestampValue: Any => Any = {
+    case t: java.sql.Timestamp => t.getTime
+    case i: java.time.Instant  => i.toEpochMilli
+    case d: java.util.Date     => d.getTime
+    case row: Row              => Row.fromSeq(row.toSeq.map(widenTimestampValue))
+    case set: Set[_]           => set.map(widenTimestampValue)
+    case list: List[_]         => list.map(widenTimestampValue)
+    case map: Map[_, _] =>
+      map.map { case (k, v) =>
+        widenTimestampValue(k) -> widenTimestampValue(v)
+      }
+    case ab: ArrayBuffer[_] => ab.map(widenTimestampValue)
     case x                  => x
   }
 
@@ -345,7 +394,10 @@ object Cassandra {
     log.info("TableDef retrieved for source:")
     log.info(tableDef)
 
-    val origSchema = StructType(tableDef.columns.map(DataTypeConverter.toStructField))
+    val origSchema = StructType(tableDef.columns.map { col =>
+      val field = DataTypeConverter.toStructField(col)
+      field.copy(dataType = widenCqlTimestamps(field.dataType))
+    })
     log.info("Original schema loaded:")
     origSchema.printTreeString()
 
@@ -369,7 +421,7 @@ object Cassandra {
     val rdd = finalCassandraRDD
       .asInstanceOf[RDD[Row]]
       .map { row =>
-        Row.fromSeq(row.toSeq.map(convertValue))
+        Row.fromSeq(row.toSeq.map(v => widenTimestampValue(convertValue(v))))
       }
 
     val rawDataframe = spark.createDataFrame(rdd, selection.schema)

--- a/tests/src/test/scala/com/scylladb/migrator/readers/CassandraTimestampWideningTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/CassandraTimestampWideningTest.scala
@@ -1,0 +1,150 @@
+package com.scylladb.migrator.readers
+
+import com.scylladb.migrator.config.SparkSecretRedaction
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{ Row, SparkSession }
+import org.apache.spark.sql.types.{
+  ArrayType,
+  LongType,
+  MapType,
+  StringType,
+  StructField,
+  StructType,
+  TimestampType
+}
+
+import scala.collection.immutable.ArraySeq
+
+class CassandraTimestampWideningTest extends munit.FunSuite {
+
+  private lazy val spark: SparkSession = {
+    val sparkConf = new SparkConf(false)
+    SparkSecretRedaction.ensureMigratorRedactionRegex(sparkConf)
+    SparkSession
+      .builder()
+      .config(sparkConf)
+      .master("local[1]")
+      .appName("CassandraTimestampWideningTest")
+      .config("spark.ui.enabled", "false")
+      .config("spark.sql.shuffle.partitions", "1")
+      .getOrCreate()
+  }
+
+  override def afterAll(): Unit = {
+    spark.stop()
+    super.afterAll()
+  }
+
+  test("widenCqlTimestamps replaces TimestampType with LongType at top level") {
+    val input = StructType(
+      Seq(
+        StructField("id", LongType, nullable            = false),
+        StructField("validity", TimestampType, nullable = true),
+        StructField("name", StringType, nullable        = true)
+      )
+    )
+
+    val widened = Cassandra.widenCqlTimestamps(input).asInstanceOf[StructType]
+
+    assertEquals(widened.fields(0), StructField("id", LongType, nullable = false))
+    assertEquals(widened.fields(1), StructField("validity", LongType, nullable = true))
+    assertEquals(widened.fields(2), StructField("name", StringType, nullable = true))
+  }
+
+  test("widenCqlTimestamps recurses into ArrayType, MapType, and nested StructType") {
+    val nestedUdt = StructType(Seq(StructField("ts", TimestampType, nullable = true)))
+    val input = StructType(
+      Seq(
+        StructField("times", ArrayType(TimestampType, containsNull = true)),
+        StructField("by_ts", MapType(TimestampType, StringType)),
+        StructField("by_str", MapType(StringType, TimestampType)),
+        StructField("udt", nestedUdt)
+      )
+    )
+
+    val widened = Cassandra.widenCqlTimestamps(input).asInstanceOf[StructType]
+
+    assertEquals(
+      widened.fields(0).dataType,
+      ArrayType(LongType, containsNull = true): org.apache.spark.sql.types.DataType
+    )
+    assertEquals(
+      widened.fields(1).dataType,
+      MapType(LongType, StringType): org.apache.spark.sql.types.DataType
+    )
+    assertEquals(
+      widened.fields(2).dataType,
+      MapType(StringType, LongType): org.apache.spark.sql.types.DataType
+    )
+    assertEquals(
+      widened.fields(3).dataType,
+      StructType(
+        Seq(StructField("ts", LongType, nullable = true))
+      ): org.apache.spark.sql.types.DataType
+    )
+  }
+
+  test("widenTimestampValue converts java.sql.Timestamp to epoch millis Long") {
+    val ts = new java.sql.Timestamp(1700000000123L)
+    assertEquals(Cassandra.widenTimestampValue(ts), 1700000000123L)
+  }
+
+  test("widenTimestampValue preserves CQL timestamp millis that overflow Spark TimestampType") {
+    // 9999999999999999 ms ≈ year 318683 AD; multiplying by 1000 overflows Long, so Spark's
+    // TimestampType encoder rejects it. As a bare millis Long it round-trips losslessly.
+    val outOfRangeMillis = 9999999999999999L
+    val ts = new java.sql.Timestamp(outOfRangeMillis)
+    assertEquals(Cassandra.widenTimestampValue(ts), outOfRangeMillis)
+  }
+
+  test("widenTimestampValue handles java.util.Date and java.time.Instant") {
+    val d = new java.util.Date(42L)
+    val i = java.time.Instant.ofEpochMilli(43L)
+    assertEquals(Cassandra.widenTimestampValue(d), 42L)
+    assertEquals(Cassandra.widenTimestampValue(i), 43L)
+  }
+
+  test("widenTimestampValue recurses into Row, Set, List, Map") {
+    val ts1 = new java.sql.Timestamp(10L)
+    val ts2 = new java.sql.Timestamp(20L)
+
+    assertEquals(Cassandra.widenTimestampValue(Row(ts1, "x")), Row(10L, "x"))
+    assertEquals(Cassandra.widenTimestampValue(List(ts1, ts2)), List(10L, 20L))
+    assertEquals(Cassandra.widenTimestampValue(Set(ts1, ts2)), Set(10L, 20L))
+    assertEquals(
+      Cassandra.widenTimestampValue(Map("a" -> ts1, "b" -> ts2)),
+      Map("a" -> 10L, "b" -> 20L)
+    )
+  }
+
+  test("widenTimestampValue passes through values it does not need to convert") {
+    assertEquals(Cassandra.widenTimestampValue(42L), 42L)
+    assertEquals(Cassandra.widenTimestampValue("hello"), "hello")
+    assertEquals(Cassandra.widenTimestampValue(null), null)
+  }
+
+  test("createDataFrame succeeds with widened schema for an out-of-range CQL timestamp") {
+    val outOfRangeMillis = 9999999999999999L
+    val widenedSchema = Cassandra
+      .widenCqlTimestamps(
+        StructType(
+          Seq(
+            StructField("id", LongType, nullable            = false),
+            StructField("validity", TimestampType, nullable = true)
+          )
+        )
+      )
+      .asInstanceOf[StructType]
+
+    val raw = new java.sql.Timestamp(outOfRangeMillis)
+    val row = Row.fromSeq(ArraySeq[Any](1L, raw).map(Cassandra.widenTimestampValue))
+
+    val rdd = spark.sparkContext.parallelize(Seq(row))
+    val df = spark.createDataFrame(rdd, widenedSchema)
+
+    val collected = df.collect().toList
+    assertEquals(collected.size, 1)
+    assertEquals(collected.head.getAs[Long]("id"), 1L)
+    assertEquals(collected.head.getAs[Long]("validity"), outOfRangeMillis)
+  }
+}


### PR DESCRIPTION
fixes CUSTOMER-342
fixes: https://github.com/scylladb/scylla-migrator/issues/372