### PR TITLE
Save points followups

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,9 +91,9 @@ jobs:
           restore-keys: |
             sbt-target-${{ runner.os }}-
       - name: Start services
-        run: make start-services-scylla
+        run: make start-services-scylla-gcs
       - name: Wait for services
-        run: make wait-for-services-scylla
+        run: make wait-for-services-scylla-gcs
       - name: Dump container logs on failure
         if: failure()
         run: make dump-logs-scylla

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHELL := bash
 .PHONY: help build docker-build-jar docker-image lint lint-fix \
         spark-image start-services stop-services wait-for-services \
         start-services-scylla wait-for-services-scylla \
+        start-services-scylla-gcs wait-for-services-scylla-gcs \
         start-services-cassandra wait-for-services-cassandra test-integration-cassandra \
         start-services-alternator wait-for-services-alternator \
         test test-unit test-integration test-integration-scylla \
@@ -152,7 +153,12 @@ start-services: ## Start all Docker Compose test services
 	$(Q)sudo chmod -R 777 $(DOCKER_SPARK_BIND_DIRS) $(DOCKER_GCS_BIND_DIRS) $(DOCKER_SCYLLA_BIND_DIRS)
 	docker compose -f $(COMPOSE_FILE) up -d mysql dynamodb cassandra cassandra2 cassandra3 cassandra5 scylla-source scylla s3 gcs
 
-start-services-scylla: ## Start services needed for Scylla integration tests
+start-services-scylla: ## Start services needed for Scylla integration tests without GCS savepoints
+	$(Q)mkdir -p $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla ./tests/docker/scylla-source
+	$(Q)sudo chmod -R 777 $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla ./tests/docker/scylla-source
+	docker compose $(COMPOSE_SCYLLA_FILES) up -d mysql cassandra scylla-source scylla
+
+start-services-scylla-gcs: ## Start services needed for Scylla integration tests including GCS savepoints
 	$(Q)mkdir -p $(DOCKER_SPARK_BIND_DIRS) $(DOCKER_GCS_BIND_DIRS) ./tests/docker/scylla ./tests/docker/scylla-source
 	$(Q)sudo chmod -R 777 $(DOCKER_SPARK_BIND_DIRS) $(DOCKER_GCS_BIND_DIRS) ./tests/docker/scylla ./tests/docker/scylla-source
 	docker compose $(COMPOSE_SCYLLA_FILES) up -d mysql cassandra scylla-source scylla gcs
@@ -181,6 +187,13 @@ wait-for-services: ## Wait for all test services to become ready
 	wait $$p1; wait $$p2; wait $$p3; wait $$p4; wait $$p5; wait $$p6; wait $$p7; wait $$p8
 
 wait-for-services-scylla: ## Wait for Scylla test services to become ready
+	$(Q)($(call wait-for-cql-compose,$(COMPOSE_SCYLLA_FILES),cassandra)) & p1=$$!
+	($(call wait-for-cql-compose,$(COMPOSE_SCYLLA_FILES),scylla-source)) & p2=$$!
+	($(call wait-for-cql-compose,$(COMPOSE_SCYLLA_FILES),scylla)) & p3=$$!
+	($(call wait-for-mysql-compose,$(COMPOSE_SCYLLA_FILES),mysql)) & p4=$$!
+	wait $$p1; wait $$p2; wait $$p3; wait $$p4
+
+wait-for-services-scylla-gcs: ## Wait for Scylla and GCS test services to become ready
 	$(Q)($(call wait-for-cql-compose,$(COMPOSE_SCYLLA_FILES),cassandra)) & p1=$$!
 	($(call wait-for-cql-compose,$(COMPOSE_SCYLLA_FILES),scylla-source)) & p2=$$!
 	($(call wait-for-cql-compose,$(COMPOSE_SCYLLA_FILES),scylla)) & p3=$$!

--- a/migrator/src/main/scala/com/scylladb/migrator/PathIO.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/PathIO.scala
@@ -36,7 +36,6 @@ private[migrator] object PathIO {
       case Some("file") | None => LocalPathIO
       case Some(_) =>
         new HadoopPathIO(
-          path,
           hadoopConfiguration.map(new Configuration(_)).getOrElse(new Configuration())
         )
     }
@@ -118,55 +117,71 @@ private[migrator] object PathIO {
       }
   }
 
-  private class HadoopPathIO(initialPath: String, hadoopConfiguration: Configuration)
-      extends PathIO {
-    private val fs = fileSystemFor(initialPath)
+  private class HadoopPathIO(hadoopConfiguration: Configuration) extends PathIO {
 
     override def normalize(path: String): String = new HadoopPath(path).toString
 
-    override def exists(path: String): Boolean = fs.exists(toPath(path))
+    override def exists(path: String): Boolean = {
+      val hadoopPath = toPath(path)
+      withFileSystem(hadoopPath)(_.exists(hadoopPath))
+    }
 
     override def createDirectories(path: String): Unit = {
       val directory = toPath(path)
-      if (!fs.mkdirs(directory))
-        throw new IOException(s"Failed to create directory ${directory}")
+      withFileSystem(directory) { fs =>
+        if (!fs.mkdirs(directory))
+          throw new IOException(s"Failed to create directory ${directory}")
+      }
     }
 
-    override def listFileNames(path: String): Seq[String] =
-      fs.listStatus(toPath(path)).iterator.map(_.getPath.getName).toSeq
-
-    override def readUtf8(path: String): String =
-      Using.resource(fs.open(toPath(path))) { in =>
-        val out = new ByteArrayOutputStream()
-        val buffer = new Array[Byte](8192)
-        var read = in.read(buffer)
-        while (read != -1) {
-          out.write(buffer, 0, read)
-          read = in.read(buffer)
-        }
-        out.toString(StandardCharsets.UTF_8.name())
+    override def listFileNames(path: String): Seq[String] = {
+      val hadoopPath = toPath(path)
+      withFileSystem(hadoopPath) { fs =>
+        fs.listStatus(hadoopPath).iterator.map(_.getPath.getName).toSeq
       }
+    }
+
+    override def readUtf8(path: String): String = {
+      val hadoopPath = toPath(path)
+      withFileSystem(hadoopPath) { fs =>
+        Using.resource(fs.open(hadoopPath)) { in =>
+          val out = new ByteArrayOutputStream()
+          val buffer = new Array[Byte](8192)
+          var read = in.read(buffer)
+          while (read != -1) {
+            out.write(buffer, 0, read)
+            read = in.read(buffer)
+          }
+          out.toString(StandardCharsets.UTF_8.name())
+        }
+      }
+    }
 
     override def writeUtf8Atomically(path: String, payload: Array[Byte]): Unit = {
       val finalPath = toPath(path)
       val tempPath = toPath(finalPath.toString + ".tmp")
 
-      var moved = false
-      try {
-        Using.resource(fs.create(tempPath, true))(_.write(payload))
-        moved = fs.rename(tempPath, finalPath)
-        if (!moved) throw new IOException(s"Failed to rename ${tempPath} to ${finalPath}")
-      } finally
-        if (!moved) deleteTemp(tempPath)
+      withFileSystem(finalPath) { fs =>
+        var moved = false
+        try {
+          Using.resource(fs.create(tempPath, true))(_.write(payload))
+          moved = fs.rename(tempPath, finalPath)
+          if (!moved) throw new IOException(s"Failed to rename ${tempPath} to ${finalPath}")
+        } finally
+          if (!moved) deleteTemp(fs, tempPath)
+      }
     }
 
     private def toPath(path: String): HadoopPath = new HadoopPath(path)
 
-    private def fileSystemFor(path: String): FileSystem =
-      try toPath(path).getFileSystem(hadoopConfiguration)
+    private def withFileSystem[A](path: HadoopPath)(f: FileSystem => A): A =
+      Using.resource(fileSystemFor(path))(f)
+
+    private def fileSystemFor(path: HadoopPath): FileSystem =
+      try FileSystem.newInstance(path.toUri, hadoopConfiguration)
       catch {
         case e: UnsupportedFileSystemException =>
-          val pathScheme = Option(toPath(path).toUri.getScheme).getOrElse("<none>")
+          val pathScheme = Option(path.toUri.getScheme).getOrElse("<none>")
           throw new IllegalArgumentException(
             s"Path ${path} uses Hadoop filesystem scheme '${pathScheme}', but no implementation " +
               s"is configured. ${connectorGuidance(pathScheme)}",
@@ -187,7 +202,7 @@ private[migrator] object PathIO {
             "configure it via Spark/Hadoop configuration."
       }
 
-    private def deleteTemp(tempPath: HadoopPath): Unit =
+    private def deleteTemp(fs: FileSystem, tempPath: HadoopPath): Unit =
       try fs.delete(tempPath, false)
       catch {
         case cleanupErr: Throwable =>

--- a/migrator/src/main/scala/com/scylladb/migrator/config/Savepoints.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/Savepoints.scala
@@ -240,6 +240,13 @@ object Savepoints {
         path <- maybeTarget match {
                   case Some(target: SavepointsTarget.StoragePathTarget) =>
                     Right(target.storagePath)
+                  case Some(other) =>
+                    Left(
+                      DecodingFailure(
+                        s"Savepoints target type '${other.targetType}' does not resolve to a storage path.",
+                        cursor.history
+                      )
+                    )
                   case None =>
                     maybePath
                       .filter(_.trim.nonEmpty)

--- a/tests/src/test/scala/com/scylladb/migrator/GcsSavepointsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/GcsSavepointsTest.scala
@@ -263,11 +263,38 @@ class GcsSavepointsTest extends munit.FunSuite {
     } finally deleteRecursively(root)
   }
 
+  test("Hadoop PathIO resolves the filesystem for each path authority") {
+    val root = Files.createTempDirectory("savepoints-gs-authority")
+    try {
+      val conf = hadoopConf(root)
+      conf.setBoolean(LocalGsFileSystem.RejectMismatchedAuthorityConfigKey, true)
+      val pathIO = PathIO.forPath("gs://bucket-a/migrator/savepoints", Some(conf))
+      val savepointPath = "gs://bucket-b/migrator/savepoints/savepoint-authority.yaml"
+
+      pathIO.writeUtf8Atomically(
+        savepointPath,
+        "savepoint".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+      )
+
+      assert(
+        Files.exists(
+          root
+            .resolve("bucket-b")
+            .resolve("migrator")
+            .resolve("savepoints")
+            .resolve("savepoint-authority.yaml")
+        )
+      )
+    } finally deleteRecursively(root)
+  }
+
   test("unsupported s3a savepoint paths report S3A connector guidance") {
     val conf = new Configuration(false)
 
     val error = intercept[IllegalArgumentException] {
-      PathIO.forPath("s3a://bucket-a/migrator/savepoints", Some(conf))
+      PathIO
+        .forPath("s3a://bucket-a/migrator/savepoints", Some(conf))
+        .exists("s3a://bucket-a/migrator/savepoints")
     }
 
     assert(
@@ -402,6 +429,8 @@ object LocalGsFileSystem {
     "scylla.migrator.test.expected.fs.s3a.aws.credentials.provider"
   val ForbidSessionTokenConfigKey =
     "scylla.migrator.test.forbid.fs.s3a.session.token"
+  val RejectMismatchedAuthorityConfigKey =
+    "scylla.migrator.test.reject-mismatched-authority"
 }
 
 class LocalGsFileSystem extends FileSystem {
@@ -410,6 +439,7 @@ class LocalGsFileSystem extends FileSystem {
   private var fsUri: URI = _
   private var workingDirectory: HadoopPath = _
   private var failRename: Boolean = false
+  private var rejectMismatchedAuthority: Boolean = false
 
   override def initialize(name: URI, conf: Configuration): Unit = {
     super.initialize(name, conf)
@@ -437,6 +467,8 @@ class LocalGsFileSystem extends FileSystem {
     fsUri            = new URI(name.getScheme, name.getAuthority, null, null, null)
     workingDirectory = new HadoopPath(s"${fsUri.toString}/")
     failRename       = conf.getBoolean(LocalGsFileSystem.FailRenameConfigKey, false)
+    rejectMismatchedAuthority =
+      conf.getBoolean(LocalGsFileSystem.RejectMismatchedAuthorityConfigKey, false)
   }
 
   override def getUri: URI = fsUri
@@ -501,7 +533,13 @@ class LocalGsFileSystem extends FileSystem {
 
   private def toLocalNioPath(path: HadoopPath): Path = {
     val uri = path.toUri
-    val bucket = Option(uri.getAuthority).getOrElse(Option(fsUri.getAuthority).getOrElse("bucket"))
+    val pathAuthority = Option(uri.getAuthority)
+    val fsAuthority = Option(fsUri.getAuthority)
+    if (rejectMismatchedAuthority && pathAuthority.exists(_ != fsAuthority.orNull))
+      throw new IOException(
+        s"Path authority ${pathAuthority.orNull} does not match filesystem authority ${fsAuthority.orNull}"
+      )
+    val bucket = pathAuthority.getOrElse(fsAuthority.getOrElse("bucket"))
     val objectPath = Option(uri.getPath).getOrElse("").stripPrefix("/")
     root.resolve(bucket).resolve(objectPath)
   }


### PR DESCRIPTION
## Summary
- save points followups for Hadoop-backed GCP bucket and S3 savepoint handling
- resolve Hadoop FileSystem instances per path operation and close them after use
- harden savepoint target decoding for future non-storage target types
- split Scylla service startup so GCS is only started by the GCS savepoint integration path

## Testing
- JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH sbt scalafmtCheckAll "tests/testOnly com.scylladb.migrator.GcsSavepointsTest com.scylladb.migrator.config.MigratorConfigTest"
- JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH make test-unit
- PR CI is green, including Scylla integration