### PR TITLE
Add target-table savepoint storage

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -491,8 +491,28 @@ savepoints:
   #   # credentials:
   #   #   accessKey: ...
   #   #   secretKey: ...
+
   # Interval in which savepoints will be created
   intervalSeconds: 300
+
+  # When true, load the newest valid savepoint from the configured target before migrating.
+  # For filesystem savepoints, you can also keep using the existing workflow of running the latest
+  # savepoint YAML file directly.
+  resumeFromLatest: false
+
+  # Optional target-table savepoints for ScyllaDB/CQL targets:
+  # The metadata table is created automatically. The keyspace must already exist.
+  # The config_yaml column stores the unredacted savepoint YAML and may include credentials;
+  # restrict access to this table.
+  # target:
+  #   type: target-table
+  #   # Default: target.keyspace
+  #   keyspace: null
+  #   # Default metadata table name
+  #   table: scylla_migrator_savepoints
+  #   # Optional stable job id override. If omitted, the migrator derives one from the
+  #   # redacted source/target config identity.
+  #   jobId: null
 
   # Optional - enables file-level savepoint tracking for parquet migrations.
   # When enabled (default), the migrator tracks which parquet files have been fully migrated
@@ -534,10 +554,3 @@ savepoints:
 #   # hashColumns:
 #   #   - large_text_column
 #   #   - blob_column
-#   # Optional - numeric cross-type comparison policy.
-#   # Lenient (default): Int==Long==BigInt==BigDecimal(scale<=0) treated as equal;
-#   #   Float/Double normalized to BigDecimal within floatingPointTolerance.
-#   # DetectWiden: same as Lenient, but flags Float->Double widening that loses bits
-#   #   (e.g. Float(0.1f) vs Double(0.1)) as NumericTypeMismatch.
-#   # StrictType: any Float vs Double pair flagged regardless of value.
-#   # numericTypePolicy: Lenient

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -521,6 +521,59 @@ writes so that re-running the migration is safe.
     path: /app/savepoints
     # Interval at which savepoints will be created
     intervalSeconds: 300
+    # Load the newest valid savepoint from the configured target before migration.
+    resumeFromLatest: false
+
+The top-level ``path`` is a shorthand for an explicit filesystem target:
+
+.. code-block:: yaml
+
+  savepoints:
+    intervalSeconds: 300
+    target:
+      type: filesystem
+      path: /app/savepoints
+
+If ``target.type`` is ``filesystem`` and ``target.path`` is omitted, the migrator uses the
+top-level ``savepoints.path`` value.
+
+For ScyllaDB targets, savepoints can also be stored in the target database:
+
+.. code-block:: yaml
+
+  savepoints:
+    intervalSeconds: 300
+    resumeFromLatest: false
+    target:
+      type: target-table
+      # Optional. Default: target.keyspace. The keyspace must already exist.
+      keyspace: null
+      # Optional. Created automatically if it does not exist.
+      table: scylla_migrator_savepoints
+      # Optional. If omitted, the migrator derives a stable job id from the
+      # redacted source and target configuration identity.
+      jobId: null
+
+The ``target-table`` backend is supported only when the migration ``target.type`` is ``scylla``.
+The migrator creates the metadata table automatically, but it does not create the keyspace. Each
+savepoint is stored as an append-only version in this table:
+
+.. code-block:: cql
+
+  CREATE TABLE IF NOT EXISTS <keyspace>.<table> (
+    job_id text,
+    epoch_millis bigint,
+    sequence bigint,
+    schema_version int,
+    reason text,
+    migrator_version text,
+    config_sha256 text,
+    config_yaml text,
+    PRIMARY KEY ((job_id), epoch_millis, sequence)
+  ) WITH CLUSTERING ORDER BY (epoch_millis DESC, sequence DESC);
+
+The ``config_yaml`` column contains the unredacted savepoint YAML, matching file-backed
+savepoints. It may contain credentials and other sensitive values; restrict access to this table.
 
 The legacy ``path`` field is shorthand for an explicit local filesystem target:
 

--- a/docs/source/resume-interrupted-migration.rst
+++ b/docs/source/resume-interrupted-migration.rst
@@ -2,13 +2,15 @@
 Resume an Interrupted Migration Where it Left Off
 =================================================
 
-.. note:: This feature is currently supported only when migrating from Apache Cassandra or DynamoDB.
+.. note:: This feature is supported for resumable sources such as Apache Cassandra/ScyllaDB CQL, DynamoDB/Alternator, and Parquet with file-level tracking enabled. MySQL migrations are not resumable.
 
 If, for some reason, the migration is interrupted (e.g., because of a networking issue, or if you need to manually stop it for some reason), the migrator is able to resume it from a “savepoints”.
 
 Savepoints are configuration files that contain information about the already migrated items, which can be skipped when the migration is resumed. The savepoint files are automatically generated during the migration. To use a savepoint, start a migration using it as configuration file.
 
 You can control the savepoints location and the interval at which they are generated in the configuration file under the top-level property ``savepoints``. See the corresponding section of the :ref:`configuration reference <config-savepoints>` .
+
+File-backed savepoints are the default. With this backend, savepoints are generated as files in the configured directory.
 
 During the migration, the savepoints are generated with file names like ``savepoint_<epochMillis>_<counter>.yaml``, where:
 
@@ -19,3 +21,36 @@ Both components are zero-padded so that **lexicographical order matches chronolo
 
 .. note::
    Older versions of the migrator produced file names like ``savepoint_1234567890.yaml`` (a single Unix-epoch-seconds component). The migrator still reads those files, but any new savepoint written during a resumed migration follows the two-component format above.
+
+Target-Database Savepoints
+---------------------------
+
+When the migration target is ScyllaDB (``target.type: scylla``), savepoints can be stored in the target database instead of on the Spark driver filesystem:
+
+.. code-block:: yaml
+
+  savepoints:
+    intervalSeconds: 300
+    resumeFromLatest: false
+    target:
+      type: target-table
+      # Optional. Default: target.keyspace.
+      keyspace: null
+      # Optional. Created automatically.
+      table: scylla_migrator_savepoints
+      # Optional stable job id override.
+      jobId: null
+
+The metadata keyspace must already exist. The migrator creates the metadata table automatically and appends one row per savepoint version. To resume from the newest target-database savepoint, run the original configuration with:
+
+.. code-block:: yaml
+
+  savepoints:
+    target:
+      type: target-table
+    resumeFromLatest: true
+
+If ``target.jobId`` is omitted, the migrator derives a stable id from the redacted source and target configuration identity, excluding progress fields, ``savepoints``, and ``validation``. Use the same original config to resume so the derived job id stays the same. During lookup, the migrator reads rows for that job from newest to oldest and skips corrupt or unparseable YAML rows with warnings.
+
+.. warning::
+   Target-database savepoints store the same unredacted YAML payload as file-backed savepoints. The ``config_yaml`` column may contain credentials and other sensitive values. Restrict access to the metadata table.

--- a/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
@@ -49,11 +49,13 @@ object Migrator {
     * `main` (spark-submit). The caller is responsible for creating and stopping the SparkSession.
     */
   def migrate(config: MigratorConfig)(implicit spark: SparkSession): Unit = {
+    val effectiveConfig = resumeFromLatestIfRequested(config)
+
     // Backend-neutral warning. Any source whose `supportsSavepoints` is `false` (MySQL, DynamoDB
     // S3 export, future non-resumable backends) gets the same up-front notice without per-source
     // `case` branches. Source-specific reader caveats (e.g. MySQL JDBC partitioning semantics)
     // are emitted from the reader itself.
-    if (!config.source.supportsSavepoints) {
+    if (!effectiveConfig.source.supportsSavepoints) {
       log.warn(
         "Source does not support savepoints; any configured savepoints settings are ignored. " +
           "If this migration is interrupted, it must be restarted from scratch. " +
@@ -61,35 +63,35 @@ object Migrator {
       )
     }
 
-    (config.source, config.target) match {
+    (effectiveConfig.source, effectiveConfig.target) match {
       case (cqlSource: SourceSettings.Cassandra, scyllaTarget: TargetSettings.Scylla) =>
         val sourceDF = readers.Cassandra.readDataframe(
           spark,
           cqlSource,
           cqlSource.preserveTimestamps,
-          config.getSkipTokenRangesOrEmptySet
+          effectiveConfig.getSkipTokenRangesOrEmptySet
         )
-        ScyllaMigrator.migrate(config, scyllaTarget, sourceDF)
+        ScyllaMigrator.migrate(effectiveConfig, scyllaTarget, sourceDF)
       case (mysqlSource: SourceSettings.MySQL, scyllaTarget: TargetSettings.Scylla) =>
         log.info("Starting MySQL to ScyllaDB migration")
         val sourceDF = readers.MySQL.readDataframe(spark, mysqlSource)
-        ScyllaMigrator.migrate(config, scyllaTarget, sourceDF)
+        ScyllaMigrator.migrate(effectiveConfig, scyllaTarget, sourceDF)
       case (parquetSource: SourceSettings.Parquet, scyllaTarget: TargetSettings.Scylla) =>
-        readers.Parquet.migrateToScylla(config, parquetSource, scyllaTarget)
+        readers.Parquet.migrateToScylla(effectiveConfig, parquetSource, scyllaTarget)
       case (cqlSource: SourceSettings.Cassandra, parquetTarget: TargetSettings.Parquet) =>
-        ScyllaMigrator.migrateToParquet(cqlSource, parquetTarget, config)
+        ScyllaMigrator.migrateToParquet(cqlSource, parquetTarget, effectiveConfig)
       case (dynamoSource: SourceSettings.DynamoDBLike, dynamoTarget: TargetSettings.DynamoDBLike) =>
-        AlternatorMigrator.migrateFromDynamoDB(dynamoSource, dynamoTarget, config)
+        AlternatorMigrator.migrateFromDynamoDB(dynamoSource, dynamoTarget, effectiveConfig)
       case (
             dynamoSource: SourceSettings.DynamoDB,
             s3ExportTarget: TargetSettings.DynamoDBS3Export
           ) =>
-        AlternatorMigrator.migrateToS3Export(dynamoSource, s3ExportTarget, config)
+        AlternatorMigrator.migrateToS3Export(dynamoSource, s3ExportTarget, effectiveConfig)
       case (
             s3Source: SourceSettings.DynamoDBS3Export,
             dynamoTarget: TargetSettings.DynamoDBLike
           ) =>
-        AlternatorMigrator.migrateFromS3Export(s3Source, dynamoTarget, config)
+        AlternatorMigrator.migrateFromS3Export(s3Source, dynamoTarget, effectiveConfig)
       case (source, target) =>
         sys.error(
           s"Unsupported combination of source and target: " +
@@ -97,5 +99,24 @@ object Migrator {
         )
     }
   }
+
+  private[migrator] def resumeFromLatestIfRequested(
+    config: MigratorConfig
+  )(implicit spark: SparkSession): MigratorConfig =
+    if (!config.savepoints.resumeFromLatest) config
+    else if (!config.source.supportsSavepoints) {
+      log.warn(
+        "savepoints.resumeFromLatest is true, but the source does not support savepoints; " +
+          "ignoring the resume request."
+      )
+      config
+    } else {
+      log.info("savepoints.resumeFromLatest is true; loading the newest valid savepoint.")
+      val store = SavepointStore.forConfig(config, Some(spark.sparkContext))
+      store.prepare()
+      val resumed = store.latestConfig()
+      log.info(s"Loaded config from latest savepoint:\n${resumed.renderRedacted}")
+      resumed
+    }
 
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/SavepointStore.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/SavepointStore.scala
@@ -1,0 +1,702 @@
+package com.scylladb.migrator
+
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.scylladb.migrator.config.{
+  MigratorConfig,
+  SavepointTarget,
+  SensitiveKeys,
+  SparkSecretRedaction,
+  TargetSettings
+}
+import io.circe.{ Json, JsonObject }
+import io.circe.syntax._
+import org.apache.hadoop.conf.Configuration
+import org.apache.logging.log4j.LogManager
+import org.apache.spark.SparkContext
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.Locale
+import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
+
+private[migrator] case class SavepointCoordinates(epochMillis: Long, sequence: Long)
+
+private[migrator] case class SavepointRecord(
+  coordinates: SavepointCoordinates,
+  reason: String,
+  yaml: String
+)
+
+private[migrator] trait SavepointStore {
+  def prepare(): Unit
+  def seedState(): Option[SavepointCoordinates]
+  def save(record: SavepointRecord): String
+  def latestConfig(): MigratorConfig
+}
+
+private[migrator] object SavepointStore {
+  private val RedactedValue = "<redacted>"
+
+  def forConfig(config: MigratorConfig, sparkContext: Option[SparkContext]): SavepointStore =
+    config.savepoints.resolvedTarget match {
+      case target: SavepointTarget.StoragePathTarget =>
+        file(
+          target.storagePath,
+          Some(configIdentitySha256(config)),
+          Some(
+            savepointHadoopConfiguration(
+              config,
+              sparkContext.map(_.hadoopConfiguration),
+              sparkContext.flatMap(SparkSecretRedaction.redactionRegex)
+            )
+          )
+        )
+      case _: SavepointTarget.TargetTable =>
+        val scyllaTarget = config.target match {
+          case target: TargetSettings.Scylla => target
+          case other =>
+            throw new IllegalArgumentException(
+              s"savepoints.target.type: target-table requires target.type scylla, got ${other.getClass.getSimpleName}"
+            )
+        }
+        val spark = sparkContext.getOrElse {
+          throw new IllegalArgumentException(
+            "savepoints.target.type: target-table requires a SparkContext to build the target connector"
+          )
+        }
+        target(config, scyllaTarget, spark)
+    }
+
+  def file(config: MigratorConfig): SavepointStore =
+    config.savepoints.resolvedTarget match {
+      case target: SavepointTarget.StoragePathTarget =>
+        file(
+          target.storagePath,
+          Some(configIdentitySha256(config)),
+          Some(savepointHadoopConfiguration(config, None, None))
+        )
+      case _: SavepointTarget.TargetTable =>
+        throw new IllegalArgumentException(
+          "savepoints.target.type: target-table requires SavepointStore.forConfig with a " +
+            "SparkContext, or an explicit SavepointStore."
+        )
+    }
+
+  def file(path: String): SavepointStore =
+    new FileSavepointStore(path)
+
+  private def file(
+    path: String,
+    expectedConfigSha256: Option[String],
+    hadoopConfiguration: Option[Configuration]
+  ): SavepointStore =
+    new FileSavepointStore(path, expectedConfigSha256, hadoopConfiguration)
+
+  def target(
+    config: MigratorConfig,
+    target: TargetSettings.Scylla,
+    sparkContext: SparkContext
+  ): ScyllaTargetSavepointStore = {
+    val savepointTarget = config.savepoints.resolvedTarget match {
+      case targetTable: SavepointTarget.TargetTable => targetTable
+      case other =>
+        throw new IllegalArgumentException(
+          s"savepoints.target.type must be target-table to build a target-table store, got ${other}"
+        )
+    }
+    val keyspace = savepointTarget.keyspace.getOrElse(target.keyspace)
+    val table = savepointTarget.table
+    new ScyllaTargetSavepointStore(
+      connector     = Connectors.targetConnector(sparkContext.getConf, target),
+      keyspace      = keyspace,
+      table         = table,
+      jobId         = targetJobId(config),
+      configSha256  = configIdentitySha256(config),
+      schemaVersion = ScyllaTargetSavepointStore.SchemaVersion
+    )
+  }
+
+  def targetJobId(config: MigratorConfig): String =
+    config.savepoints.resolvedTarget match {
+      case targetTable: SavepointTarget.TargetTable =>
+        targetTable.jobId.getOrElse(s"auto-${configIdentitySha256(config).take(32)}")
+      case _: SavepointTarget.StoragePathTarget =>
+        s"auto-${configIdentitySha256(config).take(32)}"
+    }
+
+  def configIdentitySha256(config: MigratorConfig): String =
+    sha256Hex(canonicalRedactedIdentity(config).noSpaces)
+
+  private[migrator] def canonicalRedactedIdentity(config: MigratorConfig): Json = {
+    val withoutVolatileFields =
+      config.asJson.mapObject(
+        _.remove("savepoints")
+          .remove("validation")
+          .remove("skipTokenRanges")
+          .remove("skipSegments")
+          .remove("skipParquetFiles")
+      )
+    canonicalJson(redactIdentity(withoutVolatileFields))
+  }
+
+  private def canonicalJson(json: Json): Json =
+    json.arrayOrObject(
+      json,
+      values => Json.fromValues(values.map(canonicalJson)),
+      obj =>
+        Json.fromJsonObject(
+          JsonObject.fromIterable(
+            obj.toIterable.toList
+              .sortBy(_._1)
+              .map { case (key, value) => key -> canonicalJson(value) }
+          )
+        )
+    )
+
+  private def redactIdentity(json: Json): Json =
+    json.arrayOrObject(
+      json,
+      values => Json.fromValues(values.map(redactIdentity)),
+      obj =>
+        Json.fromJsonObject(
+          obj.toIterable.foldLeft(JsonObject.empty) { case (acc, (key, value)) =>
+            val updatedValue =
+              if (value.isString && SensitiveKeys.isSensitiveKey(key))
+                Json.fromString(RedactedValue)
+              else if (key == "where")
+                // WHERE clauses affect the migrated dataset; digest them so the identity changes
+                // without exposing the raw filter in the canonical identity JSON.
+                value.asString
+                  .map(where => Json.obj("sha256" -> sha256Hex(where).asJson))
+                  .getOrElse(redactIdentity(value))
+              else
+                redactIdentity(value)
+            acc.add(key, updatedValue)
+          }
+        )
+    )
+
+  private def sha256Hex(value: String): String = {
+    val digest = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8))
+    digest.map(b => f"${b & 0xff}%02x").mkString
+  }
+
+  private[migrator] def savepointSortKey(name: String): Option[(Long, Long)] = {
+    def reasonableSortKey(millis: Long, sequence: Long): Option[(Long, Long)] =
+      if (SavepointsManager.isResumeSafeSortKey(millis, sequence))
+        Some((millis, sequence))
+      else None
+
+    name match {
+      case SavepointsManager.SavepointName(head, tailOrNull) =>
+        try
+          if (tailOrNull == null) {
+            val millis = java.lang.Math.multiplyExact(java.lang.Long.parseLong(head), 1000L)
+            reasonableSortKey(millis, -1L)
+          } else {
+            val millis = java.lang.Long.parseLong(head)
+            val seq = java.lang.Long.parseLong(tailOrNull)
+            reasonableSortKey(millis, seq)
+          }
+        catch {
+          case _: NumberFormatException | _: ArithmeticException =>
+            None
+        }
+      case _ =>
+        None
+    }
+  }
+
+  private def savepointHadoopConfiguration(
+    config: MigratorConfig,
+    baseConfiguration: Option[Configuration],
+    redactionRegex: Option[String]
+  ): Configuration = {
+    val conf = baseConfiguration.map(new Configuration(_)).getOrElse(new Configuration())
+
+    config.savepoints.resolvedTarget match {
+      case s3: SavepointTarget.S3 =>
+        s3.region.foreach(conf.set("fs.s3a.endpoint.region", _))
+        s3.credentials.foreach { configuredCredentials =>
+          AwsUtils.computeFinalCredentials(Some(configuredCredentials), None, s3.region).foreach {
+            credentials =>
+              val credentialOptions =
+                Seq(
+                  "fs.s3a.access.key" -> credentials.accessKey,
+                  "fs.s3a.secret.key" -> credentials.secretKey
+                ) ++ credentials.maybeSessionToken.toSeq.map { sessionToken =>
+                  "fs.s3a.session.token" -> sessionToken
+                }
+
+              ensureHadoopKeysRedacted(redactionRegex, credentialOptions.map(_._1))
+              credentialOptions.foreach { case (key, value) => conf.set(key, value) }
+              credentials.maybeSessionToken match {
+                case Some(_) =>
+                  conf.set("fs.s3a.aws.credentials.provider", S3ATemporaryCredentialsProvider)
+                case None =>
+                  conf.set("fs.s3a.aws.credentials.provider", S3ASimpleCredentialsProvider)
+                  conf.unset("fs.s3a.session.token")
+              }
+          }
+        }
+      case gcs: SavepointTarget.GCS =>
+        gcs.projectId.foreach(conf.set("fs.gs.project.id", _))
+        gcs.credentials.foreach { credentials =>
+          ensureHadoopKeysRedacted(
+            redactionRegex,
+            Seq("fs.gs.auth.service.account.json.keyfile")
+          )
+          conf.set("fs.gs.auth.type", GcsServiceAccountJsonKeyfileAuthType)
+          conf.set(
+            "fs.gs.auth.service.account.json.keyfile",
+            credentials.serviceAccountJsonKeyfile
+          )
+        }
+      case _ => ()
+    }
+
+    conf
+  }
+
+  private def ensureHadoopKeysRedacted(
+    redactionRegex: Option[String],
+    keys: Iterable[String]
+  ): Unit =
+    SparkSecretRedaction.ensureKeysRedacted(
+      redactionRegex,
+      keys,
+      "savepoint Hadoop configuration"
+    )
+
+  private val S3ASimpleCredentialsProvider =
+    "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+
+  private val S3ATemporaryCredentialsProvider =
+    "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider"
+
+  private val GcsServiceAccountJsonKeyfileAuthType = "SERVICE_ACCOUNT_JSON_KEYFILE"
+}
+
+private[migrator] class FileSavepointStore(
+  path: String,
+  expectedConfigSha256: Option[String] = None,
+  hadoopConfiguration: Option[Configuration] = None
+) extends SavepointStore {
+  private val log = LogManager.getLogger(classOf[FileSavepointStore])
+  private val pathIO = PathIO.forPath(path, hadoopConfiguration)
+
+  override def prepare(): Unit =
+    if (!pathIO.exists(path)) {
+      log.debug(
+        s"Directory ${pathIO.normalize(path)} does not exist. Creating it..."
+      )
+      pathIO.createDirectories(path)
+    }
+
+  override def seedState(): Option[SavepointCoordinates] = {
+    if (!pathIO.exists(path)) return None
+
+    var maxMillis = 0L
+    var maxSeq = 0L
+    try
+      pathIO.listFileNames(path).foreach { name =>
+        name match {
+          case SavepointsManager.SavepointName(head, tailOrNull) =>
+            val parsedCoordinates =
+              try
+                Some {
+                  val millis =
+                    if (tailOrNull == null)
+                      java.lang.Math.multiplyExact(java.lang.Long.parseLong(head), 1000L)
+                    else java.lang.Long.parseLong(head)
+                  val seq =
+                    if (tailOrNull == null) 0L
+                    else java.lang.Long.parseLong(tailOrNull)
+                  (millis, seq)
+                }
+              catch {
+                case _: NumberFormatException | _: ArithmeticException => None
+              }
+
+            parsedCoordinates match {
+              case None =>
+                log.warn(
+                  s"Ignoring hostile/corrupted savepoint filename ${name} during seed: " +
+                    s"coordinates are not valid signed 64-bit integers."
+                )
+              case Some((millis, seq)) =>
+                if (!SavepointsManager.isResumeSafeCoordinate(millis, seq)) {
+                  log.warn(
+                    s"Ignoring hostile/corrupted savepoint filename ${name} during seed " +
+                      s"(millis=${millis}, seq=${seq} outside accepted bounds: " +
+                      s"millis < ${SavepointsManager.MaxReasonableSeedValue}, " +
+                      s"seq <= ${SavepointsManager.MaxSavepointSequenceValue}, and " +
+                      s"max-sequence seeds must leave room for millisecond rollover)."
+                  )
+                } else if (millis > maxMillis || (millis == maxMillis && seq > maxSeq)) {
+                  maxMillis = millis
+                  maxSeq    = seq
+                }
+            }
+          case _ => ()
+        }
+      }
+    catch {
+      case NonFatal(e) =>
+        log.warn(
+          s"Could not scan ${pathIO.normalize(path)} to seed savepoint state; " +
+            s"falling back to clock-only ordering: ${e.getMessage}"
+        )
+        return None
+    }
+
+    if (maxMillis > 0L) Some(SavepointCoordinates(maxMillis, maxSeq))
+    else None
+  }
+
+  override def save(record: SavepointRecord): String = {
+    val finalPath =
+      childPath(
+        String.format(
+          Locale.ROOT,
+          "savepoint_%013d_%010d.yaml",
+          java.lang.Long.valueOf(record.coordinates.epochMillis),
+          java.lang.Long.valueOf(record.coordinates.sequence)
+        )
+      )
+
+    pathIO.writeUtf8Atomically(finalPath, record.yaml.getBytes(StandardCharsets.UTF_8))
+    pathIO.normalize(finalPath)
+  }
+
+  override def latestConfig(): MigratorConfig = {
+    val candidates =
+      if (!pathIO.exists(path)) Seq.empty
+      else pathIO.listFileNames(path).filter(name => name.startsWith("savepoint_") && name.endsWith(".yaml"))
+
+    candidates
+      .flatMap { name =>
+        SavepointStore.savepointSortKey(name) match {
+          case Some(sortKey) => Some(sortKey -> name)
+          case None =>
+            log.warn(
+              s"Skipping savepoint file ${childPath(name)}: filename coordinates are invalid or unreasonable."
+            )
+            None
+        }
+      }
+      .sortBy(_._1)
+      .reverseIterator
+      .map { case (_, savepointName) =>
+        val savepoint = childPath(savepointName)
+        try {
+          val config = MigratorConfig.loadFromString(pathIO.readUtf8(savepoint))
+          expectedConfigSha256 match {
+            case None => Some(config)
+            case Some(expected) =>
+              val actual = SavepointStore.configIdentitySha256(config)
+              if (actual == expected) Some(config)
+              else {
+                log.warn(
+                  s"Skipping savepoint file ${savepoint}: config identity mismatch: " +
+                    s"expected ${expected}, got ${actual}."
+                )
+                None
+              }
+          }
+        } catch {
+          case NonFatal(e) =>
+            log.warn(
+              s"Skipping invalid savepoint file ${savepoint}: ${Option(e.getMessage).getOrElse(e.toString)}"
+            )
+            None
+        }
+      }
+      .collectFirst { case Some(config) => config }
+      .getOrElse(
+        throw new IllegalStateException(
+          s"No valid file-backed savepoint found in ${pathIO.normalize(path)}"
+        )
+      )
+  }
+
+  private def childPath(name: String): String =
+    if (path.endsWith("/")) s"${path}${name}"
+    else s"${path}/${name}"
+}
+
+private[migrator] class ScyllaTargetSavepointStore(
+  connector: CassandraConnector,
+  keyspace: String,
+  table: String,
+  jobId: String,
+  configSha256: String,
+  schemaVersion: Int
+) extends SavepointStore {
+  import ScyllaTargetSavepointStore._
+
+  private val log = LogManager.getLogger(classOf[ScyllaTargetSavepointStore])
+  private val tableName = s"${cqlIdentifier(keyspace)}.${cqlIdentifier(table)}"
+
+  override def prepare(): Unit =
+    connector.withSessionDo { session =>
+      session.execute(
+        s"""CREATE TABLE IF NOT EXISTS ${tableName} (
+           |  job_id text,
+           |  epoch_millis bigint,
+           |  sequence bigint,
+           |  schema_version int,
+           |  reason text,
+           |  migrator_version text,
+           |  config_sha256 text,
+           |  config_yaml text,
+           |  PRIMARY KEY ((job_id), epoch_millis, sequence)
+           |) WITH CLUSTERING ORDER BY (epoch_millis DESC, sequence DESC)""".stripMargin
+      )
+    }
+
+  override def seedState(): Option[SavepointCoordinates] =
+    connector.withSessionDo { session =>
+      val statement =
+        session.prepare(
+          s"SELECT epoch_millis, sequence, config_sha256 FROM ${tableName} WHERE job_id = ?"
+        )
+      val rows = session
+        .execute(statement.bind(jobId))
+        .iterator()
+        .asScala
+        .map(row =>
+          StoredSavepointCoordinates(
+            epochMillis  = row.getLong("epoch_millis"),
+            sequence     = row.getLong("sequence"),
+            configSha256 = Option(row.getString("config_sha256"))
+          )
+        )
+        .toSeq
+
+      newestCoordinates(rows, Some(configSha256), warnInvalidSeed)
+    }
+
+  override def save(record: SavepointRecord): String =
+    connector.withSessionDo { session =>
+      val statement =
+        session.prepare(
+          s"""INSERT INTO ${tableName} (
+             |  job_id,
+             |  epoch_millis,
+             |  sequence,
+             |  schema_version,
+             |  reason,
+             |  migrator_version,
+             |  config_sha256,
+             |  config_yaml
+             |) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""".stripMargin
+        )
+      session.execute(
+        statement.bind(
+          jobId,
+          java.lang.Long.valueOf(record.coordinates.epochMillis),
+          java.lang.Long.valueOf(record.coordinates.sequence),
+          Integer.valueOf(schemaVersion),
+          record.reason,
+          BuildInfo.version,
+          configSha256,
+          record.yaml
+        )
+      )
+      s"${tableName} job_id=${jobId} epoch_millis=${record.coordinates.epochMillis} sequence=${record.coordinates.sequence}"
+    }
+
+  override def latestConfig(): MigratorConfig =
+    connector.withSessionDo { session =>
+      val statement =
+        session.prepare(
+          s"SELECT epoch_millis, sequence, config_sha256, config_yaml FROM ${tableName} WHERE job_id = ?"
+        )
+      val rows = session
+        .execute(statement.bind(jobId))
+        .iterator()
+        .asScala
+        .map(row =>
+          StoredSavepoint(
+            epochMillis  = row.getLong("epoch_millis"),
+            sequence     = row.getLong("sequence"),
+            configYaml   = row.getString("config_yaml"),
+            configSha256 = Option(row.getString("config_sha256"))
+          )
+        )
+        .toSeq
+
+      newestValidConfig(rows, configSha256, warnInvalidRow)
+        .getOrElse(
+          throw new IllegalStateException(
+            s"No valid target-database savepoint found in ${tableName} for job_id=${jobId}"
+          )
+        )
+    }
+
+  private def warnInvalidRow(row: StoredSavepoint, error: Throwable): Unit =
+    log.warn(
+      s"Skipping invalid target-database savepoint in ${tableName} for job_id=${jobId} " +
+        s"epoch_millis=${row.epochMillis} sequence=${row.sequence}: " +
+        s"${Option(error.getMessage).getOrElse(error.toString)}"
+    )
+
+  private def warnInvalidSeed(row: StoredSavepointCoordinates, error: Throwable): Unit =
+    log.warn(
+      s"Skipping invalid target-database savepoint seed in ${tableName} for job_id=${jobId} " +
+        s"epoch_millis=${row.epochMillis} sequence=${row.sequence}: " +
+        s"${Option(error.getMessage).getOrElse(error.toString)}"
+    )
+}
+
+private[migrator] object ScyllaTargetSavepointStore {
+  val SchemaVersion: Int = 1
+
+  private val UnquotedIdentifier = "^[A-Za-z][A-Za-z0-9_]*$".r
+  private val QuotedIdentifier = "^\"((?:[^\"]|\"\")*)\"$".r
+
+  private[migrator] case class StoredSavepoint(
+    epochMillis: Long,
+    sequence: Long,
+    configYaml: String,
+    configSha256: Option[String] = None
+  ) {
+    def coordinates: StoredSavepointCoordinates =
+      StoredSavepointCoordinates(epochMillis, sequence, configSha256)
+  }
+
+  private[migrator] case class StoredSavepointCoordinates(
+    epochMillis: Long,
+    sequence: Long,
+    configSha256: Option[String]
+  )
+
+  private[migrator] def newestValidConfig(
+    rows: Iterable[StoredSavepoint],
+    warnInvalidRow: (StoredSavepoint, Throwable) => Unit
+  ): Option[MigratorConfig] =
+    newestValidConfig(rows, None, warnInvalidRow)
+
+  private[migrator] def newestValidConfig(
+    rows: Iterable[StoredSavepoint],
+    expectedConfigSha256: String,
+    warnInvalidRow: (StoredSavepoint, Throwable) => Unit
+  ): Option[MigratorConfig] =
+    newestValidConfig(rows, Some(expectedConfigSha256), warnInvalidRow)
+
+  private def newestValidConfig(
+    rows: Iterable[StoredSavepoint],
+    expectedConfigSha256: Option[String],
+    warnInvalidRow: (StoredSavepoint, Throwable) => Unit
+  ): Option[MigratorConfig] =
+    rows.toSeq
+      .filter(row => reasonableCoordinates(row.coordinates, warnInvalidRowFor(row, warnInvalidRow)))
+      .filter(row =>
+        matchesExpectedIdentity(
+          row.coordinates,
+          expectedConfigSha256,
+          warnInvalidRowFor(row, warnInvalidRow)
+        )
+      )
+      .sortBy(row => (row.epochMillis, row.sequence))
+      .reverseIterator
+      .map { row =>
+        try {
+          val config = MigratorConfig.loadFromString(row.configYaml)
+          expectedConfigSha256 match {
+            case None => Some(config)
+            case Some(expected) =>
+              val actual = SavepointStore.configIdentitySha256(config)
+              if (actual == expected) Some(config)
+              else {
+                warnInvalidRow(
+                  row,
+                  new IllegalArgumentException(
+                    s"config_yaml identity mismatch: expected ${expected}, got ${actual}"
+                  )
+                )
+                None
+              }
+          }
+        } catch {
+          case NonFatal(e) =>
+            warnInvalidRow(row, e)
+            None
+        }
+      }
+      .collectFirst { case Some(config) => config }
+
+  private[migrator] def newestCoordinates(
+    rows: Iterable[StoredSavepointCoordinates],
+    expectedConfigSha256: Option[String],
+    warnInvalidRow: (StoredSavepointCoordinates, Throwable) => Unit
+  ): Option[SavepointCoordinates] =
+    rows.toSeq
+      .filter(row => reasonableCoordinates(row, warnInvalidRow))
+      .filter(row => matchesExpectedIdentity(row, expectedConfigSha256, warnInvalidRow))
+      .sortBy(row => (row.epochMillis, row.sequence))
+      .lastOption
+      .map(row => SavepointCoordinates(row.epochMillis, row.sequence))
+
+  private def warnInvalidRowFor(
+    row: StoredSavepoint,
+    warnInvalidRow: (StoredSavepoint, Throwable) => Unit
+  ): (StoredSavepointCoordinates, Throwable) => Unit =
+    (_, error) => warnInvalidRow(row, error)
+
+  private def reasonableCoordinates(
+    row: StoredSavepointCoordinates,
+    warnInvalidRow: (StoredSavepointCoordinates, Throwable) => Unit
+  ): Boolean = {
+    val reasonable =
+      SavepointsManager.isResumeSafeCoordinate(row.epochMillis, row.sequence)
+    if (!reasonable)
+      warnInvalidRow(
+        row,
+        new IllegalArgumentException(
+          s"unreasonable savepoint coordinates: epoch_millis=${row.epochMillis}, " +
+            s"sequence=${row.sequence}; coordinates must be within bounds and max-sequence " +
+            s"values must leave room for millisecond rollover"
+        )
+      )
+    reasonable
+  }
+
+  private def matchesExpectedIdentity(
+    row: StoredSavepointCoordinates,
+    expectedConfigSha256: Option[String],
+    warnInvalidRow: (StoredSavepointCoordinates, Throwable) => Unit
+  ): Boolean =
+    expectedConfigSha256 match {
+      case None => true
+      case Some(expected) =>
+        row.configSha256 match {
+          case Some(actual) if actual == expected => true
+          case Some(actual) =>
+            warnInvalidRow(
+              row,
+              new IllegalArgumentException(
+                s"config_sha256 mismatch: expected ${expected}, got ${actual}"
+              )
+            )
+            false
+          case None =>
+            warnInvalidRow(
+              row,
+              new IllegalArgumentException(s"missing config_sha256; expected ${expected}")
+            )
+            false
+        }
+    }
+
+  private def cqlIdentifier(raw: String): String =
+    raw match {
+      case QuotedIdentifier(_) => raw
+      case UnquotedIdentifier() =>
+        raw.toLowerCase(Locale.ROOT)
+      case other =>
+        "\"" + other.replace("\"", "\"\"") + "\""
+    }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/SavepointStore.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/SavepointStore.scala
@@ -38,7 +38,12 @@ private[migrator] trait SavepointStore {
 private[migrator] object SavepointStore {
   private val RedactedValue = "<redacted>"
 
-  def forConfig(config: MigratorConfig, sparkContext: Option[SparkContext]): SavepointStore =
+  def forConfig(
+    config: MigratorConfig,
+    sparkContext: Option[SparkContext],
+    redactionRegex: Option[String] = None,
+    hadoopConfiguration: Option[Configuration] = None
+  ): SavepointStore =
     config.savepoints.resolvedTarget match {
       case target: SavepointTarget.StoragePathTarget =>
         file(
@@ -47,8 +52,8 @@ private[migrator] object SavepointStore {
           Some(
             savepointHadoopConfiguration(
               config,
-              sparkContext.map(_.hadoopConfiguration),
-              sparkContext.flatMap(SparkSecretRedaction.redactionRegex)
+              sparkContext.map(_.hadoopConfiguration).orElse(hadoopConfiguration),
+              redactionRegex.orElse(sparkContext.flatMap(SparkSecretRedaction.redactionRegex))
             )
           )
         )
@@ -207,6 +212,9 @@ private[migrator] object SavepointStore {
         None
     }
   }
+
+  private[migrator] def savepointSortKey(path: java.nio.file.Path): Option[(Long, Long)] =
+    savepointSortKey(path.getFileName.toString)
 
   private def savepointHadoopConfiguration(
     config: MigratorConfig,
@@ -373,7 +381,10 @@ private[migrator] class FileSavepointStore(
   override def latestConfig(): MigratorConfig = {
     val candidates =
       if (!pathIO.exists(path)) Seq.empty
-      else pathIO.listFileNames(path).filter(name => name.startsWith("savepoint_") && name.endsWith(".yaml"))
+      else
+        pathIO
+          .listFileNames(path)
+          .filter(name => name.startsWith("savepoint_") && name.endsWith(".yaml"))
 
     candidates
       .flatMap { name =>

--- a/migrator/src/main/scala/com/scylladb/migrator/SavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/SavepointsManager.scala
@@ -1,12 +1,9 @@
 package com.scylladb.migrator
 
-import com.scylladb.migrator.config.{ MigratorConfig, SavepointsTarget, SparkSecretRedaction }
-import org.apache.hadoop.conf.Configuration
+import com.scylladb.migrator.config.MigratorConfig
 import org.apache.logging.log4j.LogManager
 import sun.misc.{ Signal, SignalHandler }
 
-import java.nio.charset.StandardCharsets
-import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.ReentrantLock
@@ -32,15 +29,12 @@ import scala.util.control.NonFatal
   * `updateConfigWithMigrationState`.
   *
   * Concurrency and ordering guarantees:
-  *   - `dumpMigrationState` is serialized so that the accumulator snapshot and the storage write
-  *     happen atomically with respect to other dumps. This prevents a scheduled dump from
-  *     overwriting a later terminal dump with a stale snapshot.
-  *   - Savepoint filenames embed a zero-padded millisecond timestamp and a zero-padded per-instance
-  *     monotonic counter (`savepoint_<epochMillis>_<counter>.yaml`). The timestamp is clamped to a
-  *     monotonic non-decreasing value within the manager instance, so a backward wall-clock step
-  *     cannot make a later savepoint sort earlier than an older one. Zero-padding keeps
-  *     lexicographical order consistent with chronological order, so `ls | tail -n 1` also returns
-  *     the newest savepoint.
+  *   - `dumpMigrationState` is serialized so that the accumulator snapshot and the store write
+  *     happen atomically with respect to other dumps. This prevents a scheduled dump from writing
+  *     after a later terminal dump with a stale snapshot.
+  *   - Savepoint versions embed a millisecond timestamp and a per-instance monotonic counter. The
+  *     timestamp is clamped to a monotonic non-decreasing value within the manager instance, so a
+  *     backward wall-clock step cannot make a later savepoint sort earlier than an older one.
   *   - `close()` awaits the scheduler so no scheduled tick races the final dump issued by the
   *     caller after `close()`. The wait is bounded by `MaxCloseAwaitMillis` so a stuck filesystem
   *     cannot hang shutdown indefinitely.
@@ -52,18 +46,13 @@ import scala.util.control.NonFatal
   */
 abstract class SavepointsManager(
   migratorConfig: MigratorConfig,
-  hadoopConfiguration: Option[Configuration] = None,
-  redactionRegex: Option[String] = None
+  maybeSavepointStore: Option[SavepointStore] = None
 ) extends AutoCloseable {
 
   import SavepointsManager._
 
   val log = LogManager.getLogger(this.getClass.getName)
-  private val savepointsPath = migratorConfig.savepoints.storagePath
-  private val pathIO = PathIO.forPath(
-    savepointsPath,
-    Some(savepointHadoopConfiguration(hadoopConfiguration))
-  )
+  private val savepointStore = maybeSavepointStore.getOrElse(SavepointStore.file(migratorConfig))
   private val scheduler = new ScheduledThreadPoolExecutor(1)
   private var oldUsr2Handler: SignalHandler = _
   private var oldTermHandler: SignalHandler = _
@@ -86,163 +75,58 @@ abstract class SavepointsManager(
   // earlier than an older one.
   private var lastSavepointMillis = 0L
 
-  createSavepointsDirectory()
+  savepointStore.prepare()
   seedStateFromExistingSavepoints()
   addUSR2Handler()
   startSavepointSchedule()
 
-  private def savepointHadoopConfiguration(
-    baseConfiguration: Option[Configuration]
-  ): Configuration = {
-    val conf = baseConfiguration.map(new Configuration(_)).getOrElse(new Configuration())
-
-    migratorConfig.savepoints.target.foreach {
-      case s3: SavepointsTarget.S3 =>
-        s3.region.foreach(conf.set("fs.s3a.endpoint.region", _))
-        s3.credentials.foreach { configuredCredentials =>
-          AwsUtils.computeFinalCredentials(Some(configuredCredentials), None, s3.region).foreach {
-            credentials =>
-              val credentialOptions =
-                Seq(
-                  "fs.s3a.access.key" -> credentials.accessKey,
-                  "fs.s3a.secret.key" -> credentials.secretKey
-                ) ++ credentials.maybeSessionToken.toSeq.map { sessionToken =>
-                  "fs.s3a.session.token" -> sessionToken
-                }
-
-              ensureHadoopKeysRedacted(credentialOptions.map(_._1))
-              credentialOptions.foreach { case (key, value) => conf.set(key, value) }
-              credentials.maybeSessionToken match {
-                case Some(_) =>
-                  conf.set("fs.s3a.aws.credentials.provider", S3ATemporaryCredentialsProvider)
-                case None =>
-                  conf.set("fs.s3a.aws.credentials.provider", S3ASimpleCredentialsProvider)
-                  conf.unset("fs.s3a.session.token")
-              }
-          }
-        }
-      case gcs: SavepointsTarget.GCS =>
-        gcs.projectId.foreach(conf.set("fs.gs.project.id", _))
-        gcs.credentials.foreach { credentials =>
-          ensureHadoopKeysRedacted(Seq("fs.gs.auth.service.account.json.keyfile"))
-          conf.set("fs.gs.auth.type", GcsServiceAccountJsonKeyfileAuthType)
-          conf.set(
-            "fs.gs.auth.service.account.json.keyfile",
-            credentials.serviceAccountJsonKeyfile
-          )
-        }
-      case _ => ()
-    }
-
-    conf
-  }
-
-  private def ensureHadoopKeysRedacted(keys: Iterable[String]): Unit =
-    SparkSecretRedaction.ensureKeysRedacted(
-      redactionRegex,
-      keys,
-      "savepoint Hadoop configuration"
-    )
-
-  private def createSavepointsDirectory(): Unit = {
-    val savepointsDirectory = savepointsPath
-    if (!pathIO.exists(savepointsDirectory)) {
-      log.debug(
-        s"Directory ${pathIO.normalize(savepointsDirectory)} does not exist. Creating it..."
-      )
-      pathIO.createDirectories(savepointsDirectory)
-    }
-  }
-
-  /** Scan the savepoints directory once at startup and seed `lastSavepointMillis` /
-    * `savepointSequence` so that filenames written by this instance are strictly greater than any
-    * filename already on disk.
+  /** Scan the savepoint store once at startup and seed `lastSavepointMillis` / `savepointSequence`
+    * so that versions written by this instance are strictly greater than any savepoint version
+    * already in the configured store.
     *
     * Without this seed, a JVM restart on a host whose wall clock has drifted backwards (NTP
-    * step-back, VM migration, docker host time skew) would make new savepoints sort *earlier* than
-    * savepoints written by the previous run still present in the same directory. Resume would then
+    * step-back, VM migration, docker host time skew) could make new savepoints sort *earlier* than
+    * savepoints written by the previous run still present in the same store. Resume would then
     * silently pick a stale savepoint and lose progress. Seeding closes that window by ensuring the
-    * `(millis, seq)` key monotonically increases across process boundaries as long as the directory
-    * is not wiped.
+    * `(millis, seq)` key monotonically increases across process boundaries as long as previous
+    * savepoints are still present.
     */
-  private def seedStateFromExistingSavepoints(): Unit = {
-    val savepointsDirectory = savepointsPath
-    if (!pathIO.exists(savepointsDirectory)) return
-
-    var maxMillis = 0L
-    var maxSeq = 0L
-    try
-      pathIO.listFileNames(savepointsDirectory).foreach { name =>
-        name match {
-          case SavepointsManager.SavepointName(head, tailOrNull) =>
-            val millis =
-              try
-                if (tailOrNull == null)
-                  // Legacy filenames carry epoch seconds; scale to millis but reject values
-                  // that would silently overflow `Long`. `multiplyExact` throws
-                  // `ArithmeticException` instead of wrapping around to a negative number,
-                  // so a hostile filename like `savepoint_99999999999999999.yaml` cannot
-                  // poison the seeded `lastSavepointMillis` with a bogus huge value.
-                  java.lang.Math.multiplyExact(java.lang.Long.parseLong(head), 1000L)
-                else java.lang.Long.parseLong(head)
-              catch {
-                case _: NumberFormatException | _: ArithmeticException => 0L
-              }
-            val seq =
-              if (tailOrNull == null) 0L
-              else
-                try java.lang.Long.parseLong(tailOrNull)
-                catch { case _: NumberFormatException => 0L }
-            // Reject hostile near-`Long.MAX_VALUE` values; a single planted file must not be
-            // allowed to push `savepointSequence` to within one `incrementAndGet` of overflow
-            // (which would emit a negative counter in the next filename and permanently break
-            // the `\d{10}` regex on resume).
-            if (millis >= MaxReasonableSeedValue || seq >= MaxReasonableSeedValue) {
-              log.warn(
-                s"Ignoring hostile/corrupted savepoint filename ${name} during seed " +
-                  s"(millis=${millis}, seq=${seq} exceeds ${MaxReasonableSeedValue})."
-              )
-            } else if (millis > maxMillis || (millis == maxMillis && seq > maxSeq)) {
-              maxMillis = millis
-              maxSeq    = seq
-            }
-          case _ => ()
-        }
-      }
-    catch {
-      case NonFatal(e) =>
-        log.warn(
-          s"Could not scan ${pathIO.normalize(savepointsDirectory)} to seed savepoint state; " +
-            s"falling back to clock-only ordering: ${e.getMessage}"
+  private def seedStateFromExistingSavepoints(): Unit =
+    savepointStore.seedState().foreach {
+      case coordinates if isReasonableSeed(coordinates) =>
+        lastSavepointMillis = coordinates.epochMillis
+        savepointSequence.set(coordinates.sequence)
+        log.info(
+          s"Seeded savepoint state from existing savepoints: " +
+            s"lastSavepointMillis=${coordinates.epochMillis}, nextSequence=${coordinates.sequence + 1}"
         )
-        return
+      case coordinates =>
+        log.warn(
+          s"Ignoring hostile/corrupted savepoint seed from ${savepointStore.getClass.getSimpleName}: " +
+            s"epoch_millis=${coordinates.epochMillis}, sequence=${coordinates.sequence} outside " +
+            s"the accepted range (0 < epoch_millis < ${MaxReasonableSeedValue}, " +
+            s"0 <= sequence <= ${MaxSavepointSequenceValue}, and max-sequence seeds must " +
+            s"leave room for millisecond rollover)."
+        )
     }
 
-    if (maxMillis > 0L) {
-      lastSavepointMillis = maxMillis
-      savepointSequence.set(maxSeq)
-      log.info(
-        s"Seeded savepoint state from existing files: " +
-          s"lastSavepointMillis=${maxMillis}, nextSequence=${maxSeq + 1}"
-      )
-    }
-  }
+  // A max-sequence seed makes the next dump advance epoch_millis by one. That rollover must
+  // still stay below MaxReasonableSeedValue, because resume lookup rejects the boundary value.
+  private def isReasonableSeed(coordinates: SavepointCoordinates): Boolean =
+    isResumeSafeCoordinate(coordinates.epochMillis, coordinates.sequence)
 
-  private def savepointFilename(path: String): String = {
+  private def nextCoordinates(): SavepointCoordinates = {
     val millis = math.max(lastSavepointMillis, System.currentTimeMillis())
-    lastSavepointMillis = millis
     val seq = savepointSequence.incrementAndGet()
-    // Zero-padded so that lexicographical order matches chronological order (handy for `ls`).
-    // `Locale.ROOT` pins the numeric formatter to ASCII digits; the JVM default locale on some
-    // hosts (e.g. `ar-SA`, `th-TH`) would otherwise emit non-ASCII numerals that break the
-    // filename regex and chronological sort used for resume.
-    String.format(
-      Locale.ROOT,
-      "%s/savepoint_%013d_%010d.yaml",
-      path,
-      java.lang.Long.valueOf(millis),
-      java.lang.Long.valueOf(seq)
-    )
+    if (seq <= MaxSavepointSequenceValue) {
+      lastSavepointMillis = millis
+      SavepointCoordinates(millis, seq)
+    } else {
+      val nextMillis = java.lang.Math.addExact(millis, 1L)
+      lastSavepointMillis = nextMillis
+      savepointSequence.set(1L)
+      SavepointCoordinates(nextMillis, 1L)
+    }
   }
 
   private def addUSR2Handler(): Unit = {
@@ -321,15 +205,12 @@ abstract class SavepointsManager(
     )
   }
 
-  /** Dump the current state of the migration into a configuration file that can be used to resume
-    * the migration.
+  /** Dump the current state of the migration into a configuration payload that can be used to
+    * resume the migration.
     *
-    * Snapshotting the current state and writing it to storage are performed under a lock so that
-    * concurrent callers (scheduler, driver, signal handler) cannot interleave and overwrite each
-    * other with stale snapshots. The file is first written to a temporary path and then renamed
-    * into place. Local filesystems use atomic rename when available; object stores depend on the
-    * Hadoop connector's rename semantics. The temp file is deleted if the rename does not succeed,
-    * so failures do not leak sibling `*.yaml.tmp` files.
+    * Snapshotting the current state and writing it to the configured store are performed under a
+    * lock so that concurrent callers (scheduler, driver, signal handler) cannot interleave with
+    * stale snapshots.
     *
     * @param reason
     *   Human-readable, informal, event that caused the dump.
@@ -373,16 +254,23 @@ abstract class SavepointsManager(
   }
 
   private def doDump(reason: String): Unit = {
-    val finalPath =
-      savepointFilename(savepointsPath)
-
+    val coordinates = nextCoordinates()
     val modifiedConfig = updateConfigWithMigrationState()
-    val payload = modifiedConfig.render.getBytes(StandardCharsets.UTF_8)
-
-    pathIO.writeUtf8Atomically(finalPath, payload)
+    // Savepoint payloads should be directly runnable; `resumeFromLatest` is only a
+    // launch-time lookup flag.
+    val savepointConfig = modifiedConfig.copy(
+      savepoints = modifiedConfig.savepoints.copy(resumeFromLatest = false)
+    )
+    val location = savepointStore.save(
+      SavepointRecord(
+        coordinates = coordinates,
+        reason      = reason,
+        yaml        = savepointConfig.render
+      )
+    )
 
     log.info(
-      s"Created a savepoint config at ${pathIO.normalize(finalPath)} due to ${reason}. ${describeMigrationState()}"
+      s"Created a savepoint config at ${location} due to ${reason}. ${describeMigrationState()}"
     )
   }
 
@@ -445,21 +333,31 @@ object SavepointsManager {
   // after the bounded wait, even if a scheduled dump is wedged on slow/unhealthy storage.
   private[migrator] val SignalDumpLockTimeoutMillis: Long = 5_000L
 
-  private val S3ASimpleCredentialsProvider =
-    "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
-
-  private val S3ATemporaryCredentialsProvider =
-    "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider"
-
-  private val GcsServiceAccountJsonKeyfileAuthType = "SERVICE_ACCOUNT_JSON_KEYFILE"
-
-  // Sanity ceiling for values read from filenames during seed. Any field at or above this
-  // threshold is treated as hostile / corrupted: ignoring it keeps a single planted file from
-  // poisoning `lastSavepointMillis` / `savepointSequence` to within one increment of
-  // `Long.MAX_VALUE`, which would wrap the next counter to `Long.MIN_VALUE` and break the
-  // `\d{10}` filename regex. Chosen as half of `Long.MAX_VALUE` (~year 146,135,510 AD for
-  // millis) so legitimate values have effectively infinite headroom.
+  // Sanity ceiling for epoch-millis values read from savepoint stores during seed. Values at or
+  // above this threshold are treated as hostile / corrupted. Chosen as half of `Long.MAX_VALUE`
+  // (~year 146,135,510 AD for millis) so legitimate values have effectively infinite headroom.
   private[migrator] val MaxReasonableSeedValue: Long = java.lang.Long.MAX_VALUE / 2L
+
+  // Highest counter value that still fits the documented ten-digit savepoint filename component.
+  // If a restored seed is already at this value, the next dump advances the millisecond component
+  // and starts the counter at 1 so filename ordering remains stable.
+  private[migrator] val MaxSavepointSequenceValue: Long = 9_999_999_999L
+
+  private[migrator] def isResumeSafeCoordinate(epochMillis: Long, sequence: Long): Boolean =
+    epochMillis > 0L &&
+      epochMillis < MaxReasonableSeedValue &&
+      sequence >= 0L &&
+      sequence <= MaxSavepointSequenceValue &&
+      (
+        sequence < MaxSavepointSequenceValue ||
+          epochMillis < MaxReasonableSeedValue - 1L
+      )
+
+  private[migrator] def isResumeSafeSortKey(epochMillis: Long, sequence: Long): Boolean =
+    if (sequence == -1L)
+      epochMillis > 0L && epochMillis < MaxReasonableSeedValue
+    else
+      isResumeSafeCoordinate(epochMillis, sequence)
 
   // Filename grammar for savepoints. Two groups:
   //   - new format: `savepoint_<epochMillis>_<counter>.yaml` (tail is the counter)

--- a/migrator/src/main/scala/com/scylladb/migrator/SavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/SavepointsManager.scala
@@ -1,6 +1,7 @@
 package com.scylladb.migrator
 
 import com.scylladb.migrator.config.MigratorConfig
+import org.apache.hadoop.conf.Configuration
 import org.apache.logging.log4j.LogManager
 import sun.misc.{ Signal, SignalHandler }
 
@@ -48,6 +49,23 @@ abstract class SavepointsManager(
   migratorConfig: MigratorConfig,
   maybeSavepointStore: Option[SavepointStore] = None
 ) extends AutoCloseable {
+
+  def this(
+    migratorConfig: MigratorConfig,
+    hadoopConfiguration: Option[Configuration],
+    redactionRegex: Option[String]
+  ) =
+    this(
+      migratorConfig,
+      Some(
+        SavepointStore.forConfig(
+          migratorConfig,
+          sparkContext        = None,
+          redactionRegex      = redactionRegex,
+          hadoopConfiguration = hadoopConfiguration
+        )
+      )
+    )
 
   import SavepointsManager._
 

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/DynamoDbSavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/DynamoDbSavepointsManager.scala
@@ -1,7 +1,7 @@
 package com.scylladb.migrator.alternator
 
-import com.scylladb.migrator.SavepointsManager
-import com.scylladb.migrator.config.{ MigratorConfig, SparkSecretRedaction }
+import com.scylladb.migrator.{ SavepointStore, SavepointsManager }
+import com.scylladb.migrator.config.MigratorConfig
 import org.apache.hadoop.dynamodb.DynamoDBItemWritable
 import org.apache.hadoop.dynamodb.split.DynamoDBSplit
 import org.apache.hadoop.io.Text
@@ -20,12 +20,8 @@ class DynamoDbSavepointsManager(
   segmentsAccumulator: IntSetAccumulator,
   sparkTaskEndListener: SparkListener,
   spark: SparkContext,
-  redactionRegex: Option[String] = None
-) extends SavepointsManager(
-      migratorConfig,
-      Some(spark.hadoopConfiguration),
-      redactionRegex
-    ) {
+  savepointStore: Option[SavepointStore] = None
+) extends SavepointsManager(migratorConfig, savepointStore) {
 
   def describeMigrationState(): String =
     s"Segments to skip: ${segmentsAccumulator.value}"
@@ -49,8 +45,7 @@ object DynamoDbSavepointsManager {
   def apply(
     migratorConfig: MigratorConfig,
     sourceRDD: RDD[(Text, DynamoDBItemWritable)],
-    spark: SparkContext,
-    redactionRegex: Option[String] = None
+    spark: SparkContext
   ): DynamoDbSavepointsManager = {
     val segmentsAccumulator =
       IntSetAccumulator(migratorConfig.skipSegments.getOrElse(Set.empty))
@@ -78,7 +73,7 @@ object DynamoDbSavepointsManager {
       segmentsAccumulator,
       sparkTaskEndListener,
       spark,
-      redactionRegex.orElse(SparkSecretRedaction.redactionRegex(spark))
+      Some(SavepointStore.forConfig(migratorConfig, Some(spark)))
     )
   }
 

--- a/migrator/src/main/scala/com/scylladb/migrator/alternator/DynamoDbSavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/alternator/DynamoDbSavepointsManager.scala
@@ -45,7 +45,8 @@ object DynamoDbSavepointsManager {
   def apply(
     migratorConfig: MigratorConfig,
     sourceRDD: RDD[(Text, DynamoDBItemWritable)],
-    spark: SparkContext
+    spark: SparkContext,
+    redactionRegex: Option[String] = None
   ): DynamoDbSavepointsManager = {
     val segmentsAccumulator =
       IntSetAccumulator(migratorConfig.skipSegments.getOrElse(Set.empty))
@@ -73,7 +74,7 @@ object DynamoDbSavepointsManager {
       segmentsAccumulator,
       sparkTaskEndListener,
       spark,
-      Some(SavepointStore.forConfig(migratorConfig, Some(spark)))
+      Some(SavepointStore.forConfig(migratorConfig, Some(spark), redactionRegex))
     )
   }
 

--- a/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/MigratorConfig.scala
@@ -65,11 +65,30 @@ object MigratorConfig {
         // this decoder.
         val savepointsRequired = decoded.source.supportsSavepoints
 
-        if (!savepointsProvided && savepointsRequired)
+        val savepointErrors = Savepoints.validate(decoded.savepoints)
+
+        if (savepointErrors.nonEmpty)
+          Left(
+            DecodingFailure(
+              s"Invalid savepoints configuration: ${savepointErrors.mkString(" ")}",
+              cursor.history
+            )
+          )
+        else if (!savepointsProvided && savepointsRequired)
           Left(
             DecodingFailure(
               "Missing required field: savepoints. This field is optional only for sources " +
                 "that do not support savepoints.",
+              cursor.history
+            )
+          )
+        else if (
+          decoded.savepoints.resolvedTarget.isInstanceOf[SavepointTarget.TargetTable] &&
+          !decoded.target.isInstanceOf[TargetSettings.Scylla]
+        )
+          Left(
+            DecodingFailure(
+              "savepoints.target.type: target-table is supported only when target.type is 'scylla'.",
               cursor.history
             )
           )
@@ -135,7 +154,7 @@ object MigratorConfig {
     value.isString && (SensitiveKeys
       .isSensitiveKey(key) || key == "where")
 
-  private[config] def redactSecrets(json: Json): Json =
+  private[migrator] def redactSecrets(json: Json): Json =
     json.arrayOrObject(
       json,
       arr => Json.fromValues(arr.map(redactSecrets)),
@@ -164,10 +183,13 @@ object MigratorConfig {
   ): MigratorConfig = {
     val configData = PathIO.forPath(path, hadoopConfiguration).readUtf8(path)
 
+    loadFromString(configData)
+  }
+
+  def loadFromString(configData: String): MigratorConfig =
     parser
       .parse(configData)
       .leftWiden[Error]
       .flatMap(_.as[MigratorConfig])
       .valueOr(throw _)
-  }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/Savepoints.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/Savepoints.scala
@@ -304,7 +304,7 @@ object Savepoints {
                         .decoderWithFilesystemDefault(path)
                         .apply(cursor)
                         .map(Some(_))
-                    case None => Right(None)
+                    case _ => Right(None)
                   }
         resolvedPath = target match {
                          case Some(target: SavepointTarget.StoragePathTarget) =>

--- a/migrator/src/main/scala/com/scylladb/migrator/config/Savepoints.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/Savepoints.scala
@@ -1,23 +1,65 @@
 package com.scylladb.migrator.config
 
-import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
+import io.circe.{ Decoder, DecodingFailure, Encoder, Json, JsonObject }
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax._
 
 import java.util.Locale
 
-sealed trait SavepointsTarget {
+/** Configuration for periodic savepoints written during a migration run.
+  *
+  * @param intervalSeconds
+  *   How often, in seconds, a savepoint should be written.
+  * @param path
+  *   Filesystem path or Hadoop filesystem URI where file-backed savepoint data will be stored.
+  * @param enableParquetFileTracking
+  *   When `true` (the default), enables tracking of already-processed Parquet files as part of the
+  *   savepoint state. This prevents the same Parquet file from being migrated more than once if the
+  *   job is restarted or savepoints are resumed.
+  * @param resumeFromLatest
+  *   When `true`, load the newest valid savepoint from the configured backend before migration.
+  * @param target
+  *   Savepoint storage target. Missing target defaults to `filesystem` using `path`.
+  *
+  * Set this to `false` to keep the legacy behavior where Parquet files are not tracked in
+  * savepoints. Disabling tracking may be useful for backwards compatibility with older savepoints
+  * or when file tracking is handled by an external mechanism, but it means repeated runs may
+  * reprocess the same Parquet files.
+  */
+case class Savepoints(
+  intervalSeconds: Int = 300,
+  path: String = Savepoints.DefaultPath,
+  enableParquetFileTracking: Boolean = true,
+  resumeFromLatest: Boolean = false,
+  target: Option[SavepointTarget] = None
+) {
+  def resolvedTarget: SavepointTarget =
+    target.getOrElse(SavepointTarget.Filesystem(path))
+
+  def effectiveTarget: SavepointTarget =
+    resolvedTarget
+
+  def storagePath: String =
+    resolvedTarget match {
+      case target: SavepointTarget.StoragePathTarget => target.storagePath
+      case _: SavepointTarget.TargetTable            => path
+    }
+
+  def filesystemPath: String = storagePath
+}
+
+sealed trait SavepointTarget {
   def targetType: String
 }
 
-object SavepointsTarget {
+object SavepointTarget {
   private val UriScheme = """^([A-Za-z][A-Za-z0-9+.-]*):/{2}.*""".r
 
-  sealed trait StoragePathTarget extends SavepointsTarget {
+  sealed trait StoragePathTarget extends SavepointTarget {
     def storagePath: String
   }
 
-  case class Filesystem(path: String) extends StoragePathTarget {
+  case class Filesystem(path: String = Savepoints.DefaultPath) extends StoragePathTarget {
     override val targetType: String = "filesystem"
     override def storagePath: String = path
   }
@@ -56,7 +98,9 @@ object SavepointsTarget {
             }
 
         keyfile.flatMap { value =>
-          nonEmpty(value, "serviceAccountJsonKeyfile", cursor).map(_ => GCSCredentials(value.trim))
+          nonEmpty(value, "serviceAccountJsonKeyfile", cursor).map(_ =>
+            GCSCredentials(value.trim)
+          )
         }
       }
 
@@ -81,6 +125,14 @@ object SavepointsTarget {
         case None    => s"gs://${bucket}"
       }
     }
+  }
+
+  case class TargetTable(
+    keyspace: Option[String] = None,
+    table: String = Savepoints.DefaultTargetTable,
+    jobId: Option[String] = None
+  ) extends SavepointTarget {
+    override val targetType: String = "target-table"
   }
 
   private def nonEmpty(value: String, field: String, cursor: io.circe.HCursor) =
@@ -110,12 +162,14 @@ object SavepointsTarget {
       case _ => Right(())
     }
 
-  implicit val decoder: Decoder[SavepointsTarget] =
+  private[config] def decoderWithFilesystemDefault(
+    filesystemDefaultPath: String
+  ): Decoder[SavepointTarget] =
     Decoder.instance { cursor =>
       cursor.get[String]("type").flatMap {
         case "filesystem" | "path" =>
           for {
-            path <- cursor.get[String]("path")
+            path <- cursor.getOrElse[String]("path")(filesystemDefaultPath)
             _    <- nonEmpty(path, "path", cursor)
             _    <- localFilesystemPath(path, cursor)
           } yield Filesystem(path)
@@ -135,6 +189,12 @@ object SavepointsTarget {
             credentials <- cursor.get[Option[GCSCredentials]]("credentials")
             _           <- nonEmpty(bucket, "bucket", cursor)
           } yield GCS(bucket.trim, prefix, projectId, credentials)
+        case "target-table" | "target-database" =>
+          for {
+            keyspace <- cursor.get[Option[String]]("keyspace")
+            table    <- cursor.getOrElse[String]("table")(Savepoints.DefaultTargetTable)
+            jobId    <- cursor.get[Option[String]]("jobId")
+          } yield TargetTable(keyspace, table, jobId)
         case "hadoop" =>
           Left(
             DecodingFailure(
@@ -143,31 +203,26 @@ object SavepointsTarget {
               cursor.history
             )
           )
-        case "target-table" | "target-database" =>
-          Left(
-            DecodingFailure(
-              "Savepoints target type 'target-table' is not supported by this runtime. " +
-                "Use a local filesystem, savepoints.path Hadoop URI, S3, or GCS savepoint target.",
-              cursor.history
-            )
-          )
         case otherwise =>
           Left(
             DecodingFailure(
-              s"Invalid savepoints target type: ${otherwise}",
+              s"Invalid savepoints.target.type '${otherwise}'. Valid values: filesystem, s3, gcs, target-table",
               cursor.history
             )
           )
       }
     }
 
-  implicit val encoder: Encoder[SavepointsTarget] =
+  implicit val decoder: Decoder[SavepointTarget] =
+    decoderWithFilesystemDefault(Savepoints.DefaultPath)
+
+  implicit val encoder: Encoder[SavepointTarget] =
     Encoder.instance {
       case t: Filesystem =>
-        deriveEncoder[Filesystem]
-          .encodeObject(t)
-          .add("type", Json.fromString(t.targetType))
-          .asJson
+        JsonObject(
+          "type" -> t.targetType.asJson,
+          "path" -> t.path.asJson
+        ).asJson
       case t: S3 =>
         deriveEncoder[S3]
           .encodeObject(t)
@@ -180,100 +235,121 @@ object SavepointsTarget {
           .filter { case (_, v) => !v.isNull }
           .add("type", Json.fromString(t.targetType))
           .asJson
+      case TargetTable(keyspace, table, jobId) =>
+        JsonObject(
+          "type"     -> "target-table".asJson,
+          "keyspace" -> keyspace.asJson,
+          "table"    -> table.asJson,
+          "jobId"    -> jobId.asJson
+        ).filter { case (_, value) => !value.isNull }.asJson
     }
 }
 
-/** Configuration for periodic savepoints written during a migration run.
-  *
-  * @param intervalSeconds
-  *   How often, in seconds, a savepoint should be written.
-  * @param path
-  *   Local filesystem path or Hadoop filesystem URI (directory or prefix) where savepoint data will
-  *   be stored.
-  * @param enableParquetFileTracking
-  *   When `true` (the default), enables tracking of already-processed Parquet files as part of the
-  *   savepoint state. This prevents the same Parquet file from being migrated more than once if the
-  *   job is restarted or savepoints are resumed.
-  *
-  * Set this to `false` to keep the legacy behavior where Parquet files are not tracked in
-  * savepoints. Disabling tracking may be useful for backwards compatibility with older savepoints
-  * or when file tracking is handled by an external mechanism, but it means repeated runs may
-  * reprocess the same Parquet files.
-  * @param target
-  *   Optional typed savepoint destination. When omitted, the legacy `path` field is interpreted as
-  *   a filesystem/Hadoop URI destination.
-  */
-case class Savepoints(
-  intervalSeconds: Int,
-  path: String,
-  enableParquetFileTracking: Boolean = true,
-  target: Option[SavepointsTarget] = None
-) {
-  def effectiveTarget: SavepointsTarget.StoragePathTarget =
-    target match {
-      case Some(target: SavepointsTarget.StoragePathTarget) => target
-      case None                                             => SavepointsTarget.Filesystem(path)
-    }
+object SavepointsTarget {
+  type StoragePathTarget = SavepointTarget.StoragePathTarget
+  type Filesystem = SavepointTarget.Filesystem
+  type S3 = SavepointTarget.S3
+  type GCSCredentials = SavepointTarget.GCSCredentials
+  type GCS = SavepointTarget.GCS
+  type TargetTable = SavepointTarget.TargetTable
 
-  def storagePath: String = effectiveTarget.storagePath
+  val Filesystem = SavepointTarget.Filesystem
+  val S3 = SavepointTarget.S3
+  val GCSCredentials = SavepointTarget.GCSCredentials
+  val GCS = SavepointTarget.GCS
+  val TargetTable = SavepointTarget.TargetTable
 }
 
 object Savepoints {
-  val Default: Savepoints = Savepoints(intervalSeconds = 300, path = "/app/savepoints")
+  val DefaultPath: String = "/app/savepoints"
+  val DefaultTargetTable: String = "scylla_migrator_savepoints"
+  val Default: Savepoints = Savepoints(intervalSeconds = 300, path = DefaultPath)
 
   implicit val decoder: Decoder[Savepoints] =
     Decoder.instance { cursor =>
+      val targetCursor = cursor
+        .downField("target")
+        .success
+        .filter(_.focus.exists(!_.isNull))
+
+      val filesystemTargetWithoutOwnPath =
+        targetCursor.exists { target =>
+          val targetType = target.get[String]("type").toOption
+          val isFilesystem = targetType.exists(t => t == "filesystem" || t == "path")
+          val hasOwnPath = target.downField("path").success.exists(_.focus.exists(!_.isNull))
+          isFilesystem && !hasOwnPath
+        }
+
       for {
-        intervalSeconds <- cursor.get[Int]("intervalSeconds")
-        enableParquetFileTracking <-
-          cursor.getOrElse[Boolean]("enableParquetFileTracking")(true)
-        maybePath   <- cursor.get[Option[String]]("path")
-        maybeTarget <- cursor.get[Option[SavepointsTarget]]("target")
+        intervalSeconds <- cursor.getOrElse[Int]("intervalSeconds")(300)
+        maybePath       <- cursor.get[Option[String]]("path")
         _ <- Either.cond(
-               maybePath.isEmpty || maybeTarget.isEmpty,
+               maybePath.isEmpty || targetCursor.isEmpty || filesystemTargetWithoutOwnPath,
                (),
                DecodingFailure(
                  "Specify only one of savepoints.path or savepoints.target.",
                  cursor.history
                )
              )
-        path <- maybeTarget match {
-                  case Some(target: SavepointsTarget.StoragePathTarget) =>
-                    Right(target.storagePath)
-                  case Some(other) =>
-                    Left(
-                      DecodingFailure(
-                        s"Savepoints target type '${other.targetType}' does not resolve to a storage path.",
-                        cursor.history
-                      )
-                    )
-                  case None =>
-                    maybePath
-                      .filter(_.trim.nonEmpty)
-                      .toRight(
-                        DecodingFailure(
-                          "Savepoints configuration requires either 'path' or 'target'.",
-                          cursor.history
-                        )
-                      )
-                }
-      } yield Savepoints(intervalSeconds, path, enableParquetFileTracking, maybeTarget)
+        path =
+          maybePath
+            .filter(_.trim.nonEmpty)
+            .getOrElse(DefaultPath)
+        enableParquetFileTracking <-
+          cursor.getOrElse[Boolean]("enableParquetFileTracking")(true)
+        resumeFromLatest <- cursor.getOrElse[Boolean]("resumeFromLatest")(false)
+        target <- targetCursor match {
+                    case Some(cursor) =>
+                      SavepointTarget
+                        .decoderWithFilesystemDefault(path)
+                        .apply(cursor)
+                        .map(Some(_))
+                    case None => Right(None)
+                  }
+        resolvedPath = target match {
+                         case Some(target: SavepointTarget.StoragePathTarget) =>
+                           target.storagePath
+                         case _ => path
+                       }
+      } yield Savepoints(
+        intervalSeconds,
+        resolvedPath,
+        enableParquetFileTracking,
+        resumeFromLatest,
+        target
+      )
     }
 
   implicit val encoder: Encoder[Savepoints] =
     Encoder.instance { savepoints =>
-      val targetField =
-        savepoints.target match {
-          case Some(target) => List("target" -> target.asJson)
-          case None         => List("path" -> savepoints.path.asJson)
-        }
-
-      Json.obj(
-        (
-          List("intervalSeconds" -> savepoints.intervalSeconds.asJson) ++ targetField ++ List(
-            "enableParquetFileTracking" -> savepoints.enableParquetFileTracking.asJson
-          )
-        ): _*
-      )
+      JsonObject(
+        "intervalSeconds"           -> savepoints.intervalSeconds.asJson,
+        "path"                      -> savepoints.path.asJson,
+        "enableParquetFileTracking" -> savepoints.enableParquetFileTracking.asJson,
+        "resumeFromLatest"          -> savepoints.resumeFromLatest.asJson,
+        "target"                    -> savepoints.target.asJson
+      ).filter { case (_, value) => !value.isNull }.asJson
     }
+
+  private[config] def validate(savepoints: Savepoints): List[String] = {
+    val errors = List.newBuilder[String]
+    if (savepoints.intervalSeconds <= 0)
+      errors += s"'intervalSeconds' must be positive, got ${savepoints.intervalSeconds}."
+    savepoints.resolvedTarget match {
+      case SavepointTarget.Filesystem(path) =>
+        if (path.trim.isEmpty) errors += "'target.path' must not be empty."
+      case s3: SavepointTarget.S3 =>
+        if (s3.bucket.trim.isEmpty) errors += "'target.bucket' must not be empty."
+      case gcs: SavepointTarget.GCS =>
+        if (gcs.bucket.trim.isEmpty) errors += "'target.bucket' must not be empty."
+      case SavepointTarget.TargetTable(keyspace, table, jobId) =>
+        if (keyspace.exists(_.trim.isEmpty))
+          errors += "'target.keyspace' must not be empty when set."
+        if (table.trim.isEmpty)
+          errors += "'target.table' must not be empty."
+        if (jobId.exists(_.trim.isEmpty))
+          errors += "'target.jobId' must not be empty when set."
+    }
+    errors.result()
+  }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/config/Savepoints.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/Savepoints.scala
@@ -98,9 +98,7 @@ object SavepointTarget {
             }
 
         keyfile.flatMap { value =>
-          nonEmpty(value, "serviceAccountJsonKeyfile", cursor).map(_ =>
-            GCSCredentials(value.trim)
-          )
+          nonEmpty(value, "serviceAccountJsonKeyfile", cursor).map(_ => GCSCredentials(value.trim))
         }
       }
 

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/ParquetSavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/ParquetSavepointsManager.scala
@@ -27,7 +27,11 @@ class ParquetSavepointsManager(
 
 object ParquetSavepointsManager {
 
-  def apply(migratorConfig: MigratorConfig, spark: SparkContext): ParquetSavepointsManager = {
+  def apply(
+    migratorConfig: MigratorConfig,
+    spark: SparkContext,
+    redactionRegex: Option[String] = None
+  ): ParquetSavepointsManager = {
     val filesAccumulator =
       StringSetAccumulator(migratorConfig.skipParquetFiles.getOrElse(Set.empty))
 
@@ -36,7 +40,7 @@ object ParquetSavepointsManager {
     new ParquetSavepointsManager(
       migratorConfig,
       filesAccumulator,
-      Some(SavepointStore.forConfig(migratorConfig, Some(spark)))
+      Some(SavepointStore.forConfig(migratorConfig, Some(spark), redactionRegex))
     )
   }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/ParquetSavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/ParquetSavepointsManager.scala
@@ -1,17 +1,15 @@
 package com.scylladb.migrator.readers
 
-import com.scylladb.migrator.SavepointsManager
-import com.scylladb.migrator.config.{ MigratorConfig, SparkSecretRedaction }
+import com.scylladb.migrator.{ SavepointStore, SavepointsManager }
+import com.scylladb.migrator.config.MigratorConfig
 import com.scylladb.migrator.alternator.StringSetAccumulator
-import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkContext
 
 class ParquetSavepointsManager(
   migratorConfig: MigratorConfig,
   filesAccumulator: StringSetAccumulator,
-  hadoopConfiguration: Option[Configuration] = None,
-  redactionRegex: Option[String] = None
-) extends SavepointsManager(migratorConfig, hadoopConfiguration, redactionRegex) {
+  savepointStore: Option[SavepointStore] = None
+) extends SavepointsManager(migratorConfig, savepointStore) {
 
   def describeMigrationState(): String = {
     val processedCount = filesAccumulator.value.size
@@ -29,11 +27,7 @@ class ParquetSavepointsManager(
 
 object ParquetSavepointsManager {
 
-  def apply(
-    migratorConfig: MigratorConfig,
-    spark: SparkContext,
-    redactionRegex: Option[String] = None
-  ): ParquetSavepointsManager = {
+  def apply(migratorConfig: MigratorConfig, spark: SparkContext): ParquetSavepointsManager = {
     val filesAccumulator =
       StringSetAccumulator(migratorConfig.skipParquetFiles.getOrElse(Set.empty))
 
@@ -42,8 +36,7 @@ object ParquetSavepointsManager {
     new ParquetSavepointsManager(
       migratorConfig,
       filesAccumulator,
-      Some(spark.hadoopConfiguration),
-      redactionRegex.orElse(SparkSecretRedaction.redactionRegex(spark))
+      Some(SavepointStore.forConfig(migratorConfig, Some(spark)))
     )
   }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/CqlParquetSavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/CqlParquetSavepointsManager.scala
@@ -45,7 +45,8 @@ object CqlParquetSavepointsManager {
   def apply(
     migratorConfig: MigratorConfig,
     sourceDF: SourceDataFrame,
-    spark: SparkContext
+    spark: SparkContext,
+    redactionRegex: Option[String] = None
   ): CqlParquetSavepointsManager = {
     val cqlTokenRangeAccumulator =
       CqlTokenRangeAccumulator(migratorConfig.getSkipTokenRangesOrEmptySet)
@@ -91,7 +92,7 @@ object CqlParquetSavepointsManager {
       cqlTokenRangeAccumulator,
       sparkTaskEndListener,
       spark,
-      Some(SavepointStore.forConfig(migratorConfig, Some(spark)))
+      Some(SavepointStore.forConfig(migratorConfig, Some(spark), redactionRegex))
     )
   }
 

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/CqlParquetSavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/CqlParquetSavepointsManager.scala
@@ -2,8 +2,8 @@ package com.scylladb.migrator.scylla
 
 import com.datastax.spark.connector.rdd.partitioner.{ CassandraPartition, CqlTokenRange }
 import com.datastax.spark.connector.rdd.partitioner.dht.Token
-import com.scylladb.migrator.SavepointsManager
-import com.scylladb.migrator.config.{ MigratorConfig, SparkSecretRedaction }
+import com.scylladb.migrator.{ SavepointStore, SavepointsManager }
+import com.scylladb.migrator.config.MigratorConfig
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.scheduler.{ SparkListener, SparkListenerTaskEnd }
 import org.apache.spark.{ SparkContext, Success => TaskEndSuccess }
@@ -20,12 +20,8 @@ class CqlParquetSavepointsManager(
   cqlTokenRangeAccumulator: CqlTokenRangeAccumulator,
   sparkTaskEndListener: SparkListener,
   spark: SparkContext,
-  redactionRegex: Option[String] = None
-) extends SavepointsManager(
-      migratorConfig,
-      Some(spark.hadoopConfiguration),
-      redactionRegex
-    ) {
+  savepointStore: Option[SavepointStore] = None
+) extends SavepointsManager(migratorConfig, savepointStore) {
 
   def describeMigrationState(): String =
     s"Token ranges accumulated: ${cqlTokenRangeAccumulator.value.size}"
@@ -49,8 +45,7 @@ object CqlParquetSavepointsManager {
   def apply(
     migratorConfig: MigratorConfig,
     sourceDF: SourceDataFrame,
-    spark: SparkContext,
-    redactionRegex: Option[String] = None
+    spark: SparkContext
   ): CqlParquetSavepointsManager = {
     val cqlTokenRangeAccumulator =
       CqlTokenRangeAccumulator(migratorConfig.getSkipTokenRangesOrEmptySet)
@@ -96,7 +91,7 @@ object CqlParquetSavepointsManager {
       cqlTokenRangeAccumulator,
       sparkTaskEndListener,
       spark,
-      redactionRegex.orElse(SparkSecretRedaction.redactionRegex(spark))
+      Some(SavepointStore.forConfig(migratorConfig, Some(spark)))
     )
   }
 

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/CqlSavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/CqlSavepointsManager.scala
@@ -90,11 +90,12 @@ class CqlSavepointsManager(
 object CqlSavepointsManager {
   def apply(
     migratorConfig: MigratorConfig,
-    accumulator: TokenRangeAccumulator
+    accumulator: TokenRangeAccumulator,
+    redactionRegex: Option[String] = None
   )(implicit spark: SparkSession): CqlSavepointsManager =
     new CqlSavepointsManager(
       migratorConfig,
       accumulator,
-      Some(SavepointStore.forConfig(migratorConfig, Some(spark.sparkContext)))
+      Some(SavepointStore.forConfig(migratorConfig, Some(spark.sparkContext), redactionRegex))
     )
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/CqlSavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/CqlSavepointsManager.scala
@@ -3,9 +3,9 @@ package com.scylladb.migrator.scylla
 import com.datastax.spark.connector.rdd.partitioner.{ CassandraPartition, CqlTokenRange }
 import com.datastax.spark.connector.rdd.partitioner.dht.Token
 import com.datastax.spark.connector.writer.TokenRangeAccumulator
-import com.scylladb.migrator.SavepointsManager
+import com.scylladb.migrator.{ SavepointStore, SavepointsManager }
 import com.scylladb.migrator.config.MigratorConfig
-import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.SparkSession
 
 import scala.util.control.NonFatal
 
@@ -14,9 +14,8 @@ import scala.util.control.NonFatal
 class CqlSavepointsManager(
   migratorConfig: MigratorConfig,
   val accumulator: TokenRangeAccumulator,
-  hadoopConfiguration: Option[Configuration] = None,
-  redactionRegex: Option[String] = None
-) extends SavepointsManager(migratorConfig, hadoopConfiguration, redactionRegex) {
+  savepointStore: Option[SavepointStore] = None
+) extends SavepointsManager(migratorConfig, savepointStore) {
   def describeMigrationState(): String =
     s"Ranges added: ${tokenRanges(accumulator)}"
 
@@ -92,6 +91,10 @@ object CqlSavepointsManager {
   def apply(
     migratorConfig: MigratorConfig,
     accumulator: TokenRangeAccumulator
-  ): CqlSavepointsManager =
-    new CqlSavepointsManager(migratorConfig, accumulator)
+  )(implicit spark: SparkSession): CqlSavepointsManager =
+    new CqlSavepointsManager(
+      migratorConfig,
+      accumulator,
+      Some(SavepointStore.forConfig(migratorConfig, Some(spark.sparkContext)))
+    )
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
@@ -112,10 +112,9 @@ object ScyllaMigrator extends ScyllaMigratorBase {
     else {
       val tokenRangeAccumulator = TokenRangeAccumulator.empty
       spark.sparkContext.register(tokenRangeAccumulator, "Token ranges copied")
-      val manager = new CqlSavepointsManager(
+      val manager = CqlSavepointsManager(
         migratorConfig,
         tokenRangeAccumulator,
-        Some(spark.sparkContext.hadoopConfiguration),
         SparkSecretRedaction.redactionRegex(spark)
       )
       // Cassandra-only diagnostic: was previously emitted from `ScyllaMigratorBase.migrate`

--- a/tests/src/test/configurations/parquet-to-scylla-target-savepoints-resume.yaml
+++ b/tests/src/test/configurations/parquet-to-scylla-target-savepoints-resume.yaml
@@ -1,0 +1,25 @@
+source:
+  type: parquet
+  path: /app/parquet/target-savepoints
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: targetsavepointstest
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  intervalSeconds: 1
+  resumeFromLatest: true
+  target:
+    type: target-table
+    table: scylla_migrator_savepoints_target_test
+    jobId: parquet-target-savepoints-test

--- a/tests/src/test/configurations/parquet-to-scylla-target-savepoints.yaml
+++ b/tests/src/test/configurations/parquet-to-scylla-target-savepoints.yaml
@@ -1,0 +1,24 @@
+source:
+  type: parquet
+  path: /app/parquet/target-savepoints
+
+target:
+  type: scylla
+  host: scylla
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: targetsavepointstest
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  intervalSeconds: 1
+  target:
+    type: target-table
+    table: scylla_migrator_savepoints_target_test
+    jobId: parquet-target-savepoints-test

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
@@ -67,25 +67,26 @@ class SavepointStoreTest extends munit.FunSuite {
     assertEquals(warnings.toSeq, Seq((SavepointsManager.MaxReasonableSeedValue, 1L)))
   }
 
-  test("file store latestConfig does not let hostile future coordinates beat a real savepoint") {
+  test("file store latestConfig ignores hostile future coordinates even with newer mtime") {
     val dir = Files.createTempDirectory("savepoint-store-latest-hostile")
     try {
+      val realMillis = System.currentTimeMillis()
       val hostilePath =
         dir.resolve(
           f"savepoint_${SavepointsManager.MaxReasonableSeedValue}%013d_${1L}%010d.yaml"
         )
       val realPath =
-        dir.resolve(f"savepoint_${System.currentTimeMillis()}%013d_${2L}%010d.yaml")
+        dir.resolve(f"savepoint_${realMillis}%013d_${2L}%010d.yaml")
 
-      Files.write(
-        hostilePath,
-        config(skipFiles = Set("hostile")).render.getBytes(StandardCharsets.UTF_8)
-      )
-      Files.setLastModifiedTime(hostilePath, FileTime.fromMillis(1L))
       Files.write(
         realPath,
         config(skipFiles = Set("real")).render.getBytes(StandardCharsets.UTF_8)
       )
+      Files.write(
+        hostilePath,
+        config(skipFiles = Set("hostile")).render.getBytes(StandardCharsets.UTF_8)
+      )
+      Files.setLastModifiedTime(hostilePath, FileTime.fromMillis(realMillis + 10_000L))
 
       val selected = SavepointStore.file(dir.toString).latestConfig()
 

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
@@ -67,6 +67,74 @@ class SavepointStoreTest extends munit.FunSuite {
     assertEquals(warnings.toSeq, Seq((SavepointsManager.MaxReasonableSeedValue, 1L)))
   }
 
+  test("target store newestValidConfig skips rows from different config identities") {
+    val requested = config(sourcePath = "s3a://bucket/requested", skipFiles = Set("requested"))
+    val unrelated = config(sourcePath = "s3a://bucket/unrelated", skipFiles = Set("unrelated"))
+    val requestedSha = SavepointStore.configIdentitySha256(requested)
+    val unrelatedSha = SavepointStore.configIdentitySha256(unrelated)
+
+    val selected = ScyllaTargetSavepointStore.newestValidConfig(
+      rows = Seq(
+        ScyllaTargetSavepointStore.StoredSavepoint(
+          3000L,
+          1L,
+          unrelated.render,
+          Some(requestedSha)
+        ),
+        ScyllaTargetSavepointStore.StoredSavepoint(
+          2000L,
+          1L,
+          unrelated.render,
+          Some(unrelatedSha)
+        ),
+        ScyllaTargetSavepointStore.StoredSavepoint(
+          1000L,
+          1L,
+          requested.render,
+          Some(requestedSha)
+        )
+      ),
+      expectedConfigSha256 = requestedSha,
+      warnInvalidRow       = (_, _) => ()
+    )
+
+    assertEquals(
+      selected.map(SavepointStore.configIdentitySha256),
+      Some(SavepointStore.configIdentitySha256(requested)),
+      "target-backed resume must not use a newer row that belongs to a different migration identity"
+    )
+  }
+
+  test("target store newestCoordinates skips rows from different config identities") {
+    val requested = config(sourcePath = "s3a://bucket/requested", skipFiles = Set("requested"))
+    val unrelated = config(sourcePath = "s3a://bucket/unrelated", skipFiles = Set("unrelated"))
+    val requestedSha = SavepointStore.configIdentitySha256(requested)
+    val unrelatedSha = SavepointStore.configIdentitySha256(unrelated)
+
+    val selected = ScyllaTargetSavepointStore.newestCoordinates(
+      rows = Seq(
+        ScyllaTargetSavepointStore.StoredSavepointCoordinates(
+          epochMillis  = 3000L,
+          sequence     = 1L,
+          configSha256 = Some(unrelatedSha)
+        ),
+        ScyllaTargetSavepointStore.StoredSavepointCoordinates(
+          epochMillis  = 2000L,
+          sequence     = 1L,
+          configSha256 = Some(requestedSha)
+        )
+      ),
+      expectedConfigSha256 = Some(requestedSha),
+      warnInvalidRow       = (_, _) => ()
+    )
+
+    assertEquals(
+      selected,
+      Some(SavepointCoordinates(2000L, 1L)),
+      "target-backed seed state must ignore coordinates from another migration identity"
+    )
+  }
+
   test("file store latestConfig ignores hostile future coordinates even with newer mtime") {
     val dir = Files.createTempDirectory("savepoint-store-latest-hostile")
     try {
@@ -102,10 +170,13 @@ class SavepointStoreTest extends munit.FunSuite {
         .forEach(Files.delete)
   }
 
-  private def config(skipFiles: Set[String]): MigratorConfig =
+  private def config(
+    skipFiles: Set[String],
+    sourcePath: String = "s3a://bucket/data"
+  ): MigratorConfig =
     MigratorConfig(
       source = SourceSettings.Parquet(
-        path        = "s3a://bucket/data",
+        path        = sourcePath,
         credentials = None,
         region      = None,
         endpoint    = None

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
@@ -42,6 +42,31 @@ class SavepointStoreTest extends munit.FunSuite {
     assertEquals(warnings.toSeq, Seq((3000L, 1L)))
   }
 
+  test("target store newestValidConfig ignores hostile future coordinates") {
+    val warnings = scala.collection.mutable.ArrayBuffer.empty[(Long, Long)]
+    val real = config(skipFiles = Set("real")).render
+    val hostile = config(skipFiles = Set("hostile")).render
+
+    val selected = ScyllaTargetSavepointStore.newestValidConfig(
+      rows = Seq(
+        ScyllaTargetSavepointStore.StoredSavepoint(1000L, 1L, real),
+        ScyllaTargetSavepointStore.StoredSavepoint(
+          SavepointsManager.MaxReasonableSeedValue,
+          1L,
+          hostile
+        )
+      ),
+      warnInvalidRow = (row, _) => warnings += ((row.epochMillis, row.sequence))
+    )
+
+    assertEquals(
+      selected.flatMap(_.skipParquetFiles),
+      Some(Set("real")),
+      "target-backed resume must not let an unreasonable future row dominate ordering"
+    )
+    assertEquals(warnings.toSeq, Seq((SavepointsManager.MaxReasonableSeedValue, 1L)))
+  }
+
   test("file store latestConfig does not let hostile future coordinates beat a real savepoint") {
     val dir = Files.createTempDirectory("savepoint-store-latest-hostile")
     try {

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
@@ -2,6 +2,10 @@ package com.scylladb.migrator
 
 import com.scylladb.migrator.config.{ MigratorConfig, Savepoints, SourceSettings, TargetSettings }
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.attribute.FileTime
+
 class SavepointStoreTest extends munit.FunSuite {
 
   test("target store newestValidConfig returns newest valid savepoint") {
@@ -36,6 +40,40 @@ class SavepointStoreTest extends munit.FunSuite {
 
     assertEquals(selected.flatMap(_.skipParquetFiles), Some(Set("valid")))
     assertEquals(warnings.toSeq, Seq((3000L, 1L)))
+  }
+
+  test("file store latestConfig does not let hostile future coordinates beat a real savepoint") {
+    val dir = Files.createTempDirectory("savepoint-store-latest-hostile")
+    try {
+      val hostilePath =
+        dir.resolve(
+          f"savepoint_${SavepointsManager.MaxReasonableSeedValue}%013d_${1L}%010d.yaml"
+        )
+      val realPath =
+        dir.resolve(f"savepoint_${System.currentTimeMillis()}%013d_${2L}%010d.yaml")
+
+      Files.write(
+        hostilePath,
+        config(skipFiles = Set("hostile")).render.getBytes(StandardCharsets.UTF_8)
+      )
+      Files.setLastModifiedTime(hostilePath, FileTime.fromMillis(1L))
+      Files.write(
+        realPath,
+        config(skipFiles = Set("real")).render.getBytes(StandardCharsets.UTF_8)
+      )
+
+      val selected = SavepointStore.file(dir.toString).latestConfig()
+
+      assertEquals(
+        selected.skipParquetFiles,
+        Some(Set("real")),
+        "a savepoint with hostile coordinates must not dominate resumeFromLatest ordering"
+      )
+    } finally
+      Files
+        .walk(dir)
+        .sorted(java.util.Comparator.reverseOrder())
+        .forEach(Files.delete)
   }
 
   private def config(skipFiles: Set[String]): MigratorConfig =

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
@@ -170,9 +170,51 @@ class SavepointStoreTest extends munit.FunSuite {
         .forEach(Files.delete)
   }
 
+  test("file store latestConfig skips savepoints from different config identities when scoped") {
+    val dir = Files.createTempDirectory("savepoint-store-latest-identity")
+    try {
+      val requested = config(
+        sourcePath     = "s3a://bucket/requested",
+        skipFiles      = Set("requested"),
+        savepointsPath = dir.toString
+      )
+      val unrelated = config(
+        sourcePath     = "s3a://bucket/unrelated",
+        skipFiles      = Set("unrelated"),
+        savepointsPath = dir.toString
+      )
+
+      Files.write(
+        dir.resolve(f"savepoint_${1000L}%013d_${1L}%010d.yaml"),
+        requested.render.getBytes(StandardCharsets.UTF_8)
+      )
+      Files.write(
+        dir.resolve(f"savepoint_${2000L}%013d_${1L}%010d.yaml"),
+        unrelated.render.getBytes(StandardCharsets.UTF_8)
+      )
+
+      val selected = SavepointStore.forConfig(requested, None).latestConfig()
+
+      assertEquals(
+        selected.skipParquetFiles,
+        Some(Set("requested")),
+        "resumeFromLatest must not use a newer file-backed savepoint from another migration"
+      )
+      assertEquals(
+        SavepointStore.configIdentitySha256(selected),
+        SavepointStore.configIdentitySha256(requested)
+      )
+    } finally
+      Files
+        .walk(dir)
+        .sorted(java.util.Comparator.reverseOrder())
+        .forEach(Files.delete)
+  }
+
   private def config(
     skipFiles: Set[String],
-    sourcePath: String = "s3a://bucket/data"
+    sourcePath: String = "s3a://bucket/data",
+    savepointsPath: String = "/tmp/savepoints"
   ): MigratorConfig =
     MigratorConfig(
       source = SourceSettings.Parquet(
@@ -196,7 +238,7 @@ class SavepointStoreTest extends munit.FunSuite {
         consistencyLevel              = "LOCAL_QUORUM"
       ),
       renames          = None,
-      savepoints       = Savepoints(intervalSeconds = 300, path = "/tmp/savepoints"),
+      savepoints       = Savepoints(intervalSeconds = 300, path = savepointsPath),
       skipTokenRanges  = None,
       skipSegments     = None,
       skipParquetFiles = Some(skipFiles),

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
@@ -1,0 +1,70 @@
+package com.scylladb.migrator
+
+import com.scylladb.migrator.config.{ MigratorConfig, Savepoints, SourceSettings, TargetSettings }
+
+class SavepointStoreTest extends munit.FunSuite {
+
+  test("target store newestValidConfig returns newest valid savepoint") {
+    val older = config(skipFiles = Set("older")).render
+    val newer = config(skipFiles = Set("newer")).render
+
+    val selected = ScyllaTargetSavepointStore.newestValidConfig(
+      rows = Seq(
+        ScyllaTargetSavepointStore.StoredSavepoint(1000L, 1L, older),
+        ScyllaTargetSavepointStore.StoredSavepoint(1000L, 2L, newer)
+      ),
+      warnInvalidRow = (_, _) => ()
+    )
+
+    assertEquals(
+      selected.flatMap(_.skipParquetFiles),
+      Some(Set("newer"))
+    )
+  }
+
+  test("target store newestValidConfig skips corrupt latest rows") {
+    val warnings = scala.collection.mutable.ArrayBuffer.empty[(Long, Long)]
+    val valid = config(skipFiles = Set("valid")).render
+
+    val selected = ScyllaTargetSavepointStore.newestValidConfig(
+      rows = Seq(
+        ScyllaTargetSavepointStore.StoredSavepoint(3000L, 1L, "not: [valid"),
+        ScyllaTargetSavepointStore.StoredSavepoint(2000L, 1L, valid)
+      ),
+      warnInvalidRow = (row, _) => warnings += ((row.epochMillis, row.sequence))
+    )
+
+    assertEquals(selected.flatMap(_.skipParquetFiles), Some(Set("valid")))
+    assertEquals(warnings.toSeq, Seq((3000L, 1L)))
+  }
+
+  private def config(skipFiles: Set[String]): MigratorConfig =
+    MigratorConfig(
+      source = SourceSettings.Parquet(
+        path        = "s3a://bucket/data",
+        credentials = None,
+        region      = None,
+        endpoint    = None
+      ),
+      target = TargetSettings.Scylla(
+        host                          = "scylla.example.com",
+        port                          = 9042,
+        localDC                       = Some("dc1"),
+        credentials                   = None,
+        sslOptions                    = None,
+        keyspace                      = "ks",
+        table                         = "tbl",
+        connections                   = None,
+        stripTrailingZerosForDecimals = false,
+        writeTTLInS                   = None,
+        writeWritetimestampInuS       = None,
+        consistencyLevel              = "LOCAL_QUORUM"
+      ),
+      renames          = None,
+      savepoints       = Savepoints(intervalSeconds = 300, path = "/tmp/savepoints"),
+      skipTokenRanges  = None,
+      skipSegments     = None,
+      skipParquetFiles = Some(skipFiles),
+      validation       = None
+    )
+}

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointStoreTest.scala
@@ -67,6 +67,75 @@ class SavepointStoreTest extends munit.FunSuite {
     assertEquals(warnings.toSeq, Seq((SavepointsManager.MaxReasonableSeedValue, 1L)))
   }
 
+  test("target store newestValidConfig skips max-counter boundary rows") {
+    val warnings = scala.collection.mutable.ArrayBuffer.empty[(Long, Long)]
+    val real = config(skipFiles = Set("real")).render
+    val boundary = config(skipFiles = Set("boundary")).render
+
+    val selected = ScyllaTargetSavepointStore.newestValidConfig(
+      rows = Seq(
+        ScyllaTargetSavepointStore.StoredSavepoint(1000L, 1L, real),
+        ScyllaTargetSavepointStore.StoredSavepoint(
+          SavepointsManager.MaxReasonableSeedValue - 1L,
+          SavepointsManager.MaxSavepointSequenceValue,
+          boundary
+        )
+      ),
+      warnInvalidRow = (row, _) => warnings += ((row.epochMillis, row.sequence))
+    )
+
+    assertEquals(
+      selected.flatMap(_.skipParquetFiles),
+      Some(Set("real")),
+      "target-backed resume must not select a row whose next savepoint would roll over to an unresumable coordinate"
+    )
+    assertEquals(
+      warnings.toSeq,
+      Seq(
+        (
+          SavepointsManager.MaxReasonableSeedValue - 1L,
+          SavepointsManager.MaxSavepointSequenceValue
+        )
+      )
+    )
+  }
+
+  test("target store newestCoordinates skips max-counter boundary seeds") {
+    val warnings = scala.collection.mutable.ArrayBuffer.empty[(Long, Long)]
+
+    val selected = ScyllaTargetSavepointStore.newestCoordinates(
+      rows = Seq(
+        ScyllaTargetSavepointStore.StoredSavepointCoordinates(
+          epochMillis  = 1000L,
+          sequence     = 1L,
+          configSha256 = None
+        ),
+        ScyllaTargetSavepointStore.StoredSavepointCoordinates(
+          epochMillis  = SavepointsManager.MaxReasonableSeedValue - 1L,
+          sequence     = SavepointsManager.MaxSavepointSequenceValue,
+          configSha256 = None
+        )
+      ),
+      expectedConfigSha256 = None,
+      warnInvalidRow       = (row, _) => warnings += ((row.epochMillis, row.sequence))
+    )
+
+    assertEquals(
+      selected,
+      Some(SavepointCoordinates(1000L, 1L)),
+      "target-backed seed state must ignore a coordinate whose rollover would be rejected by resume lookup"
+    )
+    assertEquals(
+      warnings.toSeq,
+      Seq(
+        (
+          SavepointsManager.MaxReasonableSeedValue - 1L,
+          SavepointsManager.MaxSavepointSequenceValue
+        )
+      )
+    )
+  }
+
   test("target store newestValidConfig skips rows from different config identities") {
     val requested = config(sourcePath = "s3a://bucket/requested", skipFiles = Set("requested"))
     val unrelated = config(sourcePath = "s3a://bucket/unrelated", skipFiles = Set("unrelated"))
@@ -162,6 +231,39 @@ class SavepointStoreTest extends munit.FunSuite {
         selected.skipParquetFiles,
         Some(Set("real")),
         "a savepoint with hostile coordinates must not dominate resumeFromLatest ordering"
+      )
+    } finally
+      Files
+        .walk(dir)
+        .sorted(java.util.Comparator.reverseOrder())
+        .forEach(Files.delete)
+  }
+
+  test("file store latestConfig skips max-counter boundary savepoints") {
+    val dir = Files.createTempDirectory("savepoint-store-latest-boundary")
+    try {
+      val realPath =
+        dir.resolve(f"savepoint_${1000L}%013d_${1L}%010d.yaml")
+      val boundaryPath =
+        dir.resolve(
+          f"savepoint_${SavepointsManager.MaxReasonableSeedValue - 1L}%013d_${SavepointsManager.MaxSavepointSequenceValue}%010d.yaml"
+        )
+
+      Files.write(
+        realPath,
+        config(skipFiles = Set("real")).render.getBytes(StandardCharsets.UTF_8)
+      )
+      Files.write(
+        boundaryPath,
+        config(skipFiles = Set("boundary")).render.getBytes(StandardCharsets.UTF_8)
+      )
+
+      val selected = SavepointStore.file(dir.toString).latestConfig()
+
+      assertEquals(
+        selected.skipParquetFiles,
+        Some(Set("real")),
+        "resumeFromLatest must not pick a savepoint whose next dump would roll over to an unresumable coordinate"
       )
     } finally
       Files

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
@@ -59,8 +59,9 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
     cfg: MigratorConfig,
     processed: => Set[String],
     snapshotDelayMillis: Long = 0L,
-    onSnapshotStarted: () => Unit = () => ()
-  ) extends SavepointsManager(cfg) {
+    onSnapshotStarted: () => Unit = () => (),
+    savepointStore: Option[SavepointStore] = None
+  ) extends SavepointsManager(cfg, savepointStore) {
     def describeMigrationState(): String = s"Processed: ${processed.size}"
     def updateConfigWithMigrationState(): MigratorConfig = {
       onSnapshotStarted()
@@ -355,6 +356,30 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
     } finally deleteRecursively(dir)
   }
 
+  test("seed rejects hostile coordinates returned by savepoint stores") {
+    val dir = Files.createTempDirectory("savepoints-hostile-store-seed")
+    val store = new RecordingStore(
+      Some(SavepointCoordinates(java.lang.Long.MAX_VALUE, java.lang.Long.MAX_VALUE))
+    )
+    try {
+      val cfg = newConfig(dir, intervalSeconds = 3600)
+      val manager = new TestManager(
+        cfg,
+        processed      = Set("alpha"),
+        savepointStore = Some(store)
+      )
+      try manager.dumpMigrationState("after-hostile-store-seed")
+      finally manager.close()
+
+      val record = store.records.headOption.getOrElse(fail("manager wrote no savepoint"))
+      assert(
+        record.coordinates.epochMillis < SavepointsManager.MaxReasonableSeedValue,
+        s"hostile epoch_millis was accepted: ${record.coordinates.epochMillis}"
+      )
+      assertEquals(record.coordinates.sequence, 1L)
+    } finally deleteRecursively(dir)
+  }
+
   test("hostile filenames do not crash sort / findLatest") {
     // An attacker (or a buggy external tool) could drop a savepoint-looking file whose numeric
     // fields overflow `Long`.  `parseLong` then throws `NumberFormatException`; an un-guarded
@@ -488,5 +513,23 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
         s"latest savepoint ${winner.getFileName} did not contain the completed terminal snapshot"
       )
     } finally deleteRecursively(dir)
+  }
+
+  private class RecordingStore(seed: Option[SavepointCoordinates]) extends SavepointStore {
+    private val saved = scala.collection.mutable.ArrayBuffer.empty[SavepointRecord]
+
+    def records: Seq[SavepointRecord] = saved.toSeq
+
+    override def prepare(): Unit = ()
+
+    override def seedState(): Option[SavepointCoordinates] = seed
+
+    override def save(record: SavepointRecord): String = {
+      saved += record
+      s"record-${saved.size}"
+    }
+
+    override def latestConfig(): MigratorConfig =
+      throw new UnsupportedOperationException("latestConfig is not used by this test store")
   }
 }

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
@@ -479,6 +479,30 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
     } finally deleteRecursively(dir)
   }
 
+  test("dumped savepoint configs disable resumeFromLatest lookup") {
+    val dir = Files.createTempDirectory("savepoints-resume-flag")
+    try {
+      val cfg = newConfig(dir, intervalSeconds = 3600).copy(
+        savepoints = Savepoints(
+          intervalSeconds  = 3600,
+          path             = dir.toString,
+          resumeFromLatest = true
+        )
+      )
+      val manager = new TestManager(cfg, processed = Set("standalone"))
+      try manager.dumpMigrationState("manual")
+      finally manager.close()
+
+      val parsed = MigratorConfig.loadFrom(latest(dir).toString)
+      assertEquals(
+        parsed.savepoints.resumeFromLatest,
+        false,
+        "a generated savepoint should be directly runnable instead of recursively loading latest"
+      )
+      assertEquals(parsed.skipParquetFiles.getOrElse(Set.empty), Set("standalone"))
+    } finally deleteRecursively(dir)
+  }
+
   test("final/completed dumps before close still win over an in-flight scheduled dump") {
     // Mirror the production ordering in Parquet.scala / ScyllaMigrator.scala:
     // a scheduled dump may already be in flight, then the driver writes "final" / "completed",

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
@@ -356,6 +356,34 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
     } finally deleteRecursively(dir)
   }
 
+  test("seed at maximum 10-digit counter rolls over to the next millisecond") {
+    val dir = Files.createTempDirectory("savepoints-seed-counter-rollover")
+    try {
+      val seedMillis = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365)
+      val maxCounter = SavepointsManager.MaxSavepointSequenceValue
+      val planted =
+        dir.resolve(f"savepoint_${seedMillis}%013d_${maxCounter}%010d.yaml")
+      Files.write(planted, Array.emptyByteArray)
+
+      val cfg = newConfig(dir, intervalSeconds = 3600)
+      val manager = new TestManager(cfg, processed = Set("rollover"))
+      try manager.dumpMigrationState("after-counter-rollover-seed")
+      finally manager.close()
+
+      val produced =
+        listSavepoints(dir).map(_.getFileName.toString).filter(_ != planted.getFileName.toString)
+      assertEquals(produced.size, 1)
+      produced.head match {
+        case savepointName(head, tailOrNull) =>
+          assertEquals(head.toLong, seedMillis + 1L)
+          assertEquals(tailOrNull, "0000000001")
+          assertEquals(tailOrNull.length, 10)
+        case other =>
+          fail(s"produced filename ${other} does not match the savepoint filename grammar")
+      }
+    } finally deleteRecursively(dir)
+  }
+
   test("seed rejects hostile coordinates returned by savepoint stores") {
     val dir = Files.createTempDirectory("savepoints-hostile-store-seed")
     val store = new RecordingStore(
@@ -406,6 +434,34 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
         winner.getFileName.toString != hostile.getFileName.toString,
         s"hostile filename ${hostile.getFileName} beat the real savepoint in sort order"
       )
+    } finally deleteRecursively(dir)
+  }
+
+  test("seed ignores filenames with overflowing counters") {
+    val dir = Files.createTempDirectory("savepoints-hostile-counter-seed")
+    try {
+      val farFuture = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365)
+      val hostile = dir.resolve(s"savepoint_${farFuture}_999999999999999999999999999.yaml")
+      Files.write(hostile, Array.emptyByteArray)
+
+      val cfg = newConfig(dir, intervalSeconds = 3600)
+      val manager = new TestManager(cfg, processed = Set("real"))
+      try manager.dumpMigrationState("after-hostile-counter")
+      finally manager.close()
+
+      val produced =
+        listSavepoints(dir).map(_.getFileName.toString).filter(_ != hostile.getFileName.toString)
+      assertEquals(produced.size, 1)
+      produced.head match {
+        case savepointName(head, tailOrNull) =>
+          assert(
+            head.toLong < farFuture,
+            s"invalid overflowing counter should not seed the next savepoint at ${farFuture}"
+          )
+          assertEquals(tailOrNull, "0000000001")
+        case other =>
+          fail(s"produced filename ${other} does not match the savepoint filename grammar")
+      }
     } finally deleteRecursively(dir)
   }
 

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
@@ -384,6 +384,33 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
     } finally deleteRecursively(dir)
   }
 
+  test("seed ignores max counter when rolling over would create an unresumable timestamp") {
+    val dir = Files.createTempDirectory("savepoints-seed-counter-rollover-boundary")
+    try {
+      val seedMillis = SavepointsManager.MaxReasonableSeedValue - 1L
+      val maxCounter = SavepointsManager.MaxSavepointSequenceValue
+      val planted =
+        dir.resolve(f"savepoint_${seedMillis}%013d_${maxCounter}%010d.yaml")
+      Files.write(planted, Array.emptyByteArray)
+
+      val cfg = newConfig(dir, intervalSeconds = 3600)
+      val manager = new TestManager(cfg, processed = Set("bounded"))
+      try manager.dumpMigrationState("after-boundary-counter-rollover-seed")
+      finally manager.close()
+
+      val produced =
+        listSavepoints(dir).filter(_.getFileName.toString != planted.getFileName.toString)
+      assertEquals(produced.size, 1)
+      assert(
+        SavepointStore.savepointSortKey(produced.head).isDefined,
+        s"manager wrote an unresumable savepoint coordinate: ${produced.head.getFileName}"
+      )
+
+      val resumed = SavepointStore.file(dir.toString).latestConfig()
+      assertEquals(resumed.skipParquetFiles.getOrElse(Set.empty), Set("bounded"))
+    } finally deleteRecursively(dir)
+  }
+
   test("seed rejects hostile coordinates returned by savepoint stores") {
     val dir = Files.createTempDirectory("savepoints-hostile-store-seed")
     val store = new RecordingStore(

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointsManagerConcurrencyTest.scala
@@ -1,6 +1,12 @@
 package com.scylladb.migrator
 
-import com.scylladb.migrator.config.{ MigratorConfig, Savepoints, SourceSettings, TargetSettings }
+import com.scylladb.migrator.config.{
+  MigratorConfig,
+  SavepointTarget,
+  Savepoints,
+  SourceSettings,
+  TargetSettings
+}
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, Path }
@@ -432,6 +438,33 @@ class SavepointsManagerConcurrencyTest extends munit.FunSuite {
         s"hostile epoch_millis was accepted: ${record.coordinates.epochMillis}"
       )
       assertEquals(record.coordinates.sequence, 1L)
+    } finally deleteRecursively(dir)
+  }
+
+  test("direct managers reject target-table configs without an explicit savepoint store") {
+    val dir = Files.createTempDirectory("savepoints-direct-target-table")
+    try {
+      val cfg = newConfig(dir, intervalSeconds = 3600).copy(
+        savepoints = Savepoints(
+          intervalSeconds = 3600,
+          path            = dir.toString,
+          target          = Some(SavepointTarget.TargetTable())
+        )
+      )
+
+      val thrown =
+        try {
+          val manager = new TestManager(cfg, processed = Set("alpha"))
+          manager.close()
+          None
+        } catch {
+          case e: IllegalArgumentException => Some(e)
+        }
+
+      assert(
+        thrown.exists(_.getMessage.contains("target-table")),
+        "a target-table savepoint config must not silently fall back to filesystem storage"
+      )
     } finally deleteRecursively(dir)
   }
 

--- a/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
@@ -3,8 +3,8 @@ package com.scylladb.migrator
 import com.scylladb.migrator.config.{
   DynamoDBEndpoint,
   MigratorConfig,
+  SavepointTarget,
   Savepoints,
-  SavepointsTarget,
   SourceSettings,
   TargetSettings
 }
@@ -173,7 +173,7 @@ object SparkUtils {
     ("http://s3", 4566)       -> ("http://localhost", 4566)
   )
 
-  private def remapForLocalExecution(config: MigratorConfig): MigratorConfig = {
+  private[migrator] def remapForLocalExecution(config: MigratorConfig): MigratorConfig = {
     val newSource = config.source match {
       case c: SourceSettings.Cassandra if c.cloud.isEmpty =>
         c.copy(host = "localhost", port = cqlHostPortMap.getOrElse(c.host, c.port))
@@ -214,8 +214,8 @@ object SparkUtils {
 
   private def remapSavepoints(savepoints: Savepoints): Savepoints = {
     val remappedTarget = savepoints.target.map {
-      case SavepointsTarget.Filesystem(path) =>
-        SavepointsTarget.Filesystem(remapContainerPath(path))
+      case SavepointTarget.Filesystem(path) =>
+        SavepointTarget.Filesystem(remapContainerPath(path))
       case other => other
     }
 

--- a/tests/src/test/scala/com/scylladb/migrator/SparkUtilsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SparkUtilsTest.scala
@@ -1,0 +1,60 @@
+package com.scylladb.migrator
+
+import com.scylladb.migrator.config.{
+  MigratorConfig,
+  SavepointTarget,
+  Savepoints,
+  SourceSettings,
+  TargetSettings
+}
+
+class SparkUtilsTest extends munit.FunSuite {
+
+  test("local execution remaps nested filesystem savepoint target path") {
+    val config = baseConfig.copy(
+      savepoints = Savepoints(
+        intervalSeconds = 300,
+        path            = "/app/savepoints/legacy",
+        target          = Some(SavepointTarget.Filesystem("/app/savepoints/nested"))
+      )
+    )
+
+    val remapped = SparkUtils.remapForLocalExecution(config)
+
+    assertEquals(remapped.savepoints.path, "docker/spark-master/legacy")
+    assertEquals(
+      remapped.savepoints.resolvedTarget,
+      SavepointTarget.Filesystem("docker/spark-master/nested")
+    )
+  }
+
+  private val baseConfig: MigratorConfig =
+    MigratorConfig(
+      source = SourceSettings.Parquet(
+        path        = "/app/parquet/data",
+        credentials = None,
+        region      = None,
+        endpoint    = None
+      ),
+      target = TargetSettings.Scylla(
+        host                          = "scylla",
+        port                          = 9042,
+        localDC                       = Some("datacenter1"),
+        credentials                   = None,
+        sslOptions                    = None,
+        keyspace                      = "test",
+        table                         = "tbl",
+        connections                   = None,
+        stripTrailingZerosForDecimals = false,
+        writeTTLInS                   = None,
+        writeWritetimestampInuS       = None,
+        consistencyLevel              = "LOCAL_QUORUM"
+      ),
+      renames          = None,
+      savepoints       = Savepoints(intervalSeconds = 300, path = "/app/savepoints"),
+      skipTokenRanges  = None,
+      skipSegments     = None,
+      skipParquetFiles = None,
+      validation       = None
+    )
+}

--- a/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigTest.scala
@@ -128,6 +128,33 @@ class MigratorConfigTest extends munit.FunSuite {
     assertEquals(savepoints.filesystemPath, "/custom/savepoints")
   }
 
+  test("null savepoints target decodes as an omitted target") {
+    val config =
+      """source:
+        |  type: parquet
+        |  path: s3a://bucket/data
+        |target:
+        |  type: scylla
+        |  host: scylla.example.com
+        |  port: 9042
+        |  keyspace: ks
+        |  table: tbl
+        |  stripTrailingZerosForDecimals: false
+        |  consistencyLevel: LOCAL_QUORUM
+        |savepoints:
+        |  path: /custom/savepoints
+        |  intervalSeconds: 60
+        |  target: null
+        |""".stripMargin
+
+    val result = yaml.parser.parse(config).flatMap(_.as[MigratorConfig])
+
+    assert(result.isRight, s"Expected valid config but got: ${result}")
+    val savepoints = result.toOption.get.savepoints
+    assertEquals(savepoints.target, None)
+    assertEquals(savepoints.resolvedTarget, SavepointTarget.Filesystem("/custom/savepoints"))
+  }
+
   test("target-table savepoints config decodes with defaults") {
     val config =
       """source:

--- a/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigTest.scala
@@ -1,6 +1,7 @@
 package com.scylladb.migrator.config
 
 import com.datastax.spark.connector.rdd.partitioner.dht.{ BigIntToken, LongToken }
+import com.scylladb.migrator.SavepointStore
 import io.circe.yaml
 
 class MigratorConfigTest extends munit.FunSuite {
@@ -41,6 +42,207 @@ class MigratorConfigTest extends munit.FunSuite {
 
   private def parquetConfig(target: String, savepoints: String): String =
     s"""${parquetSource}${target}${savepoints}"""
+
+  test("existing file savepoints config decodes as filesystem target") {
+    val config =
+      """source:
+        |  type: parquet
+        |  path: s3a://bucket/data
+        |target:
+        |  type: scylla
+        |  host: scylla.example.com
+        |  port: 9042
+        |  keyspace: ks
+        |  table: tbl
+        |  stripTrailingZerosForDecimals: false
+        |  consistencyLevel: LOCAL_QUORUM
+        |savepoints:
+        |  path: /tmp/savepoints
+        |  intervalSeconds: 300
+        |""".stripMargin
+
+    val result = yaml.parser.parse(config).flatMap(_.as[MigratorConfig])
+
+    assert(result.isRight, s"Expected valid config but got: ${result}")
+    val savepoints = result.toOption.get.savepoints
+    assertEquals(savepoints.resolvedTarget, SavepointTarget.Filesystem("/tmp/savepoints"))
+    assertEquals(savepoints.path, "/tmp/savepoints")
+    assertEquals(savepoints.intervalSeconds, 300)
+    assertEquals(savepoints.resumeFromLatest, false)
+  }
+
+  test("filesystem savepoints target decodes") {
+    val config =
+      """source:
+        |  type: parquet
+        |  path: s3a://bucket/data
+        |target:
+        |  type: scylla
+        |  host: scylla.example.com
+        |  port: 9042
+        |  keyspace: ks
+        |  table: tbl
+        |  stripTrailingZerosForDecimals: false
+        |  consistencyLevel: LOCAL_QUORUM
+        |savepoints:
+        |  intervalSeconds: 60
+        |  target:
+        |    type: filesystem
+        |    path: /nested/savepoints
+        |""".stripMargin
+
+    val result = yaml.parser.parse(config).flatMap(_.as[MigratorConfig])
+
+    assert(result.isRight, s"Expected valid config but got: ${result}")
+    val savepoints = result.toOption.get.savepoints
+    assertEquals(savepoints.resolvedTarget, SavepointTarget.Filesystem("/nested/savepoints"))
+    assertEquals(savepoints.filesystemPath, "/nested/savepoints")
+    assertEquals(savepoints.intervalSeconds, 60)
+  }
+
+  test("filesystem savepoints target inherits top-level path when target path is omitted") {
+    val config =
+      """source:
+        |  type: parquet
+        |  path: s3a://bucket/data
+        |target:
+        |  type: scylla
+        |  host: scylla.example.com
+        |  port: 9042
+        |  keyspace: ks
+        |  table: tbl
+        |  stripTrailingZerosForDecimals: false
+        |  consistencyLevel: LOCAL_QUORUM
+        |savepoints:
+        |  path: /custom/savepoints
+        |  intervalSeconds: 60
+        |  target:
+        |    type: filesystem
+        |""".stripMargin
+
+    val result = yaml.parser.parse(config).flatMap(_.as[MigratorConfig])
+
+    assert(result.isRight, s"Expected valid config but got: ${result}")
+    val savepoints = result.toOption.get.savepoints
+    assertEquals(savepoints.resolvedTarget, SavepointTarget.Filesystem("/custom/savepoints"))
+    assertEquals(savepoints.filesystemPath, "/custom/savepoints")
+  }
+
+  test("target-table savepoints config decodes with defaults") {
+    val config =
+      """source:
+        |  type: parquet
+        |  path: s3a://bucket/data
+        |target:
+        |  type: scylla
+        |  host: scylla.example.com
+        |  port: 9042
+        |  keyspace: ks
+        |  table: tbl
+        |  stripTrailingZerosForDecimals: false
+        |  consistencyLevel: LOCAL_QUORUM
+        |savepoints:
+        |  intervalSeconds: 60
+        |  target:
+        |    type: target-table
+        |""".stripMargin
+
+    val result = yaml.parser.parse(config).flatMap(_.as[MigratorConfig])
+
+    assert(result.isRight, s"Expected valid config but got: ${result}")
+    val savepoints = result.toOption.get.savepoints
+    assertEquals(savepoints.path, Savepoints.Default.path)
+    assertEquals(
+      savepoints.resolvedTarget,
+      SavepointTarget.TargetTable(
+        keyspace = None,
+        table    = "scylla_migrator_savepoints",
+        jobId    = None
+      )
+    )
+  }
+
+  test("target-table savepoints config decodes explicit keyspace and table") {
+    val config =
+      """source:
+        |  type: parquet
+        |  path: s3a://bucket/data
+        |target:
+        |  type: scylla
+        |  host: scylla.example.com
+        |  port: 9042
+        |  keyspace: ks
+        |  table: tbl
+        |  stripTrailingZerosForDecimals: false
+        |  consistencyLevel: LOCAL_QUORUM
+        |savepoints:
+        |  intervalSeconds: 300
+        |  target:
+        |    type: target-table
+        |    keyspace: my-keyspace
+        |    table: my-table
+        |""".stripMargin
+
+    val result = yaml.parser.parse(config).flatMap(_.as[MigratorConfig])
+
+    assert(result.isRight, s"Expected valid config but got: ${result}")
+    assertEquals(
+      result.toOption.get.savepoints.resolvedTarget,
+      SavepointTarget.TargetTable(
+        keyspace = Some("my-keyspace"),
+        table    = "my-table",
+        jobId    = None
+      )
+    )
+  }
+
+  test("target-table savepoints config rejects non-Scylla targets") {
+    val config =
+      """source:
+        |  type: dynamodb
+        |  table: Src
+        |target:
+        |  type: dynamodb
+        |  table: Dst
+        |  streamChanges: false
+        |savepoints:
+        |  intervalSeconds: 300
+        |  target:
+        |    type: target-table
+        |""".stripMargin
+
+    val result = yaml.parser.parse(config).flatMap(_.as[MigratorConfig])
+
+    assert(result.isLeft, s"Expected decoding failure but got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("target-table")),
+      s"Expected Scylla-only error, got: ${result.left.map(_.getMessage)}"
+    )
+  }
+
+  test("derived target savepoint job id ignores progress fields and tracks source/target identity") {
+    val base = parquetToScyllaConfig(
+      sourcePath  = "s3a://bucket/source-a",
+      targetTable = "table_a"
+    )
+    val withProgress = base.copy(skipParquetFiles = Some(Set("file-a.parquet")))
+    val differentTarget = parquetToScyllaConfig(
+      sourcePath  = "s3a://bucket/source-a",
+      targetTable = "table_b"
+    )
+    val differentSource = parquetToScyllaConfig(
+      sourcePath  = "s3a://bucket/source-b",
+      targetTable = "table_a"
+    )
+
+    val jobId = SavepointStore.targetJobId(base)
+
+    assert(jobId.startsWith("auto-"), s"Expected auto-derived job id, got: ${jobId}")
+    assertEquals(jobId.length, "auto-".length + 32)
+    assertEquals(SavepointStore.targetJobId(withProgress), jobId)
+    assertNotEquals(SavepointStore.targetJobId(differentTarget), jobId)
+    assertNotEquals(SavepointStore.targetJobId(differentSource), jobId)
+  }
 
   test("full MigratorConfig with Alternator types round-trips through YAML") {
     val config = MigratorConfig(
@@ -702,4 +904,40 @@ class MigratorConfigTest extends munit.FunSuite {
     assertEquals(roundTripped.skipTokenRanges, config.skipTokenRanges)
     assertEquals(roundTripped.skipSegments, config.skipSegments)
   }
+
+  private def parquetToScyllaConfig(
+    sourcePath: String,
+    targetTable: String
+  ): MigratorConfig =
+    MigratorConfig(
+      source = SourceSettings.Parquet(
+        path        = sourcePath,
+        credentials = None,
+        region      = None,
+        endpoint    = None
+      ),
+      target = TargetSettings.Scylla(
+        host                          = "scylla.example.com",
+        port                          = 9042,
+        localDC                       = Some("dc1"),
+        credentials                   = None,
+        sslOptions                    = None,
+        keyspace                      = "ks",
+        table                         = targetTable,
+        connections                   = None,
+        stripTrailingZerosForDecimals = false,
+        writeTTLInS                   = None,
+        writeWritetimestampInuS       = None,
+        consistencyLevel              = "LOCAL_QUORUM"
+      ),
+      renames = None,
+      savepoints = Savepoints(
+        intervalSeconds = 300,
+        target          = Some(SavepointTarget.TargetTable())
+      ),
+      skipTokenRanges  = None,
+      skipSegments     = None,
+      skipParquetFiles = None,
+      validation       = None
+    )
 }

--- a/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigTest.scala
@@ -220,7 +220,9 @@ class MigratorConfigTest extends munit.FunSuite {
     )
   }
 
-  test("derived target savepoint job id ignores progress fields and tracks source/target identity") {
+  test(
+    "derived target savepoint job id ignores progress fields and tracks source/target identity"
+  ) {
     val base = parquetToScyllaConfig(
       sourcePath  = "s3a://bucket/source-a",
       targetTable = "table_a"

--- a/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/MigratorConfigTest.scala
@@ -244,6 +244,18 @@ class MigratorConfigTest extends munit.FunSuite {
     assertNotEquals(SavepointStore.targetJobId(differentSource), jobId)
   }
 
+  test("derived target savepoint job id distinguishes Cassandra where filters") {
+    val activeTenant =
+      cassandraToScyllaConfig(where = Some("tenant_id = 'active'"))
+    val archivedTenant =
+      cassandraToScyllaConfig(where = Some("tenant_id = 'archived'"))
+
+    assertNotEquals(
+      SavepointStore.targetJobId(activeTenant),
+      SavepointStore.targetJobId(archivedTenant)
+    )
+  }
+
   test("full MigratorConfig with Alternator types round-trips through YAML") {
     val config = MigratorConfig(
       source = SourceSettings.Alternator(
@@ -924,6 +936,48 @@ class MigratorConfigTest extends munit.FunSuite {
         sslOptions                    = None,
         keyspace                      = "ks",
         table                         = targetTable,
+        connections                   = None,
+        stripTrailingZerosForDecimals = false,
+        writeTTLInS                   = None,
+        writeWritetimestampInuS       = None,
+        consistencyLevel              = "LOCAL_QUORUM"
+      ),
+      renames = None,
+      savepoints = Savepoints(
+        intervalSeconds = 300,
+        target          = Some(SavepointTarget.TargetTable())
+      ),
+      skipTokenRanges  = None,
+      skipSegments     = None,
+      skipParquetFiles = None,
+      validation       = None
+    )
+
+  private def cassandraToScyllaConfig(where: Option[String]): MigratorConfig =
+    MigratorConfig(
+      source = SourceSettings.Cassandra(
+        host               = "cassandra.example.com",
+        port               = 9042,
+        localDC            = Some("dc1"),
+        credentials        = None,
+        sslOptions         = None,
+        keyspace           = "source_ks",
+        table              = "source_tbl",
+        splitCount         = None,
+        connections        = None,
+        fetchSize          = 1000,
+        preserveTimestamps = false,
+        where              = where,
+        consistencyLevel   = "LOCAL_QUORUM"
+      ),
+      target = TargetSettings.Scylla(
+        host                          = "scylla.example.com",
+        port                          = 9042,
+        localDC                       = Some("dc1"),
+        credentials                   = None,
+        sslOptions                    = None,
+        keyspace                      = "ks",
+        table                         = "tbl",
         connections                   = None,
         stripTrailingZerosForDecimals = false,
         writeTTLInS                   = None,

--- a/tests/src/test/scala/com/scylladb/migrator/readers/FileCompletionListenerTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/FileCompletionListenerTest.scala
@@ -1,6 +1,6 @@
 package com.scylladb.migrator.readers
 
-import com.scylladb.migrator.config.{ MigratorConfig, SourceSettings }
+import com.scylladb.migrator.config.{ MigratorConfig, SourceSettings, TargetSettings }
 import org.apache.spark.scheduler.{ SparkListenerTaskEnd, TaskInfo }
 import org.apache.spark.{ Success, TaskEndReason }
 import org.apache.spark.sql.SparkSession
@@ -56,7 +56,7 @@ class FileCompletionListenerTest extends munit.FunSuite {
     try {
       val config = MigratorConfig(
         source           = SourceSettings.Parquet("dummy", None, None, None),
-        target           = null,
+        target           = testTarget,
         renames          = None,
         savepoints       = com.scylladb.migrator.config.Savepoints(300, tempDir.toString),
         skipTokenRanges  = None,
@@ -118,7 +118,7 @@ class FileCompletionListenerTest extends munit.FunSuite {
     try {
       val config = MigratorConfig(
         source           = SourceSettings.Parquet("dummy", None, None, None),
-        target           = null,
+        target           = testTarget,
         renames          = None,
         savepoints       = com.scylladb.migrator.config.Savepoints(300, tempDir.toString),
         skipTokenRanges  = None,
@@ -182,7 +182,7 @@ class FileCompletionListenerTest extends munit.FunSuite {
     try {
       val config = MigratorConfig(
         source           = SourceSettings.Parquet("dummy", None, None, None),
-        target           = null,
+        target           = testTarget,
         renames          = None,
         savepoints       = com.scylladb.migrator.config.Savepoints(300, tempDir.toString),
         skipTokenRanges  = None,
@@ -234,7 +234,7 @@ class FileCompletionListenerTest extends munit.FunSuite {
     try {
       val config = MigratorConfig(
         source           = SourceSettings.Parquet("dummy", None, None, None),
-        target           = null,
+        target           = testTarget,
         renames          = None,
         savepoints       = com.scylladb.migrator.config.Savepoints(300, tempDir.toString),
         skipTokenRanges  = None,
@@ -277,7 +277,7 @@ class FileCompletionListenerTest extends munit.FunSuite {
     try {
       val config = MigratorConfig(
         source           = SourceSettings.Parquet("dummy", None, None, None),
-        target           = null,
+        target           = testTarget,
         renames          = None,
         savepoints       = com.scylladb.migrator.config.Savepoints(300, tempDir.toString),
         skipTokenRanges  = None,
@@ -333,7 +333,7 @@ class FileCompletionListenerTest extends munit.FunSuite {
     try {
       val config = MigratorConfig(
         source           = SourceSettings.Parquet("dummy", None, None, None),
-        target           = null,
+        target           = testTarget,
         renames          = None,
         savepoints       = com.scylladb.migrator.config.Savepoints(300, tempDir.toString),
         skipTokenRanges  = None,
@@ -369,4 +369,20 @@ class FileCompletionListenerTest extends munit.FunSuite {
         .sorted(java.util.Comparator.reverseOrder())
         .forEach(Files.delete)
   }
+
+  private val testTarget: TargetSettings.Scylla =
+    TargetSettings.Scylla(
+      host                          = "localhost",
+      port                          = 9042,
+      localDC                       = None,
+      credentials                   = None,
+      sslOptions                    = None,
+      keyspace                      = "ks",
+      table                         = "tbl",
+      connections                   = None,
+      stripTrailingZerosForDecimals = false,
+      writeTTLInS                   = None,
+      writeWritetimestampInuS       = None,
+      consistencyLevel              = "LOCAL_QUORUM"
+    )
 }

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/MySQLSavepointsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/MySQLSavepointsTest.scala
@@ -7,6 +7,7 @@ import com.scylladb.migrator.config.{
   SourceSettings,
   TargetSettings
 }
+import com.scylladb.migrator.{ Migrator, SparkUtils }
 import org.apache.spark.sql.SparkSession
 
 import java.nio.file.Files
@@ -69,6 +70,69 @@ class MySQLSavepointsTest extends munit.FunSuite {
       manager.foreach(_.close())
       assertEquals(manager, None)
       assert(!Files.exists(savepointsDir), "savepoints directory should not be created for MySQL")
+    } finally {
+      if (Files.exists(savepointsDir))
+        Files
+          .walk(savepointsDir)
+          .sorted(java.util.Comparator.reverseOrder())
+          .forEach(Files.delete)
+      Files.deleteIfExists(tempDir)
+    }
+  }
+
+  test("resumeFromLatest is ignored for MySQL because the source has no savepoint support") {
+    val tempDir = Files.createTempDirectory("mysql-resume-savepoints-test")
+    val savepointsDir = tempDir.resolve("savepoints")
+
+    try {
+      val config = MigratorConfig(
+        source = SourceSettings.MySQL(
+          host                 = "mysql.example.com",
+          port                 = 3306,
+          database             = "mydb",
+          table                = "users",
+          credentials          = Credentials("mysql-user", "mysql-secret"),
+          primaryKey           = None,
+          partitionColumn      = None,
+          numPartitions        = None,
+          lowerBound           = None,
+          upperBound           = None,
+          zeroDateTimeBehavior = SourceSettings.MySQL.ZeroDateTimeBehavior.Exception,
+          fetchSize            = SourceSettings.MySQL.DefaultFetchSize,
+          where                = None,
+          connectionProperties = None
+        ),
+        target = TargetSettings.Scylla(
+          host                          = "scylla.example.com",
+          port                          = 9042,
+          localDC                       = Some("datacenter1"),
+          credentials                   = None,
+          sslOptions                    = None,
+          keyspace                      = "ks",
+          table                         = "users",
+          connections                   = Some(1),
+          stripTrailingZerosForDecimals = false,
+          writeTTLInS                   = None,
+          writeWritetimestampInuS       = None,
+          consistencyLevel              = "LOCAL_QUORUM"
+        ),
+        renames = None,
+        savepoints = Savepoints(
+          intervalSeconds  = 300,
+          path             = savepointsDir.toString,
+          resumeFromLatest = true
+        ),
+        skipTokenRanges  = None,
+        skipSegments     = None,
+        skipParquetFiles = None,
+        validation       = None
+      )
+
+      SparkUtils.withSparkSession() { implicit spark =>
+        val effectiveConfig = Migrator.resumeFromLatestIfRequested(config)
+        assertEquals(effectiveConfig, config)
+      }
+      assert(!Files.exists(savepointsDir), "resume lookup should not touch savepoints for MySQL")
     } finally {
       if (Files.exists(savepointsDir))
         Files

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetSavepointsIntegrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetSavepointsIntegrationTest.scala
@@ -11,6 +11,11 @@ import scala.util.chaining._
 class ParquetSavepointsIntegrationTest extends ParquetMigratorSuite {
 
   private val configFileName: String = "parquet-to-scylla-savepoints.yaml"
+  private val targetConfigFileName: String = "parquet-to-scylla-target-savepoints.yaml"
+  private val targetResumeConfigFileName: String =
+    "parquet-to-scylla-target-savepoints-resume.yaml"
+  private val targetSavepointsTable: String = "scylla_migrator_savepoints_target_test"
+  private val targetSavepointsJobId: String = "parquet-target-savepoints-test"
 
   withTableAndSavepoints("savepointstest", "savepoints", "parquet-savepoints-test").test(
     "Parquet savepoints include all processed files"
@@ -62,6 +67,76 @@ class ParquetSavepointsIntegrationTest extends ParquetMigratorSuite {
       savepointConfig.skipParquetFiles.getOrElse(fail("skipParquetFiles were not written"))
 
     assertEquals(skipFiles, expectedProcessedFiles)
+  }
+
+  FunFixture.map2(
+    withTable("targetsavepointstest"),
+    withParquetDir("target-savepoints")
+  ).test("Parquet target savepoints are written to Scylla and used for resume") {
+    case (tableName, parquetRoot) =>
+      targetScylla().execute(s"DROP TABLE IF EXISTS ${keyspace}.${targetSavepointsTable}")
+
+      try {
+        val parquetDir = parquetRoot.resolve("target-savepoints")
+        Files.createDirectories(parquetDir)
+
+        writeParquetTestFile(
+          parquetDir.resolve("batch.parquet"),
+          List(
+            TestRecord("1", "alpha", 10),
+            TestRecord("2", "beta", 20)
+          )
+        )
+
+        val expectedProcessedFiles = listDataFiles(parquetDir).map(toContainerParquetUri)
+
+        successfullyPerformMigration(targetConfigFileName)
+
+        val rows = targetScylla()
+          .execute(
+            s"SELECT epoch_millis, sequence, schema_version, reason, migrator_version, config_sha256, config_yaml FROM ${keyspace}.${targetSavepointsTable} WHERE job_id = '${targetSavepointsJobId}'"
+          )
+          .all()
+          .asScala
+
+        assert(rows.nonEmpty, "target-backed savepoint row was not inserted")
+        assert(
+          rows.forall(_.getInt("schema_version") == 1),
+          "all target-backed savepoints should use schema_version 1"
+        )
+        assert(
+          rows.exists(_.getString("reason") == "completed"),
+          "target-backed savepoints should include the completed terminal snapshot"
+        )
+        assert(
+          rows.forall(row =>
+            Option(row.getString("migrator_version")).exists(_.nonEmpty) &&
+              Option(row.getString("config_sha256")).exists(_.matches("[0-9a-f]{64}"))
+          ),
+          "target-backed savepoints should include migrator version and config SHA-256 metadata"
+        )
+
+        val savedConfigs = rows.map(row => MigratorConfig.loadFromString(row.getString("config_yaml")))
+        assert(
+          savedConfigs.exists(_.skipParquetFiles.contains(expectedProcessedFiles)),
+          s"no target savepoint contained expected processed files: ${expectedProcessedFiles}"
+        )
+
+        targetScylla().execute(s"TRUNCATE ${keyspace}.${tableName}")
+        successfullyPerformMigration(targetResumeConfigFileName)
+
+        val rowCountAfterResume = targetScylla()
+          .execute(s"SELECT id FROM ${keyspace}.${tableName}")
+          .all()
+          .size()
+
+        assertEquals(
+          rowCountAfterResume,
+          0,
+          "resumeFromLatest should load DB progress and skip the already processed Parquet file"
+        )
+      } finally
+        targetScylla().execute(s"DROP TABLE IF EXISTS ${keyspace}.${targetSavepointsTable}")
   }
 
 }

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetSavepointsIntegrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetSavepointsIntegrationTest.scala
@@ -69,74 +69,77 @@ class ParquetSavepointsIntegrationTest extends ParquetMigratorSuite {
     assertEquals(skipFiles, expectedProcessedFiles)
   }
 
-  FunFixture.map2(
-    withTable("targetsavepointstest"),
-    withParquetDir("target-savepoints")
-  ).test("Parquet target savepoints are written to Scylla and used for resume") {
-    case (tableName, parquetRoot) =>
-      targetScylla().execute(s"DROP TABLE IF EXISTS ${keyspace}.${targetSavepointsTable}")
-
-      try {
-        val parquetDir = parquetRoot.resolve("target-savepoints")
-        Files.createDirectories(parquetDir)
-
-        writeParquetTestFile(
-          parquetDir.resolve("batch.parquet"),
-          List(
-            TestRecord("1", "alpha", 10),
-            TestRecord("2", "beta", 20)
-          )
-        )
-
-        val expectedProcessedFiles = listDataFiles(parquetDir).map(toContainerParquetUri)
-
-        successfullyPerformMigration(targetConfigFileName)
-
-        val rows = targetScylla()
-          .execute(
-            s"SELECT epoch_millis, sequence, schema_version, reason, migrator_version, config_sha256, config_yaml FROM ${keyspace}.${targetSavepointsTable} WHERE job_id = '${targetSavepointsJobId}'"
-          )
-          .all()
-          .asScala
-
-        assert(rows.nonEmpty, "target-backed savepoint row was not inserted")
-        assert(
-          rows.forall(_.getInt("schema_version") == 1),
-          "all target-backed savepoints should use schema_version 1"
-        )
-        assert(
-          rows.exists(_.getString("reason") == "completed"),
-          "target-backed savepoints should include the completed terminal snapshot"
-        )
-        assert(
-          rows.forall(row =>
-            Option(row.getString("migrator_version")).exists(_.nonEmpty) &&
-              Option(row.getString("config_sha256")).exists(_.matches("[0-9a-f]{64}"))
-          ),
-          "target-backed savepoints should include migrator version and config SHA-256 metadata"
-        )
-
-        val savedConfigs = rows.map(row => MigratorConfig.loadFromString(row.getString("config_yaml")))
-        assert(
-          savedConfigs.exists(_.skipParquetFiles.contains(expectedProcessedFiles)),
-          s"no target savepoint contained expected processed files: ${expectedProcessedFiles}"
-        )
-
-        targetScylla().execute(s"TRUNCATE ${keyspace}.${tableName}")
-        successfullyPerformMigration(targetResumeConfigFileName)
-
-        val rowCountAfterResume = targetScylla()
-          .execute(s"SELECT id FROM ${keyspace}.${tableName}")
-          .all()
-          .size()
-
-        assertEquals(
-          rowCountAfterResume,
-          0,
-          "resumeFromLatest should load DB progress and skip the already processed Parquet file"
-        )
-      } finally
+  FunFixture
+    .map2(
+      withTable("targetsavepointstest"),
+      withParquetDir("target-savepoints")
+    )
+    .test("Parquet target savepoints are written to Scylla and used for resume") {
+      case (tableName, parquetRoot) =>
         targetScylla().execute(s"DROP TABLE IF EXISTS ${keyspace}.${targetSavepointsTable}")
-  }
+
+        try {
+          val parquetDir = parquetRoot.resolve("target-savepoints")
+          Files.createDirectories(parquetDir)
+
+          writeParquetTestFile(
+            parquetDir.resolve("batch.parquet"),
+            List(
+              TestRecord("1", "alpha", 10),
+              TestRecord("2", "beta", 20)
+            )
+          )
+
+          val expectedProcessedFiles = listDataFiles(parquetDir).map(toContainerParquetUri)
+
+          successfullyPerformMigration(targetConfigFileName)
+
+          val rows = targetScylla()
+            .execute(
+              s"SELECT epoch_millis, sequence, schema_version, reason, migrator_version, config_sha256, config_yaml FROM ${keyspace}.${targetSavepointsTable} WHERE job_id = '${targetSavepointsJobId}'"
+            )
+            .all()
+            .asScala
+
+          assert(rows.nonEmpty, "target-backed savepoint row was not inserted")
+          assert(
+            rows.forall(_.getInt("schema_version") == 1),
+            "all target-backed savepoints should use schema_version 1"
+          )
+          assert(
+            rows.exists(_.getString("reason") == "completed"),
+            "target-backed savepoints should include the completed terminal snapshot"
+          )
+          assert(
+            rows.forall(row =>
+              Option(row.getString("migrator_version")).exists(_.nonEmpty) &&
+                Option(row.getString("config_sha256")).exists(_.matches("[0-9a-f]{64}"))
+            ),
+            "target-backed savepoints should include migrator version and config SHA-256 metadata"
+          )
+
+          val savedConfigs =
+            rows.map(row => MigratorConfig.loadFromString(row.getString("config_yaml")))
+          assert(
+            savedConfigs.exists(_.skipParquetFiles.contains(expectedProcessedFiles)),
+            s"no target savepoint contained expected processed files: ${expectedProcessedFiles}"
+          )
+
+          targetScylla().execute(s"TRUNCATE ${keyspace}.${tableName}")
+          successfullyPerformMigration(targetResumeConfigFileName)
+
+          val rowCountAfterResume = targetScylla()
+            .execute(s"SELECT id FROM ${keyspace}.${tableName}")
+            .all()
+            .size()
+
+          assertEquals(
+            rowCountAfterResume,
+            0,
+            "resumeFromLatest should load DB progress and skip the already processed Parquet file"
+          )
+        } finally
+          targetScylla().execute(s"DROP TABLE IF EXISTS ${keyspace}.${targetSavepointsTable}")
+    }
 
 }

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetSavepointsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/ParquetSavepointsTest.scala
@@ -1,6 +1,6 @@
 package com.scylladb.migrator.scylla
 
-import com.scylladb.migrator.config.{ MigratorConfig, SourceSettings }
+import com.scylladb.migrator.config.{ MigratorConfig, SourceSettings, TargetSettings }
 import com.scylladb.migrator.readers.{ Parquet, ParquetSavepointsManager }
 import org.apache.spark.sql.SparkSession
 
@@ -71,7 +71,7 @@ class ParquetSavepointsTest extends munit.FunSuite {
     try {
       val config = MigratorConfig(
         source           = SourceSettings.Parquet("dummy", None, None, None),
-        target           = null,
+        target           = testTarget,
         renames          = None,
         savepoints       = com.scylladb.migrator.config.Savepoints(300, tempDir.toString),
         skipTokenRanges  = None,
@@ -158,7 +158,7 @@ class ParquetSavepointsTest extends munit.FunSuite {
 
       val config = MigratorConfig(
         source           = parquetSource,
-        target           = null,
+        target           = testTarget,
         renames          = None,
         savepoints       = com.scylladb.migrator.config.Savepoints(300, savepointsDir.toString),
         skipTokenRanges  = None,
@@ -205,4 +205,20 @@ class ParquetSavepointsTest extends munit.FunSuite {
         .forEach(Files.delete)
     }
   }
+
+  private val testTarget: TargetSettings.Scylla =
+    TargetSettings.Scylla(
+      host                          = "localhost",
+      port                          = 9042,
+      localDC                       = None,
+      credentials                   = None,
+      sslOptions                    = None,
+      keyspace                      = "ks",
+      table                         = "tbl",
+      connections                   = None,
+      stripTrailingZerosForDecimals = false,
+      writeTTLInS                   = None,
+      writeWritetimestampInuS       = None,
+      consistencyLevel              = "LOCAL_QUORUM"
+    )
 }


### PR DESCRIPTION
## Summary
- add target-table-backed savepoint storage and configuration
- harden savepoint coordinate, seed, and config identity handling
- add docs, examples, and tests for target-table savepoints

## Testing
- Not run; extracted existing local commits into a branch only.

## Notes
- Extracted from local master at 2ec1aac.
- origin/master has newer validator and GCS/S3 savepoint changes, so this draft may need conflict resolution before it can merge.