### PR TITLE
refactor code to unify the rename collision detection, case insensitive resolution and avoid silent schema mismatches

### DIFF
--- a/migrator/src/main/scala/com/scylladb/migrator/config/Rename.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/Rename.scala
@@ -3,8 +3,45 @@ package com.scylladb.migrator.config
 import io.circe.{ Decoder, Encoder }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 
+import java.util.Locale
+
 case class Rename(from: String, to: String)
 object Rename {
   implicit val encoder: Encoder[Rename] = deriveEncoder[Rename]
   implicit val decoder: Decoder[Rename] = deriveDecoder[Rename]
+
+  /** Build a rename map keyed by lowercase source column name. Detects conflicting case-insensitive
+    * mappings (e.g. "Foo"→"bar" and "foo"→"baz").
+    */
+  def buildCaseInsensitiveMap(renames: List[Rename]): Map[String, String] =
+    renames
+      .groupBy(_.from.toLowerCase(Locale.ROOT))
+      .view
+      .map { case (lowerKey, entries) =>
+        val targets = entries.map(_.to).distinct
+        if (targets.size > 1)
+          sys.error(
+            s"Renames contain conflicting case-insensitive mappings for source column '$lowerKey': " +
+              s"${targets.mkString(", ")}"
+          )
+        lowerKey -> targets.head
+      }
+      .toMap
+
+  /** Resolve a column name through a case-insensitive rename map, falling back to identity. */
+  def resolveRename(caseInsensitiveMap: Map[String, String], column: String): String =
+    caseInsensitiveMap.getOrElse(column.toLowerCase(Locale.ROOT), column)
+
+  /** Detect case-insensitive collisions in the *target* side of renames. Returns error messages for
+    * each collision group, or empty list if clean.
+    */
+  def detectTargetCollisions(renames: List[Rename]): List[String] =
+    renames
+      .groupBy(_.to.toLowerCase(Locale.ROOT))
+      .collect {
+        case (_, entries) if entries.map(_.from).distinct.size > 1 =>
+          val sources = entries.map(_.from).distinct
+          s"Multiple source columns (${sources.mkString(", ")}) rename to the same target '${entries.head.to}'"
+      }
+      .toList
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/schema/SchemaResolver.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/schema/SchemaResolver.scala
@@ -1,0 +1,103 @@
+package com.scylladb.migrator.schema
+
+import org.apache.spark.sql.{ Column, DataFrame }
+import org.apache.spark.sql.functions.col
+
+import java.util.Locale
+
+/** Shared case-insensitive schema resolution utilities for readers, writers, and validators. */
+object SchemaResolver {
+
+  /** Non-throwing case-insensitive field lookup. Prefers exact-case match, falls back to
+    * case-insensitive using Locale.ROOT normalization.
+    */
+  def findFieldName(fields: Array[String], name: String): Option[String] = {
+    val nameLower = name.toLowerCase(Locale.ROOT)
+    fields.find(_ == name).orElse(fields.find(_.toLowerCase(Locale.ROOT) == nameLower))
+  }
+
+  /** Case-insensitive field lookup. Prefers exact-case match. Throws with a diagnostic error
+    * listing available columns if no match is found.
+    */
+  def resolveFieldName(fields: Array[String], name: String): String =
+    findFieldName(fields, name)
+      .getOrElse(
+        sys.error(
+          s"Column '$name' not found in schema. Available columns: ${fields.mkString(", ")}. " +
+            "This may indicate a missing rename entry or schema mismatch."
+        )
+      )
+
+  /** Backtick-escape a column name for Spark SQL expressions (handles dots and embedded backticks).
+    */
+  def escapeSparkColumnName(name: String): String =
+    s"`${name.replace("`", "``")}`"
+
+  /** Create a Spark Column reference with proper backtick quoting. */
+  def sparkColumn(name: String): Column =
+    col(escapeSparkColumnName(name))
+
+  /** Detect case-insensitive column name collisions in a field name sequence. Throws
+    * IllegalArgumentException with details if collisions are found.
+    *
+    * @param context
+    *   human-readable description of where the collision was detected
+    */
+  def requireNoCollisions(fieldNames: Seq[String], context: String): Unit = {
+    val collisions =
+      fieldNames
+        .groupBy(_.toLowerCase(Locale.ROOT))
+        .collect { case (_, names) if names.size > 1 => names.distinct }
+    if (collisions.nonEmpty) {
+      val collisionDetails = collisions
+        .map(names => names.mkString("[", ", ", "]"))
+        .mkString(", ")
+      throw new IllegalArgumentException(
+        s"Column name collision detected $context. " +
+          s"Multiple source columns resolve to the same target column name: $collisionDetails. " +
+          "Check the configured renames and source schema."
+      )
+    }
+  }
+
+  /** Validate that all requested columns exist (case-insensitively) in the available columns.
+    * Throws with a diagnostic error listing missing columns.
+    *
+    * @param context
+    *   human-readable description (e.g. "in target after renames")
+    */
+  def validateColumnPresence(
+    requested: Seq[String],
+    available: Seq[String],
+    context: String
+  ): Unit = {
+    val availableLower = available.map(_.toLowerCase(Locale.ROOT)).toSet
+    val missing = requested.filterNot(c => availableLower.contains(c.toLowerCase(Locale.ROOT)))
+    if (missing.nonEmpty)
+      sys.error(
+        s"Columns not found: ${missing.mkString(", ")}. Context: $context. " +
+          s"Available: ${available.mkString(", ")}."
+      )
+  }
+
+  /** Return columns present in `superset` but not in `subset` (case-insensitive comparison). */
+  def columnsOnlyIn(superset: Seq[String], subset: Seq[String]): Seq[String] = {
+    val subsetLower = subset.map(_.toLowerCase(Locale.ROOT)).toSet
+    superset.filterNot(c => subsetLower.contains(c.toLowerCase(Locale.ROOT)))
+  }
+
+  /** Prefix all DataFrame column names with a given string. */
+  def prefixColumns(df: DataFrame, prefix: String): DataFrame =
+    df.select(df.columns.toIndexedSeq.map(c => sparkColumn(c).as(s"$prefix$c")): _*)
+
+  /** Select and alias columns by resolving names case-insensitively against the DataFrame schema.
+    */
+  def selectAndAlias(df: DataFrame, columns: Seq[String]): DataFrame = {
+    val schemaFields = df.schema.fieldNames
+    df.select(
+      columns.toIndexedSeq.map { columnName =>
+        sparkColumn(resolveFieldName(schemaFields, columnName)).as(columnName)
+      }: _*
+    )
+  }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidator.scala
@@ -7,6 +7,7 @@ import com.scylladb.migrator.Connectors
 import com.scylladb.migrator.config.{ MigratorConfig, Rename, SourceSettings, TargetSettings }
 import com.scylladb.migrator.readers
 import com.scylladb.migrator.readers.MySQL
+import com.scylladb.migrator.schema.SchemaResolver
 import com.scylladb.migrator.validation.RowComparisonFailure
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.rdd.RDD
@@ -42,25 +43,13 @@ object MySQLToScyllaValidator {
   private[scylla] def buildCaseInsensitiveRenameMap(
     renames: List[Rename]
   ): Map[String, String] =
-    renames
-      .groupBy(_.from.toLowerCase(Locale.ROOT))
-      .view
-      .map { case (sourceName, entries) =>
-        val targets = entries.map(_.to).distinct
-        if (targets.size > 1)
-          sys.error(
-            s"Renames contain conflicting case-insensitive mappings for source column '${sourceName}': " +
-              s"${targets.mkString(", ")}"
-          )
-        sourceName -> targets.head
-      }
-      .toMap
+    Rename.buildCaseInsensitiveMap(renames)
 
   private[scylla] def escapeSparkColumnName(name: String): String =
-    s"`${name.replace("`", "``")}`"
+    SchemaResolver.escapeSparkColumnName(name)
 
   private[scylla] def sparkColumn(name: String): Column =
-    col(escapeSparkColumnName(name))
+    SchemaResolver.sparkColumn(name)
 
   private[scylla] def areDifferent(
     left: Option[Any],
@@ -336,14 +325,7 @@ object MySQLToScyllaValidator {
     }
 
   private[scylla] def resolveFieldName(fields: Array[String], name: String): String =
-    fields
-      .find(_.equalsIgnoreCase(name))
-      .getOrElse(
-        sys.error(
-          s"Column '$name' not found in schema. Available columns: ${fields.mkString(", ")}. " +
-            "This may indicate a missing rename entry or schema mismatch."
-        )
-      )
+    SchemaResolver.resolveFieldName(fields, name)
 
   private[scylla] def differingFieldsBetweenRows(
     sourceRow: Row,
@@ -432,25 +414,20 @@ object MySQLToScyllaValidator {
   private[scylla] def validateSourceColumnsPresentInTarget(
     sourceColumns: Seq[String],
     targetColumns: Seq[String]
-  ): Unit = {
-    val targetColumnsLower = targetColumns.map(_.toLowerCase(Locale.ROOT)).toSet
-    val missingInTarget =
-      sourceColumns.filterNot(c => targetColumnsLower.contains(c.toLowerCase(Locale.ROOT)))
-    if (missingInTarget.nonEmpty)
-      sys.error(
-        s"Source columns not found in target after renames: ${missingInTarget.mkString(", ")}. " +
-          "Validation would silently skip these columns, so the run has been aborted. " +
-          "If this is unexpected, check your target schema or 'renames' configuration."
-      )
-  }
+  ): Unit =
+    SchemaResolver.validateColumnPresence(
+      sourceColumns,
+      targetColumns,
+      "in target after renames. " +
+        "Validation would silently skip these columns, so the run has been aborted. " +
+        "If this is unexpected, check your target schema or 'renames' configuration"
+    )
 
   private[scylla] def targetOnlyColumns(
     sourceColumns: Seq[String],
     targetColumns: Seq[String]
-  ): Seq[String] = {
-    val sourceColumnsLower = sourceColumns.map(_.toLowerCase(Locale.ROOT)).toSet
-    targetColumns.filterNot(c => sourceColumnsLower.contains(c.toLowerCase(Locale.ROOT)))
-  }
+  ): Seq[String] =
+    SchemaResolver.columnsOnlyIn(targetColumns, sourceColumns)
 
   private[scylla] def normalizePrimaryKeyComponent(value: Any): Any = value match {
     case bytes: Array[Byte] => bytes.toIndexedSeq
@@ -486,14 +463,8 @@ object MySQLToScyllaValidator {
   private[scylla] def selectAndAliasColumns(
     df: DataFrame,
     requestedColumns: Seq[String]
-  ): DataFrame = {
-    val schemaFields = df.schema.fieldNames
-    df.select(
-      requestedColumns.toIndexedSeq.map { columnName =>
-        sparkColumn(resolveFieldName(schemaFields, columnName)).as(columnName)
-      }: _*
-    )
-  }
+  ): DataFrame =
+    SchemaResolver.selectAndAlias(df, requestedColumns)
 
   private[scylla] def validateHashColumnsPresentOnBothSides(
     requestedHashColumns: Seq[String],
@@ -1197,7 +1168,7 @@ object MySQLToScyllaValidator {
   }
 
   private[scylla] def prefixColumns(df: DataFrame, prefix: String): DataFrame =
-    df.select(df.columns.toIndexedSeq.map(c => sparkColumn(c).as(s"$prefix$c")): _*)
+    SchemaResolver.prefixColumns(df, prefix)
 
   private val MaxValueReprLength = 100
 

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -6,6 +6,7 @@ import com.datastax.spark.connector.cql.Schema
 import com.scylladb.migrator.Connectors
 import com.scylladb.migrator.config.{ Rename, SourceSettings, TargetSettings }
 import com.scylladb.migrator.readers.TimestampColumns
+import com.scylladb.migrator.schema.SchemaResolver
 import org.apache.logging.log4j.{ LogManager, Logger }
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{ DataFrame, Row, SparkSession }
@@ -34,10 +35,9 @@ object Scylla {
     val reverseRenames = renames.map(r => r.to -> r.from).toMap
     val sourcePkNames =
       targetPkNames.map(name => reverseRenames.getOrElse(name, name))
-    val dfFieldNamesLower =
-      dfSchema.fieldNames.map(name => name.toLowerCase(Locale.ROOT) -> name).toMap
+    val fields = dfSchema.fieldNames
     val resolution = sourcePkNames.map { sourcePkName =>
-      sourcePkName -> dfFieldNamesLower.get(sourcePkName.toLowerCase(Locale.ROOT))
+      sourcePkName -> SchemaResolver.findFieldName(fields, sourcePkName)
     }
 
     val resolvedSourcePkNames = resolution.collect { case (_, Some(dfFieldName)) =>
@@ -74,24 +74,8 @@ object Scylla {
   private[writers] def requireNoCaseInsensitiveColumnNameCollisions(
     fieldNames: Seq[String],
     context: String
-  ): Unit = {
-    val collisions =
-      fieldNames
-        .groupBy(_.toLowerCase(Locale.ROOT))
-        .collect { case (_, names) if names.size > 1 => names.distinct }
-        .toList
-
-    if (collisions.nonEmpty) {
-      val collisionDetails = collisions
-        .map(names => names.mkString("[", ", ", "]"))
-        .mkString(", ")
-      throw new IllegalArgumentException(
-        s"Column name collision detected $context. " +
-          s"Multiple source columns resolve to the same target column name: $collisionDetails. " +
-          "Check the configured renames and source schema."
-      )
-    }
-  }
+  ): Unit =
+    SchemaResolver.requireNoCollisions(fieldNames, context)
 
   private[writers] def dropRowsWithNullPrimaryKeys(
     rdd: RDD[Row],

--- a/tests/src/test/scala/com/scylladb/migrator/config/RenameTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/RenameTest.scala
@@ -1,0 +1,58 @@
+package com.scylladb.migrator.config
+
+class RenameTest extends munit.FunSuite {
+
+  test("buildCaseInsensitiveMap creates lowercase-keyed map") {
+    val renames = List(Rename("UserId", "user_id"), Rename("Email", "email_addr"))
+    val result = Rename.buildCaseInsensitiveMap(renames)
+    assertEquals(result, Map("userid" -> "user_id", "email" -> "email_addr"))
+  }
+
+  test("buildCaseInsensitiveMap detects conflicting case-insensitive mappings") {
+    val renames = List(Rename("Foo", "bar"), Rename("foo", "baz"))
+    val error = intercept[RuntimeException] {
+      Rename.buildCaseInsensitiveMap(renames)
+    }
+    assert(error.getMessage.contains("conflicting case-insensitive mappings"))
+    assert(error.getMessage.contains("foo"))
+  }
+
+  test("buildCaseInsensitiveMap allows same-target duplicates (idempotent)") {
+    val renames = List(Rename("Foo", "bar"), Rename("foo", "bar"))
+    val result = Rename.buildCaseInsensitiveMap(renames)
+    assertEquals(result, Map("foo" -> "bar"))
+  }
+
+  test("buildCaseInsensitiveMap empty list returns empty map") {
+    assertEquals(Rename.buildCaseInsensitiveMap(Nil), Map.empty[String, String])
+  }
+
+  test("resolveRename returns mapped value when present") {
+    val map = Map("userid" -> "user_id")
+    assertEquals(Rename.resolveRename(map, "UserId"), "user_id")
+    assertEquals(Rename.resolveRename(map, "userid"), "user_id")
+    assertEquals(Rename.resolveRename(map, "USERID"), "user_id")
+  }
+
+  test("resolveRename returns identity when not in map") {
+    val map = Map("userid" -> "user_id")
+    assertEquals(Rename.resolveRename(map, "Email"), "Email")
+  }
+
+  test("detectTargetCollisions finds multiple sources mapping to same target") {
+    val renames = List(Rename("a", "X"), Rename("b", "x"))
+    val errors = Rename.detectTargetCollisions(renames)
+    assertEquals(errors.size, 1)
+    assert(errors.head.contains("a"))
+    assert(errors.head.contains("b"))
+  }
+
+  test("detectTargetCollisions returns empty for clean renames") {
+    val renames = List(Rename("a", "x"), Rename("b", "y"))
+    assertEquals(Rename.detectTargetCollisions(renames), Nil)
+  }
+
+  test("detectTargetCollisions empty list returns empty") {
+    assertEquals(Rename.detectTargetCollisions(Nil), Nil)
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/schema/SchemaResolverTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/schema/SchemaResolverTest.scala
@@ -1,0 +1,151 @@
+package com.scylladb.migrator.schema
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.{ IntegerType, StringType, StructField, StructType }
+
+class SchemaResolverTest extends munit.FunSuite {
+
+  // --- resolveFieldName ---
+
+  test("resolveFieldName finds exact case match") {
+    val fields = Array("userId", "email", "age")
+    assertEquals(SchemaResolver.resolveFieldName(fields, "email"), "email")
+  }
+
+  test("resolveFieldName finds case-insensitive match") {
+    val fields = Array("UserId", "Email", "Age")
+    assertEquals(SchemaResolver.resolveFieldName(fields, "userid"), "UserId")
+    assertEquals(SchemaResolver.resolveFieldName(fields, "EMAIL"), "Email")
+  }
+
+  test("resolveFieldName prefers exact-case match over case-insensitive") {
+    val fields = Array("Status", "status")
+    assertEquals(SchemaResolver.resolveFieldName(fields, "status"), "status")
+    assertEquals(SchemaResolver.resolveFieldName(fields, "Status"), "Status")
+  }
+
+  // --- findFieldName ---
+
+  test("findFieldName returns Some for exact match") {
+    val fields = Array("id", "Name")
+    assertEquals(SchemaResolver.findFieldName(fields, "id"), Some("id"))
+  }
+
+  test("findFieldName returns Some for case-insensitive match") {
+    val fields = Array("UserId", "Email")
+    assertEquals(SchemaResolver.findFieldName(fields, "userid"), Some("UserId"))
+  }
+
+  test("findFieldName returns None when not found") {
+    val fields = Array("id", "name")
+    assertEquals(SchemaResolver.findFieldName(fields, "missing"), None)
+  }
+
+  test("resolveFieldName throws with diagnostic when not found") {
+    val fields = Array("id", "name")
+    val error = intercept[RuntimeException] {
+      SchemaResolver.resolveFieldName(fields, "missing")
+    }
+    assert(error.getMessage.contains("missing"))
+    assert(error.getMessage.contains("id, name"))
+  }
+
+  // --- escapeSparkColumnName ---
+
+  test("escapeSparkColumnName wraps in backticks") {
+    assertEquals(SchemaResolver.escapeSparkColumnName("col"), "`col`")
+  }
+
+  test("escapeSparkColumnName doubles embedded backticks") {
+    assertEquals(SchemaResolver.escapeSparkColumnName("a`b"), "`a``b`")
+  }
+
+  test("escapeSparkColumnName handles dots (no splitting)") {
+    assertEquals(SchemaResolver.escapeSparkColumnName("user.name"), "`user.name`")
+  }
+
+  // --- requireNoCollisions ---
+
+  test("requireNoCollisions passes for unique names") {
+    SchemaResolver.requireNoCollisions(Seq("a", "b", "c"), "test context")
+  }
+
+  test("requireNoCollisions throws on case-insensitive collision") {
+    val error = intercept[IllegalArgumentException] {
+      SchemaResolver.requireNoCollisions(Seq("Foo", "foo", "bar"), "after renames")
+    }
+    assert(error.getMessage.contains("Foo"))
+    assert(error.getMessage.contains("foo"))
+    assert(error.getMessage.contains("after renames"))
+  }
+
+  // --- validateColumnPresence ---
+
+  test("validateColumnPresence passes when all present") {
+    SchemaResolver.validateColumnPresence(
+      Seq("id", "name"),
+      Seq("ID", "Name", "Extra"),
+      "in target"
+    )
+  }
+
+  test("validateColumnPresence throws listing missing columns") {
+    val error = intercept[RuntimeException] {
+      SchemaResolver.validateColumnPresence(
+        Seq("id", "missing1", "missing2"),
+        Seq("id", "other"),
+        "in target"
+      )
+    }
+    assert(error.getMessage.contains("missing1"))
+    assert(error.getMessage.contains("missing2"))
+    assert(error.getMessage.contains("in target"))
+  }
+
+  // --- columnsOnlyIn ---
+
+  test("columnsOnlyIn returns columns in superset but not in subset") {
+    val result = SchemaResolver.columnsOnlyIn(
+      Seq("A", "B", "C"),
+      Seq("a", "c")
+    )
+    assertEquals(result, Seq("B"))
+  }
+
+  test("columnsOnlyIn returns empty when all present") {
+    val result = SchemaResolver.columnsOnlyIn(Seq("x", "y"), Seq("X", "Y"))
+    assertEquals(result, Seq.empty[String])
+  }
+
+  // --- prefixColumns and selectAndAlias (require SparkSession) ---
+
+  implicit lazy val spark: SparkSession = SparkSession
+    .builder()
+    .appName("SchemaResolverTest")
+    .master("local[*]")
+    .config("spark.sql.shuffle.partitions", "1")
+    .getOrCreate()
+
+  override def afterAll(): Unit = {
+    spark.stop()
+    super.afterAll()
+  }
+
+  test("prefixColumns adds prefix to all column names") {
+    import spark.implicits._
+    val df = Seq((1, "a")).toDF("id", "name")
+    val prefixed = SchemaResolver.prefixColumns(df, "src_")
+    assertEquals(prefixed.columns.toList, List("src_id", "src_name"))
+  }
+
+  test("selectAndAlias resolves case-insensitively and aliases to requested name") {
+    import spark.implicits._
+    val df = Seq((1, "a", 42)).toDF("ID", "Name", "Age")
+    val selected = SchemaResolver.selectAndAlias(df, Seq("id", "name"))
+    assertEquals(selected.columns.toList, List("id", "name"))
+    val rows = selected.collect()
+    assertEquals(rows.length, 1)
+    assertEquals(rows(0).getInt(0), 1)
+    assertEquals(rows(0).getString(1), "a")
+  }
+}


### PR DESCRIPTION
This PR is to resolve case-insensitive schema handling item in the issue https://github.com/scylladb/scylla-migrator/issues/358

## Current State

Case-insensitive schema handling is spread across multiple files with duplicated patterns:

- **`MySQLToScyllaValidator`** (`scylla/MySQLToScyllaValidator.scala`): Contains `buildCaseInsensitiveRenameMap`, `resolveFieldName`, `escapeSparkColumnName`, `sparkColumn`, `validateSourceColumnsPresentInTarget`, `targetOnlyColumns`, `prefixColumns`, `selectAndAliasColumns` -- all `private[scylla]`.
- **`writers/Scylla`** (`writers/Scylla.scala`): Contains `requireNoCaseInsensitiveColumnNameCollisions`, `resolvePrimaryKeyColumns` -- uses manual `toLowerCase(Locale.ROOT)` map building.
- **`MigratorConfig`** (`config/MigratorConfig.scala`): `renamesMap` is **case-sensitive** (`Map[String, String].withDefault(identity)`), while the MySQL validator builds a separate case-insensitive version.
- **`ScyllaValidator`** (`scylla/ScyllaValidator.scala`): Uses `config.renamesMap` directly (case-sensitive lookups), which can silently fail if column casing differs between source and target.
- **`AlternatorValidator`** (`alternator/AlternatorValidator.scala`): Same -- uses `config.renamesMap` with case-sensitive keys.

### Solution: Enhance existing `config.Rename` companion object + new `validation.core.SchemaResolver` trait

Split responsibilities:
1. **`config/Rename.scala`**: Add `buildCaseInsensitiveMap`, collision detection, and rename resolution logic here since it directly operates on `Rename` instances.
2. **New trait `validation/core/SchemaResolver`** (or object): DataFrame-level helpers like `resolveFieldName`, `sparkColumn`, `prefixColumns`, `validateColumnPresence`.

**What moves where:**
- `Rename` companion gets: `buildCaseInsensitiveMap`, `detectCollisions`, `resolveRename(renames, column)`
- `SchemaResolver` gets: `resolveFieldName`, `sparkColumn`, `escapeSparkColumnName`, `validateColumnPresence`, `columnsOnlyIn`, `requireNoCollisions`

**Reasons:**

1. **Separation of concerns.** Rename map construction and collision detection logically belong with the `Rename` type. DataFrame schema resolution is a distinct concern that belongs closer to the validation/execution layer.

2. **Aligned with issue #358's direction.** The issue already proposes a `validation/core/` package for NumericComparison, ContentHashJoiner, and KeyDrivenLookup. Placing `SchemaResolver` there creates a coherent "shared validation building blocks" module.

3. **Does not break DynamoDB semantics.** This doesn't force case-insensitivity on backends where column names are genuinely case-sensitive. Each validator can choose whether to use `buildCaseInsensitiveMap` or the existing case-sensitive map.

4. **Incremental adoption.** The MySQL validator can immediately switch to the shared helpers. Cassandra/Scylla validator and writers can adopt them later when convenient, without a forced migration.

5. **Testability.** Both `Rename` companion methods and `SchemaResolver` helpers are pure functions with no external dependencies, making them trivial to unit test independently.


## Implementation Sketch

### File: `migrator/src/main/scala/com/scylladb/migrator/config/Rename.scala`

Add to the existing `Rename` companion:

```scala
object Rename {
  // existing codec implicits...

  def buildCaseInsensitiveMap(renames: List[Rename]): Map[String, String] =
    renames
      .groupBy(_.from.toLowerCase(Locale.ROOT))
      .view.map { case (key, entries) =>
        val targets = entries.map(_.to).distinct
        if (targets.size > 1)
          sys.error(s"Conflicting case-insensitive rename mappings for '$key': ${targets.mkString(", ")}")
        key -> targets.head
      }.toMap

  def resolveRename(caseInsensitiveMap: Map[String, String], column: String): String =
    caseInsensitiveMap.getOrElse(column.toLowerCase(Locale.ROOT), column)

  def detectCollisions(renames: List[Rename]): List[String] = // ...error messages
}
```

### File: `migrator/src/main/scala/com/scylladb/migrator/schema/SchemaResolver.scala`

```scala
package com.scylladb.migrator.schema

object SchemaResolver {
  def resolveFieldName(fields: Array[String], name: String): String = ...
  def escapeSparkColumnName(name: String): String = ...
  def sparkColumn(name: String): Column = ...
  def requireNoCollisions(fieldNames: Seq[String], context: String): Unit = ...
  def validateColumnPresence(requested: Seq[String], available: Seq[String], context: String): Unit = ...
  def columnsOnlyIn(superset: Seq[String], subset: Seq[String]): Seq[String] = ...
  def prefixColumns(df: DataFrame, prefix: String): DataFrame = ...
  def selectAndAlias(df: DataFrame, columns: Seq[String]): DataFrame = ...
}
```

### Callers updated:
- `MySQLToScyllaValidator`: Replace private helpers with `Rename.buildCaseInsensitiveMap` + `SchemaResolver.*`
- `writers/Scylla`: Replace `requireNoCaseInsensitiveColumnNameCollisions` with `SchemaResolver.requireNoCollisions`; use `SchemaResolver.resolveFieldName` in PK resolution
- `ScyllaValidator` / `AlternatorValidator`: Optionally adopt `Rename.buildCaseInsensitiveMap` (can be deferred)

### Tests:
- `tests/.../config/RenameTest.scala` -- unit tests for collision detection, case-insensitive map building
- `tests/.../schema/SchemaResolverTest.scala` -- unit tests for field resolution, quoting, column validation