### PR TITLE
reusability refactoring

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -499,3 +499,10 @@ savepoints:
 #   # hashColumns:
 #   #   - large_text_column
 #   #   - blob_column
+#   # Optional - numeric cross-type comparison policy.
+#   # Lenient (default): Int==Long==BigInt==BigDecimal(scale<=0) treated as equal;
+#   #   Float/Double normalized to BigDecimal within floatingPointTolerance.
+#   # DetectWiden: same as Lenient, but flags Float->Double widening that loses bits
+#   #   (e.g. Float(0.1f) vs Double(0.1)) as NumericTypeMismatch.
+#   # StrictType: any Float vs Double pair flagged regardless of value.
+#   # numericTypePolicy: Lenient

--- a/migrator/src/main/scala/com/scylladb/migrator/Validator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Validator.scala
@@ -72,6 +72,9 @@ object Validator {
       val differingCount = failures.count(
         _.items.exists(_.isInstanceOf[RowComparisonFailure.Item.DifferingFieldValues])
       )
+      val numericTypeMismatchCount = failures.count(
+        _.items.exists(_.isInstanceOf[RowComparisonFailure.Item.NumericTypeMismatch])
+      )
       val mismatchedColumnCount =
         failures.count(_.items.contains(RowComparisonFailure.Item.MismatchedColumnCount))
       val mismatchedColumnNames =
@@ -81,6 +84,9 @@ object Validator {
         if (missingCount > 0) Some(s"$missingCount missing target row(s)") else None,
         if (extraCount > 0) Some(s"$extraCount extra target row(s)") else None,
         if (differingCount > 0) Some(s"$differingCount differing field value(s)") else None,
+        if (numericTypeMismatchCount > 0)
+          Some(s"$numericTypeMismatchCount numeric type mismatch(es)")
+        else None,
         if (mismatchedColumnCount > 0) Some(s"$mismatchedColumnCount mismatched column count(s)")
         else None,
         if (mismatchedColumnNames > 0) Some(s"$mismatchedColumnNames mismatched column name(s)")

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala
@@ -83,7 +83,8 @@ object AlternatorValidator {
           l,
           r,
           renamedColumn,
-          configValidation.floatingPointTolerance
+          configValidation.floatingPointTolerance,
+          configValidation.numericTypePolicy
         )
       }
       .take(configValidation.failuresToFetch)

--- a/migrator/src/main/scala/com/scylladb/migrator/config/Validation.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/Validation.scala
@@ -3,6 +3,7 @@ package com.scylladb.migrator.config
 import io.circe.{ Decoder, DecodingFailure, Encoder }
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto._
+import com.scylladb.migrator.validation.core.NumericTypePolicy
 
 import java.util.Locale
 
@@ -32,7 +33,8 @@ case class Validation(
   failuresToFetch: Int,
   floatingPointTolerance: Double,
   timestampMsTolerance: Long,
-  hashColumns: Option[List[String]] = None
+  hashColumns: Option[List[String]] = None,
+  numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient
 )
 object Validation {
   private implicit val circeConfig: Configuration = Configuration.default.withDefaults

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidator.scala
@@ -8,6 +8,8 @@ import com.scylladb.migrator.config.{ MigratorConfig, Rename, SourceSettings, Ta
 import com.scylladb.migrator.readers
 import com.scylladb.migrator.readers.MySQL
 import com.scylladb.migrator.validation.RowComparisonFailure
+import com.scylladb.migrator.validation.core._
+import com.scylladb.migrator.validation.core.SchemaResolver.{ resolveFieldName, sparkColumn }
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.cassandra.{ CassandraSQLRow, DataTypeConverter }
@@ -42,141 +44,43 @@ object MySQLToScyllaValidator {
   private[scylla] def buildCaseInsensitiveRenameMap(
     renames: List[Rename]
   ): Map[String, String] =
-    renames
-      .groupBy(_.from.toLowerCase(Locale.ROOT))
-      .view
-      .map { case (sourceName, entries) =>
-        val targets = entries.map(_.to).distinct
-        if (targets.size > 1)
-          sys.error(
-            s"Renames contain conflicting case-insensitive mappings for source column '${sourceName}': " +
-              s"${targets.mkString(", ")}"
-          )
-        sourceName -> targets.head
-      }
-      .toMap
+    SchemaResolver.buildCaseInsensitiveRenameMap(renames)
 
   private[scylla] def escapeSparkColumnName(name: String): String =
-    s"`${name.replace("`", "``")}`"
+    SchemaResolver.escapeSparkColumnName(name)
 
   private[scylla] def sparkColumn(name: String): Column =
-    col(escapeSparkColumnName(name))
+    SchemaResolver.sparkColumn(name)
 
   private[scylla] def areDifferent(
     left: Option[Any],
     right: Option[Any],
     timestampMsTolerance: Long,
-    floatingPointTolerance: Double
+    floatingPointTolerance: Double,
+    numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient
   ): Boolean =
-    (left, right) match {
-      case (Some(l: Number), Some(r: Number)) =>
-        areNumbersDifferent(l, r, floatingPointTolerance)
-      case _ =>
-        RowComparisonFailure.areDifferent(
-          left,
-          right,
-          timestampMsTolerance,
-          floatingPointTolerance
-        )
-    }
-
-  private sealed trait FloatingPointSpecial
-  private case object NaNValue extends FloatingPointSpecial
-  private case class InfinityValue(sign: Int) extends FloatingPointSpecial
-
-  private def areNumbersDifferent(left: Number, right: Number, tolerance: Double): Boolean =
-    floatingPointSpecial(left)
-      .orElse(floatingPointSpecial(right))
-      .map { _ =>
-        (floatingPointSpecial(left), floatingPointSpecial(right)) match {
-          case (Some(NaNValue), Some(NaNValue)) => false
-          case (Some(InfinityValue(leftSign)), Some(InfinityValue(rightSign))) =>
-            leftSign != rightSign
-          case _ => true
-        }
-      }
-      .getOrElse {
-        (normalizedIntegralValue(left), normalizedIntegralValue(right)) match {
-          case (Some(l), Some(r)) => l != r
-          case _ =>
-            (normalizedDecimalValue(left), normalizedDecimalValue(right)) match {
-              case (Some(l), Some(r)) => areNumericalValuesDifferent(l, r, tolerance)
-              case _                  => left != right
-            }
-        }
-      }
-
-  private def floatingPointSpecial(value: Number): Option[FloatingPointSpecial] =
-    value match {
-      case d: java.lang.Double if d.isNaN      => Some(NaNValue)
-      case d: java.lang.Double if d.isInfinite => Some(InfinityValue(Math.signum(d).toInt))
-      case f: java.lang.Float if f.isNaN       => Some(NaNValue)
-      case f: java.lang.Float if f.isInfinite  => Some(InfinityValue(Math.signum(f).toInt))
-      case _                                   => None
-    }
-
-  private def normalizedIntegralValue(value: Number): Option[BigInt] =
-    value match {
-      case b: java.lang.Byte        => Some(BigInt(b.longValue))
-      case s: java.lang.Short       => Some(BigInt(s.longValue))
-      case i: java.lang.Integer     => Some(BigInt(i.longValue))
-      case l: java.lang.Long        => Some(BigInt(l.longValue))
-      case bi: java.math.BigInteger => Some(BigInt(bi))
-      case bi: BigInt               => Some(bi)
-      case bd: java.math.BigDecimal =>
-        val stripped = bd.stripTrailingZeros
-        if (stripped.scale <= 0) Some(BigInt(stripped.toBigIntegerExact)) else None
-      case bd: BigDecimal =>
-        val stripped = bd.bigDecimal.stripTrailingZeros
-        if (stripped.scale <= 0) Some(BigInt(stripped.toBigIntegerExact)) else None
-      case _ => None
-    }
-
-  private def normalizedDecimalValue(value: Number): Option[BigDecimal] =
-    value match {
-      case d: java.lang.Double if d.isNaN || d.isInfinite => None
-      case f: java.lang.Float if f.isNaN || f.isInfinite  => None
-      case b: java.lang.Byte                              => Some(BigDecimal(BigInt(b.longValue)))
-      case s: java.lang.Short                             => Some(BigDecimal(BigInt(s.longValue)))
-      case i: java.lang.Integer                           => Some(BigDecimal(BigInt(i.longValue)))
-      case l: java.lang.Long                              => Some(BigDecimal(BigInt(l.longValue)))
-      case bi: java.math.BigInteger                       => Some(BigDecimal(BigInt(bi)))
-      case bi: BigInt                                     => Some(BigDecimal(bi))
-      case bd: java.math.BigDecimal                       => Some(BigDecimal(bd))
-      case bd: BigDecimal                                 => Some(bd)
-      case f: java.lang.Float                             => Some(BigDecimal.decimal(f.doubleValue))
-      case d: java.lang.Double                            => Some(BigDecimal.decimal(d.doubleValue))
-      case _                                              => None
-    }
-
-  private def areNumericalValuesDifferent(
-    x: BigDecimal,
-    y: BigDecimal,
-    tolerance: BigDecimal
-  ): Boolean =
-    (x - y).abs > tolerance
+    RowComparisonFailure.areDifferent(
+      left,
+      right,
+      timestampMsTolerance,
+      floatingPointTolerance,
+      numericTypePolicy
+    )
 
   private[scylla] def differingFieldNamesForRow(
     joinedRow: Row,
     fieldIndices: Seq[(String, Int, Int)],
     timestampMsTolerance: Long,
-    floatingPointTolerance: Double
+    floatingPointTolerance: Double,
+    numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient
   ): List[String] =
-    fieldIndices.flatMap { case (colName, srcIdx, tgtIdx) =>
-      val srcVal = if (joinedRow.isNullAt(srcIdx)) None else Some(joinedRow.get(srcIdx))
-      val tgtVal = if (joinedRow.isNullAt(tgtIdx)) None else Some(joinedRow.get(tgtIdx))
-      if (
-        areDifferent(
-          srcVal,
-          tgtVal,
-          timestampMsTolerance,
-          floatingPointTolerance
-        )
-      )
-        Some(colName)
-      else
-        None
-    }.toList
+    ContentHashJoiner.differingFieldNamesForRow(
+      joinedRow,
+      fieldIndices,
+      timestampMsTolerance,
+      floatingPointTolerance,
+      numericTypePolicy
+    )
 
   private[scylla] def compareFieldsBySchemaForRow(
     joinedRow: Row,
@@ -184,64 +88,33 @@ object MySQLToScyllaValidator {
     hashBackedFieldIndices: Seq[(String, Int, Int)],
     contentHashFieldIndices: Option[(Int, Int)],
     timestampMsTolerance: Long,
-    floatingPointTolerance: Double
-  ): List[String] = {
-    val directDifferences =
-      differingFieldNamesForRow(
-        joinedRow,
-        directFieldIndices,
-        timestampMsTolerance,
-        floatingPointTolerance
-      )
-
-    val hashBackedDifferences = contentHashFieldIndices match {
-      case Some((srcHashIdx, tgtHashIdx)) =>
-        val srcHash = if (joinedRow.isNullAt(srcHashIdx)) None else Some(joinedRow.get(srcHashIdx))
-        val tgtHash = if (joinedRow.isNullAt(tgtHashIdx)) None else Some(joinedRow.get(tgtHashIdx))
-        if (
-          areDifferent(
-            srcHash,
-            tgtHash,
-            timestampMsTolerance,
-            floatingPointTolerance
-          )
-        )
-          differingFieldNamesForRow(
-            joinedRow,
-            hashBackedFieldIndices,
-            timestampMsTolerance,
-            floatingPointTolerance
-          )
-        else
-          Nil
-      case None =>
-        differingFieldNamesForRow(
-          joinedRow,
-          hashBackedFieldIndices,
-          timestampMsTolerance,
-          floatingPointTolerance
-        )
-    }
-
-    directDifferences ++ hashBackedDifferences
-  }
+    floatingPointTolerance: Double,
+    numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient
+  ): List[String] =
+    ContentHashJoiner.compareFieldsBySchemaForRow(
+      joinedRow,
+      directFieldIndices,
+      hashBackedFieldIndices,
+      contentHashFieldIndices,
+      timestampMsTolerance,
+      floatingPointTolerance,
+      numericTypePolicy
+    )
 
   private[scylla] def hasContentHashMismatch(
     joinedRow: Row,
     contentHashFieldIndices: Option[(Int, Int)],
     timestampMsTolerance: Long,
-    floatingPointTolerance: Double
+    floatingPointTolerance: Double,
+    numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient
   ): Boolean =
-    contentHashFieldIndices.exists { case (srcHashIdx, tgtHashIdx) =>
-      val srcHash = if (joinedRow.isNullAt(srcHashIdx)) None else Some(joinedRow.get(srcHashIdx))
-      val tgtHash = if (joinedRow.isNullAt(tgtHashIdx)) None else Some(joinedRow.get(tgtHashIdx))
-      areDifferent(
-        srcHash,
-        tgtHash,
-        timestampMsTolerance,
-        floatingPointTolerance
-      )
-    }
+    ContentHashJoiner.hasContentHashMismatch(
+      joinedRow,
+      contentHashFieldIndices,
+      timestampMsTolerance,
+      floatingPointTolerance,
+      numericTypePolicy
+    )
 
   private[scylla] def materializeValidationCandidate(
     candidate: ValidationCandidate,
@@ -281,7 +154,8 @@ object MySQLToScyllaValidator {
     hashBackedColumns: Seq[String],
     timestampMsTolerance: Long,
     floatingPointTolerance: Double,
-    failuresToFetch: Int
+    failuresToFetch: Int,
+    numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient
   )(implicit spark: SparkSession): List[RowComparisonFailure] =
     if (failuresToFetch <= 0) Nil
     else {
@@ -315,7 +189,8 @@ object MySQLToScyllaValidator {
                 hashMismatchCandidates.map(_.sourcePkValues),
                 hashBackedColumns,
                 timestampMsTolerance,
-                floatingPointTolerance
+                floatingPointTolerance,
+                numericTypePolicy
               )
             else Map.empty[Vector[Any], List[String]]
 
@@ -594,28 +469,17 @@ object MySQLToScyllaValidator {
     targetSettings: TargetSettings.Scylla,
     primaryKeyColumns: Seq[String],
     selectedColumns: Seq[String]
-  ): DataFrame = {
-    val sourceSchemaFields = sourceDF.schema.fieldNames
-    val resolvedSourcePK = primaryKeyColumns.map(resolveFieldName(sourceSchemaFields, _))
-    val resolvedTargetPK = resolveTargetColumns(targetTableDef, primaryKeyColumns)
-    val resolvedSelectedColumns = resolveTargetColumns(targetTableDef, selectedColumns)
-    val schema = buildTargetSchema(targetTableDef, resolvedSelectedColumns)
-    val targetRows = sourceDF
-      .select(resolvedSourcePK.map(sparkColumn): _*)
-      .distinct()
-      .rdd
-      .leftJoinWithCassandraTable[CassandraSQLRow](
-        targetSettings.keyspace,
-        targetSettings.table,
-        SomeColumns(resolvedSelectedColumns.map(ColumnName(_)): _*),
-        SomeColumns(resolvedTargetPK.map(ColumnName(_)): _*),
-        targetReadConf(spark, targetSettings)
-      )
-      .withConnector(targetConnector)
-      .flatMap(_._2)
-      .map(row => Row.fromSeq(row.toSeq.map(readers.Cassandra.convertValue)))
-    spark.createDataFrame(targetRows, schema)
-  }
+  ): DataFrame =
+    KeyDrivenLookup.lookupTargetRowsForSourceKeys(
+      spark,
+      sourceDF,
+      targetConnector,
+      targetTableDef,
+      targetSettings,
+      primaryKeyColumns,
+      selectedColumns,
+      targetReadConf(spark, targetSettings)
+    )
 
   private[scylla] def collectExtraTargetFailureSample(
     sourceKeys: DataFrame,
@@ -623,24 +487,12 @@ object MySQLToScyllaValidator {
     primaryKeyColumns: Seq[String],
     failuresToFetch: Int
   ): List[RowComparisonFailure] =
-    if (failuresToFetch <= 0) Nil
-    else
-      targetKeys
-        .join(sourceKeys.distinct(), primaryKeyColumns, "left_anti")
-        .rdd
-        .map { row =>
-          val targetRepr =
-            primaryKeyColumns
-              .map(pk => s"$pk=${row.getAs[Any](pk)}")
-              .mkString(", ")
-          RowComparisonFailure(
-            targetRepr,
-            None,
-            List(RowComparisonFailure.Item.ExtraTargetRow)
-          )
-        }
-        .take(failuresToFetch)
-        .toList
+    ExtraRowDetector.collectExtraTargetFailureSample(
+      sourceKeys,
+      targetKeys,
+      primaryKeyColumns,
+      failuresToFetch
+    )
 
   private[scylla] def collectExtraTargetFailureSample(
     sourceDF: DataFrame,
@@ -888,6 +740,7 @@ object MySQLToScyllaValidator {
     val joinedSchemaFields = joined.schema.fieldNames
     val floatTol = validationConfig.floatingPointTolerance
     val tsTol = validationConfig.timestampMsTolerance
+    val numericPolicy = validationConfig.numericTypePolicy
 
     // Pre-compute field indices to avoid repeated case-insensitive lookups on every row.
     // For wide tables (100+ columns) × millions of rows, this provides significant speedup.
@@ -954,15 +807,21 @@ object MySQLToScyllaValidator {
           )
         } else {
           val directDifferingFields =
-            differingFieldNamesForRow(joinedRow, directFieldIndices, tsTol, floatTol).map {
-              colName =>
+            differingFieldNamesForRow(joinedRow, directFieldIndices, tsTol, floatTol, numericPolicy)
+              .map { colName =>
                 val (srcIdx, tgtIdx) = fieldIndexByName(colName)
                 val srcVal = if (joinedRow.isNullAt(srcIdx)) None else Some(joinedRow.get(srcIdx))
                 val tgtVal = if (joinedRow.isNullAt(tgtIdx)) None else Some(joinedRow.get(tgtIdx))
                 s"$colName (source=${truncateValue(srcVal)}, target=${truncateValue(tgtVal)})"
-            }
+              }
           val hashMismatch =
-            hasContentHashMismatch(joinedRow, contentHashFieldIndices, tsTol, floatTol)
+            hasContentHashMismatch(
+              joinedRow,
+              contentHashFieldIndices,
+              tsTol,
+              floatTol,
+              numericPolicy
+            )
           if (directDifferingFields.isEmpty && !hashMismatch) None
           else {
             val srcPkValues = srcPKIndices.map { case (_, idx) => joinedRow.get(idx) }.toVector
@@ -995,7 +854,8 @@ object MySQLToScyllaValidator {
       finalHashBackedColumns,
       tsTol,
       floatTol,
-      validationConfig.failuresToFetch
+      validationConfig.failuresToFetch,
+      numericPolicy
     )
     val failures =
       if (
@@ -1027,7 +887,8 @@ object MySQLToScyllaValidator {
     primaryKeyValues: Seq[Vector[Any]],
     hashBackedColumns: Seq[String],
     timestampMsTolerance: Long,
-    floatingPointTolerance: Double
+    floatingPointTolerance: Double,
+    numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient
   )(implicit spark: SparkSession): Map[Vector[Any], List[String]] = {
     val refinementFrames =
       createHashRefinementFrames(rawSourceDF, rawTargetDF, primaryKey, hashBackedColumns)
@@ -1038,7 +899,8 @@ object MySQLToScyllaValidator {
         primaryKeyValues,
         hashBackedColumns,
         timestampMsTolerance,
-        floatingPointTolerance
+        floatingPointTolerance,
+        numericTypePolicy
       )
     finally {
       refinementFrames.source.unpersist(blocking = false)
@@ -1052,7 +914,8 @@ object MySQLToScyllaValidator {
     primaryKeyValues: Seq[Vector[Any]],
     hashBackedColumns: Seq[String],
     timestampMsTolerance: Long,
-    floatingPointTolerance: Double
+    floatingPointTolerance: Double,
+    numericTypePolicy: NumericTypePolicy
   )(implicit spark: SparkSession): Map[Vector[Any], List[String]] = {
     val projectedSource = refinementFrames.source
     val projectedTarget = refinementFrames.target
@@ -1109,11 +972,12 @@ object MySQLToScyllaValidator {
               val srcVal = if (joinedRow.isNullAt(srcIdx)) None else Some(joinedRow.get(srcIdx))
               val tgtVal = if (joinedRow.isNullAt(tgtIdx)) None else Some(joinedRow.get(tgtIdx))
               if (
-                areDifferent(
+                RowComparisonFailure.areDifferent(
                   srcVal,
                   tgtVal,
                   timestampMsTolerance,
-                  floatingPointTolerance
+                  floatingPointTolerance,
+                  numericTypePolicy
                 )
               )
                 Some(
@@ -1145,59 +1009,11 @@ object MySQLToScyllaValidator {
     hashCols: List[String],
     pkCols: List[String],
     dropHashedColumns: Boolean = true
-  ): DataFrame = {
-    val dfColsLower = df.columns.map(_.toLowerCase(Locale.ROOT)).toSet
-    require(
-      !dfColsLower.contains(MySQL.ContentHashColumn.toLowerCase(Locale.ROOT)),
-      s"Source/target table contains a column named '${MySQL.ContentHashColumn}' which conflicts " +
-        "with the internal hash column. Rename the column or disable hash-based validation."
-    )
-    val existingHashCols = hashCols.filter(c => dfColsLower.contains(c.toLowerCase(Locale.ROOT)))
-    if (existingHashCols.isEmpty) {
-      log.warn("No hash columns found in DataFrame. Skipping hash computation.")
-      df
-    } else {
-      // Resolve user-supplied column names against the actual DataFrame schema so that
-      // subsequent operations (col(), drop()) use the exact case from the schema rather
-      // than the user-supplied case. Spark's drop() is case-insensitive by default, but
-      // using resolved names makes the code robust against configuration changes.
-      val dfCols = df.columns
-      def resolveCol(name: String): String =
-        dfCols.find(_.equalsIgnoreCase(name)).getOrElse(name)
-      val resolvedHashCols =
-        existingHashCols.map(resolveCol).sortBy(_.toLowerCase(Locale.ROOT))
-
-      log.info(
-        s"Computing content hash for columns: ${resolvedHashCols.mkString(", ")}"
-      )
-
-      val contentHashBits = 256
-      val perColHashes = resolvedHashCols.map { c =>
-        val encodedValue = df.schema(c).dataType match {
-          case BinaryType => base64(sparkColumn(c))
-          case _          => sparkColumn(c).cast(StringType)
-        }
-        when(sparkColumn(c).isNull, sha2(lit("1|"), contentHashBits))
-          .otherwise(sha2(concat(lit("0|"), encodedValue), contentHashBits))
-      }
-      val hashCol = sha2(concat_ws("|", perColHashes: _*), contentHashBits)
-      val withHash = df.withColumn(MySQL.ContentHashColumn, hashCol)
-
-      if (!dropHashedColumns) withHash
-      else {
-        // Preserve primary key columns; drop only the hashed columns to reduce shuffle volume.
-        val pkColsLower = pkCols.map(_.toLowerCase(Locale.ROOT)).toSet
-        val colsToDrop = resolvedHashCols
-          .filterNot(c => pkColsLower.contains(c.toLowerCase(Locale.ROOT)))
-        colsToDrop.foldLeft(withHash) { (d, c) =>
-          d.drop(c)
-        }
-      }
-    }
-  }
+  ): DataFrame =
+    ContentHashJoiner.addContentHash(df, hashCols, pkCols, dropHashedColumns)
 
   private[scylla] def prefixColumns(df: DataFrame, prefix: String): DataFrame =
-    df.select(df.columns.toIndexedSeq.map(c => sparkColumn(c).as(s"$prefix$c")): _*)
+    SchemaResolver.prefixColumns(df, prefix)
 
   private val MaxValueReprLength = 100
 

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidator.scala
@@ -16,7 +16,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.cassandra.{ CassandraSQLRow, DataTypeConverter }
 import org.apache.spark.sql.{ Column, DataFrame, Row, SparkSession }
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{ BinaryType, StringType, StructType }
+import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 
 import java.sql.DatabaseMetaData
@@ -315,6 +315,48 @@ object MySQLToScyllaValidator {
     targetColumns: Seq[String]
   ): Seq[String] =
     SchemaResolver.columnsOnlyIn(targetColumns, sourceColumns)
+
+  private def isNumericType(dt: DataType): Boolean = dt match {
+    case FloatType | DoubleType | ByteType | ShortType | IntegerType | LongType | _: DecimalType =>
+      true
+    case _ => false
+  }
+
+  private[scylla] def detectSchemaTypeMismatches(
+    sourceSchema: StructType,
+    targetSchema: StructType,
+    columns: Seq[String],
+    policy: NumericTypePolicy
+  ): List[(String, String, String)] = {
+    if (policy == NumericTypePolicy.Lenient) return Nil
+
+    columns.flatMap { col =>
+      val srcField = sourceSchema.fields.find(_.name.equalsIgnoreCase(col))
+      val tgtField = targetSchema.fields.find(_.name.equalsIgnoreCase(col))
+      (srcField, tgtField) match {
+        case (Some(sf), Some(tf)) if sf.dataType != tf.dataType =>
+          // Guard uses && so cross-category mismatches (one numeric, one not) fall through
+          // to the policy-specific handling below.
+          if (!isNumericType(sf.dataType) && !isNumericType(tf.dataType)) None
+          else
+            policy match {
+              case NumericTypePolicy.StrictType =>
+                Some((col, sf.dataType.simpleString, tf.dataType.simpleString))
+              case NumericTypePolicy.DetectWiden =>
+                val isFloatDouble =
+                  (sf.dataType == FloatType && tf.dataType == DoubleType) ||
+                    (sf.dataType == DoubleType && tf.dataType == FloatType)
+                val isCrossCategory =
+                  isNumericType(sf.dataType) != isNumericType(tf.dataType)
+                if (isFloatDouble || isCrossCategory)
+                  Some((col, sf.dataType.simpleString, tf.dataType.simpleString))
+                else None
+              case NumericTypePolicy.Lenient => None
+            }
+        case _ => None
+      }
+    }.toList
+  }
 
   private[scylla] def normalizePrimaryKeyComponent(value: Any): Any = value match {
     case bytes: Array[Byte] => bytes.toIndexedSeq
@@ -665,16 +707,38 @@ object MySQLToScyllaValidator {
           targetColumns        = targetColumnNames
         )
 
+        val promotedToDirectCols =
+          if (validationConfig.numericTypePolicy == NumericTypePolicy.DetectWiden) {
+            val promoted = detectSchemaTypeMismatches(
+              rawSourceDF.schema,
+              rawTargetDF.schema,
+              renamedCols,
+              NumericTypePolicy.DetectWiden
+            ).map(_._1)
+            if (promoted.nonEmpty)
+              log.info(
+                s"Promoting hash-backed columns to direct comparison for DetectWiden: " +
+                  s"${promoted.mkString(", ")}"
+              )
+            promoted.map(_.toLowerCase(Locale.ROOT)).toSet
+          } else Set.empty[String]
+
+        val effectiveHashCols =
+          renamedCols.filterNot(c => promotedToDirectCols.contains(c.toLowerCase(Locale.ROOT)))
         val hashedSource =
-          addContentHash(rawSourceDF, renamedCols, renamedPK, dropHashedColumns = true)
+          if (effectiveHashCols.nonEmpty)
+            addContentHash(rawSourceDF, effectiveHashCols, renamedPK, dropHashedColumns = true)
+          else rawSourceDF
         val hashedTarget =
-          addContentHash(rawTargetDF, renamedCols, renamedPK, dropHashedColumns = true)
-        val hashBackedColumnsLower = renamedCols.map(_.toLowerCase(Locale.ROOT)).toSet
+          if (effectiveHashCols.nonEmpty)
+            addContentHash(rawTargetDF, effectiveHashCols, renamedPK, dropHashedColumns = true)
+          else rawTargetDF
+        val hashBackedColumnsLower = effectiveHashCols.map(_.toLowerCase(Locale.ROOT)).toSet
         val directCols = hashedSource.columns
           .filter(c => !renamedPKLower.contains(c.toLowerCase(Locale.ROOT)))
           .filter(_ != MySQL.ContentHashColumn)
           .filterNot(c => hashBackedColumnsLower.contains(c.toLowerCase(Locale.ROOT)))
-        (hashedSource, hashedTarget, directCols, renamedCols)
+        (hashedSource, hashedTarget, directCols, effectiveHashCols)
 
       case None =>
         val nonPKCols =
@@ -684,7 +748,7 @@ object MySQLToScyllaValidator {
 
     val targetColumnsLower = targetDF.columns.map(_.toLowerCase(Locale.ROOT)).toSet
     val droppedColumns =
-      (directComparableColumns ++ (if (hashColumns.isDefined) Seq(MySQL.ContentHashColumn)
+      (directComparableColumns ++ (if (hashBackedColumns.nonEmpty) Seq(MySQL.ContentHashColumn)
                                    else Nil))
         .filterNot(c => targetColumnsLower.contains(c.toLowerCase(Locale.ROOT)))
     if (droppedColumns.nonEmpty)
@@ -698,6 +762,32 @@ object MySQLToScyllaValidator {
     log.info(
       s"Comparable columns: ${(finalDirectComparableColumns ++ finalHashBackedColumns).mkString(", ")}"
     )
+
+    val numericPolicy = validationConfig.numericTypePolicy
+    val schemaTypeMismatchFields =
+      if (numericPolicy == NumericTypePolicy.StrictType && finalHashBackedColumns.nonEmpty)
+        detectSchemaTypeMismatches(
+          rawSourceDF.schema,
+          rawTargetDF.schema,
+          finalHashBackedColumns,
+          numericPolicy
+        )
+      else Nil
+    val schemaTypeMismatches: List[RowComparisonFailure] =
+      if (schemaTypeMismatchFields.isEmpty) Nil
+      else {
+        val desc = schemaTypeMismatchFields
+          .map { case (col, src, tgt) => s"$col ($src vs $tgt)" }
+          .mkString(", ")
+        log.error(s"Schema-level numeric type mismatches on hash-backed columns: $desc")
+        List(
+          RowComparisonFailure(
+            "[schema-level type mismatch]",
+            None,
+            List(RowComparisonFailure.Item.NumericTypeMismatch(schemaTypeMismatchFields))
+          )
+        )
+      }
 
     val sourcePrefixed = prefixColumns(sourceDF, "src_")
     val targetPrefixed = prefixColumns(targetDF, "tgt_")
@@ -723,7 +813,6 @@ object MySQLToScyllaValidator {
     val joinedSchemaFields = joined.schema.fieldNames
     val floatTol = validationConfig.floatingPointTolerance
     val tsTol = validationConfig.timestampMsTolerance
-    val numericPolicy = validationConfig.numericTypePolicy
 
     // Pre-compute field indices to avoid repeated case-insensitive lookups on every row.
     // For wide tables (100+ columns) × millions of rows, this provides significant speedup.
@@ -733,7 +822,7 @@ object MySQLToScyllaValidator {
       (colName, joinedSchemaFields.indexOf(srcFieldName), joinedSchemaFields.indexOf(tgtFieldName))
     }
     val contentHashFieldIndices =
-      if (hashColumns.isDefined) {
+      if (finalHashBackedColumns.nonEmpty) {
         val srcFieldName = resolveFieldName(joinedSchemaFields, s"src_${MySQL.ContentHashColumn}")
         val tgtFieldName = resolveFieldName(joinedSchemaFields, s"tgt_${MySQL.ContentHashColumn}")
         Some((joinedSchemaFields.indexOf(srcFieldName), joinedSchemaFields.indexOf(tgtFieldName)))
@@ -854,13 +943,14 @@ object MySQLToScyllaValidator {
           renamedPK,
           validationConfig.failuresToFetch - sourceSideFailures.size
         )
+    val allFailures = schemaTypeMismatches ++ failures
     log.info(
       s"Validation complete for ${sourceSettings.database}.${sourceSettings.table} -> " +
         s"${targetSettings.keyspace}.${targetSettings.table}. " +
-        s"Collected ${failures.size} failure(s) in sample."
+        s"Collected ${allFailures.size} failure(s) in sample."
     )
 
-    failures
+    allFailures
   }
 
   private[scylla] def resolveHashBackedDifferences(

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala
@@ -136,7 +136,8 @@ object ScyllaValidator {
           validationConfig.timestampMsTolerance,
           validationConfig.ttlToleranceMillis,
           validationConfig.writetimeToleranceMillis,
-          validationConfig.compareTimestamps
+          validationConfig.compareTimestamps,
+          validationConfig.numericTypePolicy
         )
       }
       .take(validationConfig.failuresToFetch)

--- a/migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala
@@ -1,8 +1,12 @@
 package com.scylladb.migrator.validation
 
 import com.datastax.spark.connector.CassandraRow
-import com.google.common.math.DoubleMath
 import com.scylladb.migrator.alternator.DdbValue
+import com.scylladb.migrator.validation.core.{
+  ComparisonResult,
+  NumericComparison,
+  NumericTypePolicy
+}
 
 import java.time.temporal.ChronoUnit
 
@@ -61,6 +65,12 @@ object RowComparisonFailure {
               s"$fieldName ($writeTimeDiff millis)"
             }
             .mkString(", ")}")
+    case class NumericTypeMismatch(fields: List[(String, String, String)])
+        extends Item(s"Numeric type mismatches: ${fields
+            .map { case (fieldName, srcType, tgtType) =>
+              s"$fieldName (source type $srcType vs target type $tgtType)"
+            }
+            .mkString(", ")}")
   }
 
   def cassandraRowComparisonFailure(
@@ -77,7 +87,8 @@ object RowComparisonFailure {
     timestampMsTolerance: Long,
     ttlToleranceMillis: Long,
     writetimeToleranceMillis: Long,
-    compareTimestamps: Boolean
+    compareTimestamps: Boolean,
+    numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient
   ): Option[RowComparisonFailure] =
     right match {
       case None => Some(cassandraRowComparisonFailure(left, right, List(Item.MissingTargetRow)))
@@ -91,14 +102,45 @@ object RowComparisonFailure {
         val leftMap = left.toMap
         val rightMap = right.toMap
 
-        val differingFieldValues =
-          for {
-            name <- names
-            if !name.endsWith("_ttl") && !name.endsWith("_writetime")
-            leftValue  = leftMap.get(name)
-            rightValue = rightMap.get(name)
-            if areDifferent(leftValue, rightValue, timestampMsTolerance, floatingPointTolerance)
-          } yield name
+        val (differingFieldValues, numericTypeMismatches) =
+          names
+            .filterNot(name => name.endsWith("_ttl") || name.endsWith("_writetime"))
+            .foldLeft(
+              (List.empty[String], List.empty[(String, String, String)])
+            ) { case ((diffs, mismatches), name) =>
+              val leftValue = leftMap.get(name)
+              val rightValue = rightMap.get(name)
+
+              (leftValue, rightValue) match {
+                case (Some(l: Number), Some(r: Number)) =>
+                  NumericComparison.compareWithPolicy(
+                    l,
+                    r,
+                    floatingPointTolerance,
+                    numericTypePolicy
+                  ) match {
+                    case ComparisonResult.Different =>
+                      (name :: diffs, mismatches)
+                    case ComparisonResult.TypeMismatch(src, tgt) =>
+                      (diffs, (name, src, tgt) :: mismatches)
+                    case ComparisonResult.Equal =>
+                      (diffs, mismatches)
+                  }
+                case _ =>
+                  if (
+                    areDifferent(
+                      leftValue,
+                      rightValue,
+                      timestampMsTolerance,
+                      floatingPointTolerance,
+                      numericTypePolicy
+                    )
+                  )
+                    (name :: diffs, mismatches)
+                  else
+                    (diffs, mismatches)
+              }
+            }
 
         val differingTtls =
           if (!compareTimestamps) Nil
@@ -138,7 +180,9 @@ object RowComparisonFailure {
                         }
             } yield result
 
-        if (differingFieldValues.isEmpty && differingTtls.isEmpty && differingWritetimes.isEmpty)
+        if (
+          differingFieldValues.isEmpty && numericTypeMismatches.isEmpty && differingTtls.isEmpty && differingWritetimes.isEmpty
+        )
           None
         else
           Some(
@@ -146,8 +190,11 @@ object RowComparisonFailure {
               left,
               Some(right),
               (if (differingFieldValues.nonEmpty)
-                 List(Item.DifferingFieldValues(differingFieldValues.toList))
+                 List(Item.DifferingFieldValues(differingFieldValues.reverse))
                else Nil) ++
+                (if (numericTypeMismatches.nonEmpty)
+                   List(Item.NumericTypeMismatch(numericTypeMismatches.reverse))
+                 else Nil) ++
                 (if (differingTtls.nonEmpty) List(Item.DifferingTtls(differingTtls.toList))
                  else Nil) ++
                 (if (differingWritetimes.nonEmpty)
@@ -180,7 +227,8 @@ object RowComparisonFailure {
     left: collection.Map[String, DdbValue],
     maybeRight: Option[collection.Map[String, DdbValue]],
     renamedColumn: String => String,
-    floatingPointTolerance: Double
+    floatingPointTolerance: Double,
+    numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient
   ): Option[RowComparisonFailure] =
     maybeRight match {
       case None => Some(dynamoDBRowComparisonFailure(left, maybeRight, List(Item.MissingTargetRow)))
@@ -197,7 +245,8 @@ object RowComparisonFailure {
               Some(leftValue),
               rightValue,
               0L, // There is no Timestamp type in DynamoDB
-              floatingPointTolerance
+              floatingPointTolerance,
+              numericTypePolicy
             )
           } yield columnName
         if (differingFieldValues.isEmpty) None
@@ -226,7 +275,8 @@ object RowComparisonFailure {
     leftValue: Option[Any],
     rightValue: Option[Any],
     timestampMsTolerance: Long,
-    floatingPointTolerance: Double
+    floatingPointTolerance: Double,
+    numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient
   ): Boolean =
     (leftValue, rightValue) match {
       // All timestamp types need to be compared with a configured tolerance
@@ -238,13 +288,13 @@ object RowComparisonFailure {
         Math.abs(r.until(l, ChronoUnit.MILLIS)) > timestampMsTolerance
       case (Some(l: java.time.Instant), Some(r: java.time.Instant)) =>
         l != r
-      // All floating-point-like types need to be compared with a configured tolerance
-      case (Some(l: Float), Some(r: Float)) =>
-        !DoubleMath.fuzzyEquals(l, r, floatingPointTolerance)
-      case (Some(l: Double), Some(r: Double)) =>
-        !DoubleMath.fuzzyEquals(l, r, floatingPointTolerance)
-      case (Some(l: java.math.BigDecimal), Some(r: java.math.BigDecimal)) =>
-        areNumericalValuesDifferent(l, r, floatingPointTolerance)
+      case (Some(l: Number), Some(r: Number)) =>
+        NumericComparison.compareWithPolicy(
+          l,
+          r,
+          floatingPointTolerance,
+          numericTypePolicy
+        ) != ComparisonResult.Equal
 
       // CQL blobs get converted to byte buffers by the Java driver, and the
       // byte buffers are converted to byte arrays by the Spark connector.
@@ -257,20 +307,40 @@ object RowComparisonFailure {
 
       // Special cases for DynamoDB item values
       case (Some(DdbValue.N(l)), Some(DdbValue.N(r))) =>
-        areNumericalValuesDifferent(BigDecimal(l), BigDecimal(r), floatingPointTolerance)
+        NumericComparison.areNumericalValuesDifferent(
+          BigDecimal(l),
+          BigDecimal(r),
+          floatingPointTolerance
+        )
       case (Some(DdbValue.Ns(l)), Some(DdbValue.Ns(r))) =>
         val xs = l.toSeq.map(BigDecimal(_)).sorted
         val ys = r.toSeq.map(BigDecimal(_)).sorted
         xs.size != ys.size || xs.zip(ys).exists { case (x, y) =>
-          areNumericalValuesDifferent(x, y, floatingPointTolerance)
+          NumericComparison.areNumericalValuesDifferent(
+            x,
+            y,
+            floatingPointTolerance
+          )
         }
       case (Some(DdbValue.L(l)), Some(DdbValue.L(r))) =>
         l.size != r.size || l.zip(r).exists { case (lv, rv) =>
-          areDifferent(Some(lv), Some(rv), timestampMsTolerance, floatingPointTolerance)
+          areDifferent(
+            Some(lv),
+            Some(rv),
+            timestampMsTolerance,
+            floatingPointTolerance,
+            numericTypePolicy
+          )
         }
       case (Some(DdbValue.M(l)), Some(DdbValue.M(r))) =>
         l.size != r.size || l.keySet != r.keySet || l.exists { case (k, lv) =>
-          areDifferent(Some(lv), r.get(k), timestampMsTolerance, floatingPointTolerance)
+          areDifferent(
+            Some(lv),
+            r.get(k),
+            timestampMsTolerance,
+            floatingPointTolerance,
+            numericTypePolicy
+          )
         }
 
       // All remaining types get compared with standard equality
@@ -279,12 +349,4 @@ object RowComparisonFailure {
       case (None, Some(_))    => true
       case (None, None)       => false
     }
-
-  /** @return true iff the difference between `x` and `y` is greater than the `tolerance` */
-  private def areNumericalValuesDifferent(
-    x: BigDecimal,
-    y: BigDecimal,
-    tolerance: BigDecimal
-  ): Boolean =
-    (x - y).abs > tolerance
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/validation/core/ContentHashJoiner.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/validation/core/ContentHashJoiner.scala
@@ -88,6 +88,17 @@ object ContentHashJoiner {
         None
     }.toList
 
+  /** Compare fields split into direct and hash-backed groups. Direct columns are compared first via
+    * [[RowComparisonFailure.areDifferent]], which delegates to
+    * [[NumericComparison.compareWithPolicy]] for Number pairs — so StrictType/DetectWiden type
+    * mismatches (e.g. Float(1.5f) vs Double(1.5d)) are caught at this stage. Hash-backed columns
+    * skip per-value comparison when content hashes match. Because the hash is computed over
+    * string-cast values, it is type-erasing and cannot detect per-value numeric type mismatches.
+    * This gap is addressed in [[com.scylladb.migrator.scylla.MySQLToScyllaValidator]]: under
+    * DetectWiden, Float/Double and cross-category (numeric vs non-numeric) hash-backed columns are
+    * promoted to direct comparison so per-value checks run; under StrictType, schema-level type
+    * mismatches on remaining hash-backed columns are reported as errors.
+    */
   def compareFieldsBySchemaForRow(
     joinedRow: Row,
     directFieldIndices: Seq[(String, Int, Int)],

--- a/migrator/src/main/scala/com/scylladb/migrator/validation/core/ContentHashJoiner.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/validation/core/ContentHashJoiner.scala
@@ -1,0 +1,162 @@
+package com.scylladb.migrator.validation.core
+
+import com.scylladb.migrator.readers.MySQL
+import com.scylladb.migrator.validation.RowComparisonFailure
+import org.apache.logging.log4j.LogManager
+import org.apache.spark.sql.{ Column, DataFrame, Row }
+import org.apache.spark.sql.functions.{ base64, concat, concat_ws, lit, sha2, when }
+import org.apache.spark.sql.types.{ BinaryType, StringType }
+import java.util.Locale
+
+object ContentHashJoiner {
+  private val log = LogManager.getLogger("com.scylladb.migrator.validation.core.ContentHashJoiner")
+
+  val ContentHashColumn: String = MySQL.ContentHashColumn
+
+  def addContentHash(
+    df: DataFrame,
+    hashCols: List[String],
+    pkCols: List[String],
+    dropHashedColumns: Boolean = true
+  ): DataFrame = {
+    val dfColsLower = df.columns.map(_.toLowerCase(Locale.ROOT)).toSet
+    require(
+      !dfColsLower.contains(ContentHashColumn.toLowerCase(Locale.ROOT)),
+      s"Source/target table contains a column named '$ContentHashColumn' which conflicts " +
+        "with the internal hash column. Rename the column or disable hash-based validation."
+    )
+    val existingHashCols = hashCols.filter(c => dfColsLower.contains(c.toLowerCase(Locale.ROOT)))
+    if (existingHashCols.isEmpty) {
+      log.warn("No hash columns found in DataFrame. Skipping hash computation.")
+      df
+    } else {
+      val dfCols = df.columns
+      def resolveCol(name: String): String =
+        dfCols.find(_.equalsIgnoreCase(name)).getOrElse(name)
+      val resolvedHashCols =
+        existingHashCols.map(resolveCol).sortBy(_.toLowerCase(Locale.ROOT))
+
+      log.info(
+        s"Computing content hash for columns: ${resolvedHashCols.mkString(", ")}"
+      )
+
+      val contentHashBits = 256
+      val perColHashes = resolvedHashCols.map { c =>
+        val encodedValue = df.schema(c).dataType match {
+          case BinaryType => base64(SchemaResolver.sparkColumn(c))
+          case _          => SchemaResolver.sparkColumn(c).cast(StringType)
+        }
+        when(SchemaResolver.sparkColumn(c).isNull, sha2(lit("1|"), contentHashBits))
+          .otherwise(sha2(concat(lit("0|"), encodedValue), contentHashBits))
+      }
+      val hashCol = sha2(concat_ws("|", perColHashes: _*), contentHashBits)
+      val withHash = df.withColumn(ContentHashColumn, hashCol)
+
+      if (!dropHashedColumns) withHash
+      else {
+        val pkColsLower = pkCols.map(_.toLowerCase(Locale.ROOT)).toSet
+        val colsToDrop = resolvedHashCols
+          .filterNot(c => pkColsLower.contains(c.toLowerCase(Locale.ROOT)))
+        colsToDrop.foldLeft(withHash) { (d, c) =>
+          d.drop(c)
+        }
+      }
+    }
+  }
+
+  def differingFieldNamesForRow(
+    joinedRow: Row,
+    fieldIndices: Seq[(String, Int, Int)],
+    timestampMsTolerance: Long,
+    floatingPointTolerance: Double,
+    numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient
+  ): List[String] =
+    fieldIndices.flatMap { case (colName, srcIdx, tgtIdx) =>
+      val srcVal = if (joinedRow.isNullAt(srcIdx)) None else Some(joinedRow.get(srcIdx))
+      val tgtVal = if (joinedRow.isNullAt(tgtIdx)) None else Some(joinedRow.get(tgtIdx))
+      if (
+        RowComparisonFailure.areDifferent(
+          srcVal,
+          tgtVal,
+          timestampMsTolerance,
+          floatingPointTolerance,
+          numericTypePolicy
+        )
+      )
+        Some(colName)
+      else
+        None
+    }.toList
+
+  def compareFieldsBySchemaForRow(
+    joinedRow: Row,
+    directFieldIndices: Seq[(String, Int, Int)],
+    hashBackedFieldIndices: Seq[(String, Int, Int)],
+    contentHashFieldIndices: Option[(Int, Int)],
+    timestampMsTolerance: Long,
+    floatingPointTolerance: Double,
+    numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient
+  ): List[String] = {
+    val directDifferences =
+      differingFieldNamesForRow(
+        joinedRow,
+        directFieldIndices,
+        timestampMsTolerance,
+        floatingPointTolerance,
+        numericTypePolicy
+      )
+
+    val hashBackedDifferences = contentHashFieldIndices match {
+      case Some((srcHashIdx, tgtHashIdx)) =>
+        val srcHash = if (joinedRow.isNullAt(srcHashIdx)) None else Some(joinedRow.get(srcHashIdx))
+        val tgtHash = if (joinedRow.isNullAt(tgtHashIdx)) None else Some(joinedRow.get(tgtHashIdx))
+        if (
+          RowComparisonFailure.areDifferent(
+            srcHash,
+            tgtHash,
+            timestampMsTolerance,
+            floatingPointTolerance,
+            numericTypePolicy
+          )
+        )
+          differingFieldNamesForRow(
+            joinedRow,
+            hashBackedFieldIndices,
+            timestampMsTolerance,
+            floatingPointTolerance,
+            numericTypePolicy
+          )
+        else
+          Nil
+      case None =>
+        differingFieldNamesForRow(
+          joinedRow,
+          hashBackedFieldIndices,
+          timestampMsTolerance,
+          floatingPointTolerance,
+          numericTypePolicy
+        )
+    }
+
+    directDifferences ++ hashBackedDifferences
+  }
+
+  def hasContentHashMismatch(
+    joinedRow: Row,
+    contentHashFieldIndices: Option[(Int, Int)],
+    timestampMsTolerance: Long,
+    floatingPointTolerance: Double,
+    numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient
+  ): Boolean =
+    contentHashFieldIndices.exists { case (srcHashIdx, tgtHashIdx) =>
+      val srcHash = if (joinedRow.isNullAt(srcHashIdx)) None else Some(joinedRow.get(srcHashIdx))
+      val tgtHash = if (joinedRow.isNullAt(tgtHashIdx)) None else Some(joinedRow.get(tgtHashIdx))
+      RowComparisonFailure.areDifferent(
+        srcHash,
+        tgtHash,
+        timestampMsTolerance,
+        floatingPointTolerance,
+        numericTypePolicy
+      )
+    }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/validation/core/ExtraRowDetector.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/validation/core/ExtraRowDetector.scala
@@ -1,0 +1,32 @@
+package com.scylladb.migrator.validation.core
+
+import com.scylladb.migrator.validation.RowComparisonFailure
+import org.apache.spark.sql.DataFrame
+
+object ExtraRowDetector {
+
+  def collectExtraTargetFailureSample(
+    sourceKeys: DataFrame,
+    targetKeys: DataFrame,
+    primaryKeyColumns: Seq[String],
+    failuresToFetch: Int
+  ): List[RowComparisonFailure] =
+    if (failuresToFetch <= 0) Nil
+    else
+      targetKeys
+        .join(sourceKeys.distinct(), primaryKeyColumns, "left_anti")
+        .rdd
+        .map { row =>
+          val targetRepr =
+            primaryKeyColumns
+              .map(pk => s"$pk=${row.getAs[Any](pk)}")
+              .mkString(", ")
+          RowComparisonFailure(
+            targetRepr,
+            None,
+            List(RowComparisonFailure.Item.ExtraTargetRow)
+          )
+        }
+        .take(failuresToFetch)
+        .toList
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/validation/core/KeyDrivenLookup.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/validation/core/KeyDrivenLookup.scala
@@ -1,0 +1,64 @@
+package com.scylladb.migrator.validation.core
+
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql.{ CassandraConnector, TableDef }
+import com.datastax.spark.connector.rdd.ReadConf
+import com.scylladb.migrator.readers
+import com.scylladb.migrator.config.TargetSettings
+import org.apache.spark.sql.cassandra.{ CassandraSQLRow, DataTypeConverter }
+import org.apache.spark.sql.{ DataFrame, Row, SparkSession }
+import org.apache.spark.sql.types.StructType
+
+object KeyDrivenLookup {
+
+  def resolveTargetColumns(
+    targetTableDef: TableDef,
+    columns: Seq[String]
+  ): Seq[String] = {
+    val targetFields = targetTableDef.columns.map(_.columnName).toArray
+    columns.map(SchemaResolver.resolveFieldName(targetFields, _))
+  }
+
+  def buildTargetSchema(
+    targetTableDef: TableDef,
+    selectedColumns: Seq[String]
+  ): StructType =
+    StructType(
+      selectedColumns.map { columnName =>
+        DataTypeConverter.toStructField(targetTableDef.columnByName(columnName))
+      }
+    )
+
+  def lookupTargetRowsForSourceKeys(
+    spark: SparkSession,
+    sourceDF: DataFrame,
+    targetConnector: CassandraConnector,
+    targetTableDef: TableDef,
+    targetSettings: TargetSettings.Scylla,
+    primaryKeyColumns: Seq[String],
+    selectedColumns: Seq[String],
+    readConf: ReadConf
+  ): DataFrame = {
+    val sourceSchemaFields = sourceDF.schema.fieldNames
+    val resolvedSourcePK =
+      primaryKeyColumns.map(SchemaResolver.resolveFieldName(sourceSchemaFields, _))
+    val resolvedTargetPK = resolveTargetColumns(targetTableDef, primaryKeyColumns)
+    val resolvedSelectedColumns = resolveTargetColumns(targetTableDef, selectedColumns)
+    val schema = buildTargetSchema(targetTableDef, resolvedSelectedColumns)
+    val targetRows = sourceDF
+      .select(resolvedSourcePK.map(SchemaResolver.sparkColumn): _*)
+      .distinct()
+      .rdd
+      .leftJoinWithCassandraTable[CassandraSQLRow](
+        targetSettings.keyspace,
+        targetSettings.table,
+        SomeColumns(resolvedSelectedColumns.map(ColumnName(_)): _*),
+        SomeColumns(resolvedTargetPK.map(ColumnName(_)): _*),
+        readConf
+      )
+      .withConnector(targetConnector)
+      .flatMap(_._2)
+      .map(row => Row.fromSeq(row.toSeq.map(readers.Cassandra.convertValue)))
+    spark.createDataFrame(targetRows, schema)
+  }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/validation/core/NumericComparison.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/validation/core/NumericComparison.scala
@@ -78,6 +78,11 @@ object NumericComparison {
     }
   }
 
+  /** Integral pairs (both normalize to BigInt) use strict equality — tolerance is not applied. When
+    * at least one side is floating-point or decimal, tolerance is applied via
+    * [[areNumericalValuesDifferent]]. This asymmetry is intentional: integral values have exact
+    * representations, so tolerance-based comparison would mask genuine differences.
+    */
   def areNumbersDifferent(left: Number, right: Number, tolerance: Double): Boolean = {
     val leftSpecial = floatingPointSpecial(left)
     val rightSpecial = floatingPointSpecial(right)
@@ -87,20 +92,13 @@ object NumericComparison {
       case (Some(InfinityValue(lSign)), Some(InfinityValue(rSign))) => lSign != rSign
       case (Some(_), _) | (_, Some(_))                              => true
       case (None, None) =>
-        if (tolerance > 0) {
-          (normalizedDecimalValue(left), normalizedDecimalValue(right)) match {
-            case (Some(l), Some(r)) => areNumericalValuesDifferent(l, r, tolerance)
-            case _                  => left != right
-          }
-        } else {
-          (normalizedIntegralValue(left), normalizedIntegralValue(right)) match {
-            case (Some(l), Some(r)) => l != r
-            case _ =>
-              (normalizedDecimalValue(left), normalizedDecimalValue(right)) match {
-                case (Some(l), Some(r)) => areNumericalValuesDifferent(l, r, tolerance)
-                case _                  => left != right
-              }
-          }
+        (normalizedIntegralValue(left), normalizedIntegralValue(right)) match {
+          case (Some(l), Some(r)) => l != r
+          case _ =>
+            (normalizedDecimalValue(left), normalizedDecimalValue(right)) match {
+              case (Some(l), Some(r)) => areNumericalValuesDifferent(l, r, tolerance)
+              case _                  => left != right
+            }
         }
     }
   }

--- a/migrator/src/main/scala/com/scylladb/migrator/validation/core/NumericComparison.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/validation/core/NumericComparison.scala
@@ -1,0 +1,157 @@
+package com.scylladb.migrator.validation.core
+
+sealed trait NumericTypePolicy
+object NumericTypePolicy {
+  case object Lenient extends NumericTypePolicy
+  case object DetectWiden extends NumericTypePolicy
+  case object StrictType extends NumericTypePolicy
+
+  implicit val encoder: io.circe.Encoder[NumericTypePolicy] =
+    io.circe.Encoder.encodeString.contramap {
+      case Lenient     => "Lenient"
+      case DetectWiden => "DetectWiden"
+      case StrictType  => "StrictType"
+    }
+
+  implicit val decoder: io.circe.Decoder[NumericTypePolicy] =
+    io.circe.Decoder.decodeString.emap {
+      case s if s.equalsIgnoreCase("Lenient")     => Right(Lenient)
+      case s if s.equalsIgnoreCase("DetectWiden") => Right(DetectWiden)
+      case s if s.equalsIgnoreCase("StrictType")  => Right(StrictType)
+      case other =>
+        Left(s"Invalid numericTypePolicy '$other'. Allowed: Lenient, DetectWiden, StrictType")
+    }
+}
+
+sealed trait ComparisonResult
+object ComparisonResult {
+  case object Equal extends ComparisonResult
+  case object Different extends ComparisonResult
+  case class TypeMismatch(srcType: String, tgtType: String) extends ComparisonResult
+}
+
+object NumericComparison {
+  import ComparisonResult._
+
+  private sealed trait FloatingPointSpecial
+  private case object NaNValue extends FloatingPointSpecial
+  private case class InfinityValue(sign: Int) extends FloatingPointSpecial
+
+  def compareWithPolicy(
+    left: Number,
+    right: Number,
+    tolerance: Double,
+    policy: NumericTypePolicy
+  ): ComparisonResult = {
+    val areValuesDifferent = areNumbersDifferent(left, right, tolerance)
+    if (areValuesDifferent) {
+      Different
+    } else {
+      policy match {
+        case NumericTypePolicy.Lenient => Equal
+        case NumericTypePolicy.StrictType =>
+          if (left.getClass != right.getClass)
+            TypeMismatch(left.getClass.getSimpleName, right.getClass.getSimpleName)
+          else
+            Equal
+        case NumericTypePolicy.DetectWiden =>
+          val leftIsFloat = left.isInstanceOf[java.lang.Float]
+          val leftIsDouble = left.isInstanceOf[java.lang.Double]
+          val rightIsFloat = right.isInstanceOf[java.lang.Float]
+          val rightIsDouble = right.isInstanceOf[java.lang.Double]
+
+          if ((leftIsFloat && rightIsDouble) || (leftIsDouble && rightIsFloat)) {
+            val (fVal, dVal) = if (leftIsFloat) {
+              (left.floatValue(), right.doubleValue())
+            } else {
+              (right.floatValue(), left.doubleValue())
+            }
+            if ((fVal.isNaN && dVal.isNaN) || fVal.toDouble == dVal) {
+              Equal
+            } else {
+              TypeMismatch(left.getClass.getSimpleName, right.getClass.getSimpleName)
+            }
+          } else {
+            Equal
+          }
+      }
+    }
+  }
+
+  def areNumbersDifferent(left: Number, right: Number, tolerance: Double): Boolean = {
+    val leftSpecial = floatingPointSpecial(left)
+    val rightSpecial = floatingPointSpecial(right)
+
+    (leftSpecial, rightSpecial) match {
+      case (Some(NaNValue), Some(NaNValue))                         => false
+      case (Some(InfinityValue(lSign)), Some(InfinityValue(rSign))) => lSign != rSign
+      case (Some(_), _) | (_, Some(_))                              => true
+      case (None, None) =>
+        if (tolerance > 0) {
+          (normalizedDecimalValue(left), normalizedDecimalValue(right)) match {
+            case (Some(l), Some(r)) => areNumericalValuesDifferent(l, r, tolerance)
+            case _                  => left != right
+          }
+        } else {
+          (normalizedIntegralValue(left), normalizedIntegralValue(right)) match {
+            case (Some(l), Some(r)) => l != r
+            case _ =>
+              (normalizedDecimalValue(left), normalizedDecimalValue(right)) match {
+                case (Some(l), Some(r)) => areNumericalValuesDifferent(l, r, tolerance)
+                case _                  => left != right
+              }
+          }
+        }
+    }
+  }
+
+  private def floatingPointSpecial(value: Number): Option[FloatingPointSpecial] =
+    value match {
+      case d: java.lang.Double if d.isNaN      => Some(NaNValue)
+      case d: java.lang.Double if d.isInfinite => Some(InfinityValue(Math.signum(d).toInt))
+      case f: java.lang.Float if f.isNaN       => Some(NaNValue)
+      case f: java.lang.Float if f.isInfinite  => Some(InfinityValue(Math.signum(f).toInt))
+      case _                                   => None
+    }
+
+  def normalizedIntegralValue(value: Number): Option[BigInt] =
+    value match {
+      case b: java.lang.Byte        => Some(BigInt(b.longValue))
+      case s: java.lang.Short       => Some(BigInt(s.longValue))
+      case i: java.lang.Integer     => Some(BigInt(i.longValue))
+      case l: java.lang.Long        => Some(BigInt(l.longValue))
+      case bi: java.math.BigInteger => Some(BigInt(bi))
+      case bi: BigInt               => Some(bi)
+      case bd: java.math.BigDecimal =>
+        val stripped = bd.stripTrailingZeros
+        if (stripped.scale <= 0) Some(BigInt(stripped.toBigIntegerExact)) else None
+      case bd: BigDecimal =>
+        val stripped = bd.bigDecimal.stripTrailingZeros
+        if (stripped.scale <= 0) Some(BigInt(stripped.toBigIntegerExact)) else None
+      case _ => None
+    }
+
+  def normalizedDecimalValue(value: Number): Option[BigDecimal] =
+    value match {
+      case d: java.lang.Double if d.isNaN || d.isInfinite => None
+      case f: java.lang.Float if f.isNaN || f.isInfinite  => None
+      case b: java.lang.Byte                              => Some(BigDecimal(BigInt(b.longValue)))
+      case s: java.lang.Short                             => Some(BigDecimal(BigInt(s.longValue)))
+      case i: java.lang.Integer                           => Some(BigDecimal(BigInt(i.longValue)))
+      case l: java.lang.Long                              => Some(BigDecimal(BigInt(l.longValue)))
+      case bi: java.math.BigInteger                       => Some(BigDecimal(BigInt(bi)))
+      case bi: BigInt                                     => Some(BigDecimal(bi))
+      case bd: java.math.BigDecimal                       => Some(BigDecimal(bd))
+      case bd: BigDecimal                                 => Some(bd)
+      case f: java.lang.Float                             => Some(BigDecimal.decimal(f.doubleValue))
+      case d: java.lang.Double                            => Some(BigDecimal.decimal(d.doubleValue))
+      case _                                              => None
+    }
+
+  def areNumericalValuesDifferent(
+    x: BigDecimal,
+    y: BigDecimal,
+    tolerance: BigDecimal
+  ): Boolean =
+    (x - y).abs > tolerance
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/validation/core/SchemaResolver.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/validation/core/SchemaResolver.scala
@@ -1,0 +1,45 @@
+package com.scylladb.migrator.validation.core
+
+import com.scylladb.migrator.config.Rename
+import org.apache.spark.sql.{ Column, DataFrame }
+import org.apache.spark.sql.functions.col
+import java.util.Locale
+
+object SchemaResolver {
+
+  def buildCaseInsensitiveRenameMap(
+    renames: List[Rename]
+  ): Map[String, String] =
+    renames
+      .groupBy(_.from.toLowerCase(Locale.ROOT))
+      .view
+      .map { case (sourceName, entries) =>
+        val targets = entries.map(_.to).distinct
+        if (targets.size > 1)
+          sys.error(
+            s"Renames contain conflicting case-insensitive mappings for source column '${sourceName}': " +
+              s"${targets.mkString(", ")}"
+          )
+        sourceName -> targets.head
+      }
+      .toMap
+
+  def escapeSparkColumnName(name: String): String =
+    s"`${name.replace("`", "``")}`"
+
+  def sparkColumn(name: String): Column =
+    col(escapeSparkColumnName(name))
+
+  def resolveFieldName(fields: Array[String], name: String): String =
+    fields
+      .find(_.equalsIgnoreCase(name))
+      .getOrElse(
+        sys.error(
+          s"Column '$name' not found in schema. Available columns: ${fields.mkString(", ")}. " +
+            "This may indicate a missing rename entry or schema mismatch."
+        )
+      )
+
+  def prefixColumns(df: DataFrame, prefix: String): DataFrame =
+    df.select(df.columns.toIndexedSeq.map(c => sparkColumn(c).as(s"$prefix$c")): _*)
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidatorTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidatorTest.scala
@@ -5,7 +5,7 @@ import com.scylladb.migrator.readers.MySQL
 import com.scylladb.migrator.validation.RowComparisonFailure
 import org.apache.spark.sql.{ Row, SparkSession }
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.types.{ IntegerType, StringType, StructField, StructType }
+import org.apache.spark.sql.types._
 
 import java.lang.reflect.{ InvocationHandler, Method, Proxy }
 import java.sql.{ DatabaseMetaData, ResultSet }
@@ -919,5 +919,138 @@ class MySQLToScyllaValidatorTest extends munit.FunSuite {
     assertEquals(failures.map(_.rowRepr), List("id=2"))
     assert(sourceReads.value == 1L)
     assert(targetReads.value == 1L)
+  }
+
+  test("detectSchemaTypeMismatches under Lenient returns no mismatches") {
+    val src = StructType(Seq(StructField("price", FloatType), StructField("id", IntegerType)))
+    val tgt = StructType(Seq(StructField("price", DoubleType), StructField("id", IntegerType)))
+    val result = MySQLToScyllaValidator.detectSchemaTypeMismatches(
+      src,
+      tgt,
+      Seq("price"),
+      com.scylladb.migrator.validation.core.NumericTypePolicy.Lenient
+    )
+    assertEquals(result, Nil)
+  }
+
+  test("detectSchemaTypeMismatches under StrictType flags any numeric type difference") {
+    val src = StructType(
+      Seq(
+        StructField("price", FloatType),
+        StructField("count", IntegerType),
+        StructField("name", StringType)
+      )
+    )
+    val tgt = StructType(
+      Seq(
+        StructField("price", DoubleType),
+        StructField("count", LongType),
+        StructField("name", StringType)
+      )
+    )
+    val result = MySQLToScyllaValidator.detectSchemaTypeMismatches(
+      src,
+      tgt,
+      Seq("price", "count", "name"),
+      com.scylladb.migrator.validation.core.NumericTypePolicy.StrictType
+    )
+    assertEquals(result.map(_._1), List("price", "count"))
+    assertEquals(result.map(_._2), List("float", "int"))
+    assertEquals(result.map(_._3), List("double", "bigint"))
+  }
+
+  test("detectSchemaTypeMismatches under DetectWiden only flags Float vs Double") {
+    val src = StructType(
+      Seq(StructField("price", FloatType), StructField("count", IntegerType))
+    )
+    val tgt = StructType(
+      Seq(StructField("price", DoubleType), StructField("count", LongType))
+    )
+    val result = MySQLToScyllaValidator.detectSchemaTypeMismatches(
+      src,
+      tgt,
+      Seq("price", "count"),
+      com.scylladb.migrator.validation.core.NumericTypePolicy.DetectWiden
+    )
+    assertEquals(result.map(_._1), List("price"))
+  }
+
+  test("detectSchemaTypeMismatches ignores non-numeric type differences") {
+    val src = StructType(Seq(StructField("data", StringType)))
+    val tgt = StructType(Seq(StructField("data", BinaryType)))
+    val result = MySQLToScyllaValidator.detectSchemaTypeMismatches(
+      src,
+      tgt,
+      Seq("data"),
+      com.scylladb.migrator.validation.core.NumericTypePolicy.StrictType
+    )
+    assertEquals(result, Nil)
+  }
+
+  test("detectSchemaTypeMismatches under DetectWiden flags cross-category numeric vs non-numeric") {
+    val src = StructType(
+      Seq(StructField("score", IntegerType), StructField("label", StringType))
+    )
+    val tgt = StructType(
+      Seq(StructField("score", StringType), StructField("label", StringType))
+    )
+    val result = MySQLToScyllaValidator.detectSchemaTypeMismatches(
+      src,
+      tgt,
+      Seq("score", "label"),
+      com.scylladb.migrator.validation.core.NumericTypePolicy.DetectWiden
+    )
+    assertEquals(result.map(_._1), List("score"))
+    assertEquals(result.map(_._2), List("int"))
+    assertEquals(result.map(_._3), List("string"))
+  }
+
+  test("all hash columns promoted under DetectWiden produces no content hash column") {
+    import spark.implicits._
+    val source = Seq((1, 1.0f, 2.0f)).toDF("id", "price", "rate")
+    val target = Seq((1, 1.0d, 2.0d)).toDF("id", "price", "rate")
+
+    val hashCols = Seq("price", "rate")
+    val mismatches = MySQLToScyllaValidator.detectSchemaTypeMismatches(
+      source.schema,
+      target.schema,
+      hashCols,
+      com.scylladb.migrator.validation.core.NumericTypePolicy.DetectWiden
+    )
+    assertEquals(mismatches.map(_._1).sorted, List("price", "rate"))
+
+    val promoted = mismatches.map(_._1.toLowerCase(java.util.Locale.ROOT)).toSet
+    val effectiveHashCols =
+      hashCols.filterNot(c => promoted.contains(c.toLowerCase(java.util.Locale.ROOT)))
+    assert(effectiveHashCols.isEmpty)
+
+    assert(!source.columns.contains(MySQL.ContentHashColumn))
+    assert(!target.columns.contains(MySQL.ContentHashColumn))
+  }
+
+  test("compareFieldsBySchemaForRow works with no content hash indices (all promoted)") {
+    val row = Row(1.0f, 1.0d)
+    val result = MySQLToScyllaValidator.compareFieldsBySchemaForRow(
+      joinedRow               = row,
+      directFieldIndices      = Seq(("price", 0, 1)),
+      hashBackedFieldIndices  = Nil,
+      contentHashFieldIndices = None,
+      timestampMsTolerance    = 0L,
+      floatingPointTolerance  = 0.01
+    )
+    assertEquals(result, Nil)
+  }
+
+  test("detectSchemaTypeMismatches returns empty when types match") {
+    val schema = StructType(
+      Seq(StructField("price", DoubleType), StructField("count", LongType))
+    )
+    val result = MySQLToScyllaValidator.detectSchemaTypeMismatches(
+      schema,
+      schema,
+      Seq("price", "count"),
+      com.scylladb.migrator.validation.core.NumericTypePolicy.StrictType
+    )
+    assertEquals(result, Nil)
   }
 }

--- a/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
@@ -2,6 +2,7 @@ package com.scylladb.migrator.validation
 
 import com.datastax.spark.connector.CassandraRow
 import com.scylladb.migrator.validation.RowComparisonFailure.{ cassandraRowComparisonFailure, Item }
+import com.scylladb.migrator.validation.core.NumericTypePolicy
 
 class CassandraRowComparisonTest extends munit.FunSuite {
 
@@ -102,21 +103,76 @@ class CassandraRowComparisonTest extends munit.FunSuite {
     assertEquals(result, expected)
   }
 
-  test("BigDecimal and integral wrappers remain different for Cassandra validation") {
+  test("BigDecimal and integral wrappers are equal under Lenient policy") {
     val left = CassandraRow.fromMap(Map("foo" -> new java.math.BigDecimal("42.0")))
     val right = CassandraRow.fromMap(Map("foo" -> 42L))
 
     val result = compareItems(left, Some(right))
-    val expected =
+    assertEquals(result, None)
+  }
+
+  test("Float vs Double under different policies") {
+    val left = CassandraRow.fromMap(Map("foo" -> 0.1f))
+    val right = CassandraRow.fromMap(Map("foo" -> 0.1))
+
+    // Lenient treats them as equal (under default tolerance)
+    assertEquals(
+      RowComparisonFailure.compareCassandraRows(
+        left,
+        Some(right),
+        0.01,
+        1,
+        1,
+        1,
+        true,
+        NumericTypePolicy.Lenient
+      ),
+      None
+    )
+
+    // DetectWiden flags lossy widening as TypeMismatch
+    assertEquals(
+      RowComparisonFailure.compareCassandraRows(
+        left,
+        Some(right),
+        0.01,
+        1,
+        1,
+        1,
+        true,
+        NumericTypePolicy.DetectWiden
+      ),
       Some(
-        cassandraRowComparisonFailure(
+        RowComparisonFailure.cassandraRowComparisonFailure(
           left,
           Some(right),
-          List(Item.DifferingFieldValues(List("foo")))
+          List(Item.NumericTypeMismatch(List(("foo", "Float", "Double"))))
         )
       )
+    )
 
-    assertEquals(result, expected)
+    // StrictType flags any Float/Double pair as TypeMismatch
+    val leftLossless = CassandraRow.fromMap(Map("foo" -> 1.5f))
+    val rightLossless = CassandraRow.fromMap(Map("foo" -> 1.5))
+    assertEquals(
+      RowComparisonFailure.compareCassandraRows(
+        leftLossless,
+        Some(rightLossless),
+        0.01,
+        1,
+        1,
+        1,
+        true,
+        NumericTypePolicy.StrictType
+      ),
+      Some(
+        RowComparisonFailure.cassandraRowComparisonFailure(
+          leftLossless,
+          Some(rightLossless),
+          List(Item.NumericTypeMismatch(List(("foo", "Float", "Double"))))
+        )
+      )
+    )
   }
 
 }

--- a/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
@@ -175,4 +175,48 @@ class CassandraRowComparisonTest extends munit.FunSuite {
     )
   }
 
+  test("Direct areDifferent flags Float(1.5f) vs Double(1.5d) before hash comparison") {
+    val floatVal: Option[Any] = Some(java.lang.Float.valueOf(1.5f))
+    val doubleVal: Option[Any] = Some(java.lang.Double.valueOf(1.5))
+
+    // StrictType: flags type mismatch even though values are numerically equal
+    assertEquals(
+      RowComparisonFailure
+        .areDifferent(floatVal, doubleVal, 0L, 0.01, NumericTypePolicy.StrictType),
+      true
+    )
+
+    // DetectWiden: 1.5f widens losslessly to 1.5d, so NOT flagged
+    assertEquals(
+      RowComparisonFailure.areDifferent(
+        floatVal,
+        doubleVal,
+        0L,
+        0.01,
+        NumericTypePolicy.DetectWiden
+      ),
+      false
+    )
+
+    // DetectWiden with lossy widening (0.1f → 0.1d loses precision): flagged even with tolerance
+    val lossyFloat: Option[Any] = Some(java.lang.Float.valueOf(0.1f))
+    val lossyDouble: Option[Any] = Some(java.lang.Double.valueOf(0.1))
+    assertEquals(
+      RowComparisonFailure.areDifferent(
+        lossyFloat,
+        lossyDouble,
+        0L,
+        0.01,
+        NumericTypePolicy.DetectWiden
+      ),
+      true
+    )
+
+    // Lenient: never flags type differences
+    assertEquals(
+      RowComparisonFailure.areDifferent(floatVal, doubleVal, 0L, 0.01, NumericTypePolicy.Lenient),
+      false
+    )
+  }
+
 }

--- a/tests/src/test/scala/com/scylladb/migrator/validation/DynamoDBRowComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/DynamoDBRowComparisonTest.scala
@@ -320,13 +320,14 @@ class DynamoDBRowComparisonTest extends munit.FunSuite {
     assertEquals(result, expected)
   }
 
-  test("BigDecimal and integral wrappers remain different for shared row comparison") {
+  test("BigDecimal and integral wrappers are equal for shared row comparison under Lenient policy") {
     assert(
-      RowComparisonFailure.areDifferent(
+      !RowComparisonFailure.areDifferent(
         Some(new java.math.BigDecimal("42.0")),
         Some(42L),
         timestampMsTolerance   = 0L,
-        floatingPointTolerance = floatingPointTolerance
+        floatingPointTolerance = floatingPointTolerance,
+        numericTypePolicy      = com.scylladb.migrator.validation.core.NumericTypePolicy.Lenient
       )
     )
   }

--- a/tests/src/test/scala/com/scylladb/migrator/validation/core/NumericComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/core/NumericComparisonTest.scala
@@ -34,9 +34,10 @@ class NumericComparisonTest extends FunSuite {
   }
 
   test("DetectWiden flags Float and Double with precision/widening loss as TypeMismatch") {
-    val left = java.lang.Float.valueOf(0.1f) // Float representation is lossy
-    val right = java.lang.Double.valueOf(0.1) // Double representation
-    // Although numerically close enough for tolerance, their exact bit representations differ.
+    val left = java.lang.Float.valueOf(0.1f)
+    val right = java.lang.Double.valueOf(0.1)
+    // Tolerance covers the value difference, but DetectWiden still flags the lossy widening.
+    // Use Lenient if tolerance should override type-mismatch detection.
     val result =
       NumericComparison.compareWithPolicy(left, right, 0.01, NumericTypePolicy.DetectWiden)
     assert(result.isInstanceOf[TypeMismatch])
@@ -114,18 +115,20 @@ class NumericComparisonTest extends FunSuite {
     )
   }
 
-  test("Tolerance consistency: Int vs Long with tolerance > 0 uses decimal path") {
-    // With tolerance=1.5, Int(5) vs Long(6) should be Equal (difference=1 < 1.5)
+  test("Integrals use exact equality regardless of tolerance") {
     val left = java.lang.Integer.valueOf(5)
     val right = java.lang.Long.valueOf(6L)
-    val isDifferent = NumericComparison.areNumbersDifferent(left, right, 1.5)
-    assertEquals(isDifferent, false)
+    // Both normalize to integral — strict != even when tolerance would cover the gap
+    assertEquals(NumericComparison.areNumbersDifferent(left, right, 1.5), true)
+    assertEquals(NumericComparison.areNumbersDifferent(left, right, 0.0), true)
   }
 
-  test("Tolerance zero: Int vs Long exact equality required") {
+  test("Mixed Int vs Double applies tolerance via decimal fallthrough") {
     val left = java.lang.Integer.valueOf(5)
-    val right = java.lang.Long.valueOf(6L)
-    val isDifferent = NumericComparison.areNumbersDifferent(left, right, 0.0)
-    assertEquals(isDifferent, true)
+    val right = java.lang.Double.valueOf(6.0)
+    // Int is integral, Double is not → falls to decimal path → |5 - 6| = 1 < 1.5
+    assertEquals(NumericComparison.areNumbersDifferent(left, right, 1.5), false)
+    // With zero tolerance, |5 - 6| = 1 > 0
+    assertEquals(NumericComparison.areNumbersDifferent(left, right, 0.0), true)
   }
 }

--- a/tests/src/test/scala/com/scylladb/migrator/validation/core/NumericComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/core/NumericComparisonTest.scala
@@ -1,0 +1,131 @@
+package com.scylladb.migrator.validation.core
+
+import munit.FunSuite
+
+class NumericComparisonTest extends FunSuite {
+  import ComparisonResult._
+
+  test("Lenient compares Int and Long of same value as equal") {
+    val left = java.lang.Integer.valueOf(42)
+    val right = java.lang.Long.valueOf(42L)
+    val result = NumericComparison.compareWithPolicy(left, right, 0.001, NumericTypePolicy.Lenient)
+    assertEquals(result, Equal)
+  }
+
+  test("Lenient compares Int and Short of same value as equal") {
+    val left = java.lang.Integer.valueOf(12)
+    val right = java.lang.Short.valueOf(12.toShort)
+    val result = NumericComparison.compareWithPolicy(left, right, 0.001, NumericTypePolicy.Lenient)
+    assertEquals(result, Equal)
+  }
+
+  test("Lenient compares Int and BigDecimal with zero scale as equal") {
+    val left = java.lang.Integer.valueOf(15)
+    val right = new java.math.BigDecimal("15.000")
+    val result = NumericComparison.compareWithPolicy(left, right, 0.001, NumericTypePolicy.Lenient)
+    assertEquals(result, Equal)
+  }
+
+  test("Lenient compares Float and Double within tolerance as equal") {
+    val left = java.lang.Float.valueOf(1.23f)
+    val right = java.lang.Double.valueOf(1.23)
+    val result = NumericComparison.compareWithPolicy(left, right, 0.001, NumericTypePolicy.Lenient)
+    assertEquals(result, Equal)
+  }
+
+  test("DetectWiden flags Float and Double with precision/widening loss as TypeMismatch") {
+    val left = java.lang.Float.valueOf(0.1f) // Float representation is lossy
+    val right = java.lang.Double.valueOf(0.1) // Double representation
+    // Although numerically close enough for tolerance, their exact bit representations differ.
+    val result =
+      NumericComparison.compareWithPolicy(left, right, 0.01, NumericTypePolicy.DetectWiden)
+    assert(result.isInstanceOf[TypeMismatch])
+  }
+
+  test("DetectWiden treats Float and Double without loss as Equal") {
+    val left = java.lang.Float.valueOf(1.5f)
+    val right = java.lang.Double.valueOf(1.5)
+    val result =
+      NumericComparison.compareWithPolicy(left, right, 0.01, NumericTypePolicy.DetectWiden)
+    assertEquals(result, Equal)
+  }
+
+  test("StrictType flags any Float and Double pair as TypeMismatch") {
+    val left = java.lang.Float.valueOf(1.5f)
+    val right = java.lang.Double.valueOf(1.5)
+    val result =
+      NumericComparison.compareWithPolicy(left, right, 0.01, NumericTypePolicy.StrictType)
+    assert(result.isInstanceOf[TypeMismatch])
+  }
+
+  test("StrictType flags Int vs Long as TypeMismatch") {
+    val left = java.lang.Integer.valueOf(42)
+    val right = java.lang.Long.valueOf(42L)
+    val result =
+      NumericComparison.compareWithPolicy(left, right, 0.001, NumericTypePolicy.StrictType)
+    assert(result.isInstanceOf[TypeMismatch])
+  }
+
+  test("StrictType allows same-type comparison as Equal") {
+    val left = java.lang.Long.valueOf(42L)
+    val right = java.lang.Long.valueOf(42L)
+    val result =
+      NumericComparison.compareWithPolicy(left, right, 0.001, NumericTypePolicy.StrictType)
+    assertEquals(result, Equal)
+  }
+
+  test("DetectWiden does not flag Int vs Long (no widening loss)") {
+    val left = java.lang.Integer.valueOf(42)
+    val right = java.lang.Long.valueOf(42L)
+    val result =
+      NumericComparison.compareWithPolicy(left, right, 0.001, NumericTypePolicy.DetectWiden)
+    assertEquals(result, Equal)
+  }
+
+  test("DetectWiden NaN Float vs NaN Double treated as Equal") {
+    val left = java.lang.Float.valueOf(Float.NaN)
+    val right = java.lang.Double.valueOf(Double.NaN)
+    val result =
+      NumericComparison.compareWithPolicy(left, right, 0.01, NumericTypePolicy.DetectWiden)
+    assertEquals(result, Equal)
+  }
+
+  test("NaN and Infinity comparisons") {
+    val nanDouble = java.lang.Double.valueOf(Double.NaN)
+    val nanFloat = java.lang.Float.valueOf(Float.NaN)
+    val infDouble = java.lang.Double.valueOf(Double.PositiveInfinity)
+    val infFloat = java.lang.Float.valueOf(Float.PositiveInfinity)
+    val negInfDouble = java.lang.Double.valueOf(Double.NegativeInfinity)
+
+    // NaN == NaN
+    assertEquals(
+      NumericComparison.compareWithPolicy(nanDouble, nanFloat, 0.01, NumericTypePolicy.Lenient),
+      Equal
+    )
+    // +Inf == +Inf
+    assertEquals(
+      NumericComparison.compareWithPolicy(infDouble, infFloat, 0.01, NumericTypePolicy.Lenient),
+      Equal
+    )
+    // +Inf != -Inf
+    assertEquals(
+      NumericComparison.compareWithPolicy(infDouble, negInfDouble, 0.01, NumericTypePolicy.Lenient),
+      Different
+    )
+  }
+
+  test("Tolerance consistency: Int vs Long with tolerance > 0 uses decimal path") {
+    // With tolerance=1.5, Int(5) vs Long(6) should be Equal (difference=1 < 1.5)
+    val left = java.lang.Integer.valueOf(5)
+    val right = java.lang.Long.valueOf(6L)
+    val isDifferent = NumericComparison.areNumbersDifferent(left, right, 1.5)
+    assertEquals(isDifferent, false)
+  }
+
+  test("Tolerance zero: Int vs Long exact equality required") {
+    val left = java.lang.Integer.valueOf(5)
+    val right = java.lang.Long.valueOf(6L)
+    val isDifferent = NumericComparison.areNumbersDifferent(left, right, 0.0)
+    assertEquals(isDifferent, true)
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/validation/core/SchemaResolverTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/core/SchemaResolverTest.scala
@@ -1,0 +1,46 @@
+package com.scylladb.migrator.validation.core
+
+import com.scylladb.migrator.config.Rename
+import munit.FunSuite
+
+class SchemaResolverTest extends FunSuite {
+
+  test("buildCaseInsensitiveRenameMap compiles mixed case mapping") {
+    val renames = List(
+      Rename("Foo", "bar"),
+      Rename("bAz", "qux")
+    )
+    val map = SchemaResolver.buildCaseInsensitiveRenameMap(renames)
+    assertEquals(map.get("foo"), Some("bar"))
+    assertEquals(map.get("baz"), Some("qux"))
+  }
+
+  test("buildCaseInsensitiveRenameMap rejects conflicting case-insensitive renames") {
+    val renames = List(
+      Rename("Foo", "bar"),
+      Rename("foo", "other")
+    )
+    intercept[RuntimeException] {
+      SchemaResolver.buildCaseInsensitiveRenameMap(renames)
+    }
+  }
+
+  test("escapeSparkColumnName escapes backticks correctly") {
+    assertEquals(SchemaResolver.escapeSparkColumnName("foo"), "`foo`")
+    assertEquals(SchemaResolver.escapeSparkColumnName("foo`bar"), "`foo``bar`")
+  }
+
+  test("resolveFieldName returns case insensitive match") {
+    val fields = Array("Id", "Name", "age")
+    assertEquals(SchemaResolver.resolveFieldName(fields, "id"), "Id")
+    assertEquals(SchemaResolver.resolveFieldName(fields, "NAME"), "Name")
+    assertEquals(SchemaResolver.resolveFieldName(fields, "Age"), "age")
+  }
+
+  test("resolveFieldName throws exception if not found") {
+    val fields = Array("Id", "Name")
+    intercept[RuntimeException] {
+      SchemaResolver.resolveFieldName(fields, "missing")
+    }
+  }
+}


### PR DESCRIPTION
This PR is to address Validation config hardening/Content-hash validation/Extra target row reporting/Key-driven target lookup/Cross-type numeric comparison listed in the issue https://github.com/scylladb/scylla-migrator/issues/358

## File Layout

New package: `migrator/src/main/scala/com/scylladb/migrator/validation/core/`

- `NumericComparison.scala` — unified `areDifferent` for `(Number, Number)`, `normalizedIntegralValue`, `normalizedDecimalValue`, `floatingPointSpecial`, `NumericTypePolicy` enum, `compareWithPolicy(...)` returning `Equal | Different | TypeMismatch(srcType, tgtType)`.
- `SchemaResolver.scala` — `buildCaseInsensitiveRenameMap`, `resolveFieldName`, `escapeSparkColumnName`, `sparkColumn`, `prefixColumns`.
- `ContentHashJoiner.scala` — `addContentHash(df, cols, hashColumnName)` plus `compareFieldsBySchemaForRow` helpers.
- `ExtraRowDetector.scala` — `collectExtraTargetFailureSample(sourceKeys, targetKeys, pkCols, failuresToFetch)` returning `List[RowComparisonFailure]`.
- `KeyDrivenLookup.scala` — trait `KeyDrivenLookup[TargetRow]` with `lookupByKeys(sourceKeys, pkCols): DataFrame`. Cassandra adapter wrapping `leftJoinWithCassandraTable`.

Modifications:

- [migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala](migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala)
  - Add `case class NumericTypeMismatch(fields: List[(String, String, String)]) extends Item("Numeric type mismatch")`.
  - Replace inline `(Float,Float)`, `(Double,Double)`, `(BigDecimal,BigDecimal)`, and the `(Some(l), Some(r))` fallthrough for `Number` pairs with delegation to `core.NumericComparison.compareWithPolicy`.
  - Signature change: `areDifferent` gains `numericTypePolicy: NumericTypePolicy` (default `Lenient` to keep call sites compiling; per-call sites pass from `Validation` config).
- [migrator/src/main/scala/com/scylladb/migrator/config/Validation.scala](migrator/src/main/scala/com/scylladb/migrator/config/Validation.scala)
  - Add `numericTypePolicy: NumericTypePolicy = NumericTypePolicy.Lenient`.
  - Circe decoder: parse string `"Lenient" | "DetectWiden" | "StrictType"` (case-insensitive), reject unknown values, default `Lenient` when omitted.
- [migrator/src/main/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidator.scala](migrator/src/main/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidator.scala)
  - Delete local `areDifferent`, `areNumbersDifferent`, `floatingPointSpecial`, `normalizedIntegralValue`, `normalizedDecimalValue`, `buildCaseInsensitiveRenameMap`, `escapeSparkColumnName`, `sparkColumn`, `resolveFieldName`, `prefixColumns`.
  - Delete `addContentHash`, `collectExtraTargetFailureSample`, `lookupTargetRowsForSourceKeys` (move to core; thin call sites remain).
  - Pass `config.validation.get.numericTypePolicy` through to `compareFieldsBySchemaForRow`.
- [migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala](migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala) — pass `numericTypePolicy` into `RowComparisonFailure.compareCassandraRows`.
- [migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala](migrator/src/main/scala/com/scylladb/migrator/alternator/AlternatorValidator.scala) — pass `numericTypePolicy` into `compareDynamoDBRows`.
- [migrator/src/main/scala/com/scylladb/migrator/Validator.scala](migrator/src/main/scala/com/scylladb/migrator/Validator.scala) — add `numericTypeMismatches` counter to summary log alongside missing/extra/differing.
- [config.yaml.example](config.yaml.example) — append commented `numericTypePolicy` entry after `hashColumns` block (lines 481–501).

## Behavior Changes

Pure false-positive fixes on Cassandra + DDB row compare. From earlier analysis:

- Now equal: `Int==Long`, `Long==BigInteger`, `Short==Int`, `Integer==BigDecimal(scale<=0)`, cross-type `Float==Double` within tolerance, NaN cross-type, BigDecimal-string with stripped zeros vs Long.
- Stays different: distinct integer values, NaN vs finite, +Inf vs -Inf, decimal-with-fraction vs integer, value vs null.
- Opt-in `DetectWiden`: `Float(0.1f)` vs `Double(0.1)` flagged as `NumericTypeMismatch` (round-trip bit-precise widening check). `Float(1.0f)` vs `Double(1.0)` stays equal.
- Opt-in `StrictType`: any cross-type Float/Double pair flagged regardless of value.

Documented in CHANGELOG + release notes.

## Tests

New unit tests (munit) under `tests/src/test/scala/com/scylladb/migrator/validation/core/`:

- `NumericComparisonTest.scala` — cases 1–19 from earlier table, all three policies.
- `ContentHashJoinerTest.scala` — port relevant cases from `MySQLToScyllaValidatorTest`; assert hashes stable across reorderings, null handling, binary/string distinction.
- `ExtraRowDetectorTest.scala` — anti-join sample, `failuresToFetch <= 0` short-circuit, `where`-disabled path.
- `SchemaResolverTest.scala` — rename map case-insensitivity, collision detection.

Modify existing:

- `CassandraRowComparisonTest.scala` — add cross-type integer + Float/Double NaN/widening assertions per policy.
- `DynamoDBRowComparisonTest.scala` — same, focused on values arriving as boxed Number after Spark inference.
- `MySQLToScyllaValidatorTest.scala` — should pass unchanged (regression gate).