### PR TITLE
fix the savepoint resume and secret redaction issue

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -521,6 +521,16 @@ writes so that re-running the migration is safe.
     path: /app/savepoints
     # Interval at which savepoints will be created
     intervalSeconds: 300
+    # Optional. When true (the default), the migrator scans this location on startup and resumes
+    # from the most recent savepoint automatically. Set to false to always start from the
+    # configuration as written.
+    autoResume: true
+
+Savepoint files are written with credentials redacted (secrets are replaced with
+``<redacted>``), so they are safe to keep in shared or long-lived storage. Because of this,
+a savepoint file cannot be used directly as a standalone configuration file; rely on
+``autoResume`` to continue an interrupted migration. See
+:doc:`resume an interrupted migration </resume-interrupted-migration>`.
 
 The legacy ``path`` field is shorthand for an explicit local filesystem target:
 

--- a/docs/source/resume-interrupted-migration.rst
+++ b/docs/source/resume-interrupted-migration.rst
@@ -4,18 +4,31 @@ Resume an Interrupted Migration Where it Left Off
 
 .. note:: This feature is currently supported only when migrating from Apache Cassandra or DynamoDB.
 
-If, for some reason, the migration is interrupted (e.g., because of a networking issue, or if you need to manually stop it for some reason), the migrator is able to resume it from a “savepoints”.
+If, for some reason, the migration is interrupted (e.g., because of a networking issue, or if you need to manually stop it for some reason), the migrator is able to resume it from a “savepoint”.
 
-Savepoints are configuration files that contain information about the already migrated items, which can be skipped when the migration is resumed. The savepoint files are automatically generated during the migration. To use a savepoint, start a migration using it as configuration file.
+Savepoints are configuration files that contain information about the already migrated items, which can be skipped when the migration is resumed. The savepoint files are automatically generated during the migration.
 
-You can control the savepoints location and the interval at which they are generated in the configuration file under the top-level property ``savepoints``. See the corresponding section of the :ref:`configuration reference <config-savepoints>` .
+Automatic resume
+================
+
+By default, the migrator resumes automatically. On startup it scans the configured ``savepoints`` location, finds the most recent savepoint, and merges its progress (the already-migrated token ranges, scan segments, or Parquet files) into the configuration it was launched with. This means that **re-running the same migration with the same configuration file continues where the previous run left off** — no manual editing or file selection is required. This is especially convenient for orchestrated environments (Kubernetes, Cloud Run, etc.) that restart the job with a fixed configuration.
+
+Only the progress information is taken from the savepoint; every other setting — in particular the source and target credentials — comes from the configuration you launch with. You can disable this behavior by setting ``savepoints.autoResume`` to ``false``, for example to force a full re-migration while reusing the same savepoints directory. See the :ref:`configuration reference <config-savepoints>`.
+
+.. warning::
+   Savepoint files are written with credentials **redacted** (secrets are replaced with ``<redacted>``). They are therefore safe to keep in shared or long-lived storage such as an S3/GCS bucket, but a savepoint file can no longer be used directly as a standalone configuration file. Use automatic resume (above) instead, which supplies the real credentials from your launch configuration.
+
+You can control the savepoints location and the interval at which they are generated in the configuration file under the top-level property ``savepoints``. See the corresponding section of the :ref:`configuration reference <config-savepoints>`.
+
+Savepoint file names
+====================
 
 During the migration, the savepoints are generated with file names like ``savepoint_<epochMillis>_<counter>.yaml``, where:
 
 * ``<epochMillis>`` is a 13-digit, zero-padded millisecond timestamp (monotonic within a migrator instance), and
 * ``<counter>`` is a 10-digit, zero-padded per-instance sequence number that disambiguates dumps produced within the same millisecond.
 
-Both components are zero-padded so that **lexicographical order matches chronological order**: listing the directory and picking the alphabetically last file (``ls <savepoints-dir> | tail -n 1``) always yields the most recent savepoint. To resume a migration, start a new migration with that latest savepoint as configuration file.
+Both components are zero-padded so that **lexicographical order matches chronological order**: listing the directory and picking the alphabetically last file (``ls <savepoints-dir> | tail -n 1``) always yields the most recent savepoint, which is the one automatic resume selects.
 
 .. note::
    Older versions of the migrator produced file names like ``savepoint_1234567890.yaml`` (a single Unix-epoch-seconds component). The migrator still reads those files, but any new savepoint written during a resumed migration follows the two-component format above.

--- a/docs/source/resume-interrupted-migration.rst
+++ b/docs/source/resume-interrupted-migration.rst
@@ -2,7 +2,10 @@
 Resume an Interrupted Migration Where it Left Off
 =================================================
 
-.. note:: This feature is currently supported only when migrating from Apache Cassandra or DynamoDB.
+.. note:: Savepoints (and automatic resume) are available for sources that track migration
+   progress: Apache Cassandra, DynamoDB (including Scylla Alternator), and Parquet. They are not
+   available for MySQL sources or the DynamoDB S3-export source, which must be restarted from
+   scratch if interrupted.
 
 If, for some reason, the migration is interrupted (e.g., because of a networking issue, or if you need to manually stop it for some reason), the migrator is able to resume it from a “savepoint”.
 

--- a/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/Migrator.scala
@@ -31,10 +31,20 @@ object Migrator {
 
     log.info(s"ScyllaDB Migrator ${BuildInfo.version}")
 
-    val migratorConfig =
+    val loadedConfig =
       MigratorConfig.loadFrom(
         spark.conf.get("spark.scylla.config"),
         spark.sparkContext.hadoopConfiguration
+      )
+
+    // Auto-resume: fold the skip-state of the latest savepoint (if any) into the configuration so
+    // that re-running the same config continues where a previous run left off. Credentials always
+    // come from the loaded config, never from the (redacted) savepoint file.
+    val migratorConfig =
+      SavepointsResume.resume(
+        loadedConfig,
+        Some(spark.sparkContext.hadoopConfiguration),
+        SparkSecretRedaction.redactionRegex(spark)
       )
 
     log.info(s"Loaded config:\n${migratorConfig.renderRedacted}")

--- a/migrator/src/main/scala/com/scylladb/migrator/SavepointStorage.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/SavepointStorage.scala
@@ -1,0 +1,78 @@
+package com.scylladb.migrator
+
+import com.scylladb.migrator.config.{ MigratorConfig, SavepointsTarget, SparkSecretRedaction }
+import org.apache.hadoop.conf.Configuration
+
+/** Builds the Hadoop [[Configuration]] used to access the savepoints store.
+  *
+  * The credentials and connector settings for the savepoints bucket are derived from
+  * `savepoints.target` (S3/GCS). Both [[SavepointsManager]] (which writes savepoints) and the
+  * startup auto-resume resolver ([[com.scylladb.migrator.config.SavepointsResume]], which reads the
+  * latest savepoint) must build an identical configuration to reach the same store, so the logic
+  * lives here in one place.
+  */
+private[migrator] object SavepointStorage {
+  private val S3ASimpleCredentialsProvider =
+    "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+  private val S3ATemporaryCredentialsProvider =
+    "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider"
+  private val GcsServiceAccountJsonKeyfileAuthType = "SERVICE_ACCOUNT_JSON_KEYFILE"
+
+  def hadoopConfiguration(
+    migratorConfig: MigratorConfig,
+    baseConfiguration: Option[Configuration],
+    redactionRegex: Option[String]
+  ): Configuration = {
+    val conf = baseConfiguration.map(new Configuration(_)).getOrElse(new Configuration())
+
+    migratorConfig.savepoints.target.foreach {
+      case s3: SavepointsTarget.S3 =>
+        s3.region.foreach(conf.set("fs.s3a.endpoint.region", _))
+        s3.credentials.foreach { configuredCredentials =>
+          AwsUtils.computeFinalCredentials(Some(configuredCredentials), None, s3.region).foreach {
+            credentials =>
+              val credentialOptions =
+                Seq(
+                  "fs.s3a.access.key" -> credentials.accessKey,
+                  "fs.s3a.secret.key" -> credentials.secretKey
+                ) ++ credentials.maybeSessionToken.toSeq.map { sessionToken =>
+                  "fs.s3a.session.token" -> sessionToken
+                }
+
+              ensureHadoopKeysRedacted(redactionRegex, credentialOptions.map(_._1))
+              credentialOptions.foreach { case (key, value) => conf.set(key, value) }
+              credentials.maybeSessionToken match {
+                case Some(_) =>
+                  conf.set("fs.s3a.aws.credentials.provider", S3ATemporaryCredentialsProvider)
+                case None =>
+                  conf.set("fs.s3a.aws.credentials.provider", S3ASimpleCredentialsProvider)
+                  conf.unset("fs.s3a.session.token")
+              }
+          }
+        }
+      case gcs: SavepointsTarget.GCS =>
+        gcs.projectId.foreach(conf.set("fs.gs.project.id", _))
+        gcs.credentials.foreach { credentials =>
+          ensureHadoopKeysRedacted(redactionRegex, Seq("fs.gs.auth.service.account.json.keyfile"))
+          conf.set("fs.gs.auth.type", GcsServiceAccountJsonKeyfileAuthType)
+          conf.set(
+            "fs.gs.auth.service.account.json.keyfile",
+            credentials.serviceAccountJsonKeyfile
+          )
+        }
+      case _ => ()
+    }
+
+    conf
+  }
+
+  private def ensureHadoopKeysRedacted(
+    redactionRegex: Option[String],
+    keys: Iterable[String]
+  ): Unit =
+    SparkSecretRedaction.ensureKeysRedacted(
+      redactionRegex,
+      keys,
+      "savepoint Hadoop configuration"
+    )
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/SavepointStorage.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/SavepointStorage.scala
@@ -7,7 +7,7 @@ import org.apache.hadoop.conf.Configuration
   *
   * The credentials and connector settings for the savepoints bucket are derived from
   * `savepoints.target` (S3/GCS). Both [[SavepointsManager]] (which writes savepoints) and the
-  * startup auto-resume resolver ([[com.scylladb.migrator.config.SavepointsResume]], which reads the
+  * startup auto-resume resolver ([[com.scylladb.migrator.SavepointsResume]], which reads the
   * latest savepoint) must build an identical configuration to reach the same store, so the logic
   * lives here in one place.
   */

--- a/migrator/src/main/scala/com/scylladb/migrator/SavepointsManager.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/SavepointsManager.scala
@@ -1,6 +1,6 @@
 package com.scylladb.migrator
 
-import com.scylladb.migrator.config.{ MigratorConfig, SavepointsTarget, SparkSecretRedaction }
+import com.scylladb.migrator.config.MigratorConfig
 import org.apache.hadoop.conf.Configuration
 import org.apache.logging.log4j.LogManager
 import sun.misc.{ Signal, SignalHandler }
@@ -62,7 +62,7 @@ abstract class SavepointsManager(
   private val savepointsPath = migratorConfig.savepoints.storagePath
   private val pathIO = PathIO.forPath(
     savepointsPath,
-    Some(savepointHadoopConfiguration(hadoopConfiguration))
+    Some(SavepointStorage.hadoopConfiguration(migratorConfig, hadoopConfiguration, redactionRegex))
   )
   private val scheduler = new ScheduledThreadPoolExecutor(1)
   private var oldUsr2Handler: SignalHandler = _
@@ -90,59 +90,6 @@ abstract class SavepointsManager(
   seedStateFromExistingSavepoints()
   addUSR2Handler()
   startSavepointSchedule()
-
-  private def savepointHadoopConfiguration(
-    baseConfiguration: Option[Configuration]
-  ): Configuration = {
-    val conf = baseConfiguration.map(new Configuration(_)).getOrElse(new Configuration())
-
-    migratorConfig.savepoints.target.foreach {
-      case s3: SavepointsTarget.S3 =>
-        s3.region.foreach(conf.set("fs.s3a.endpoint.region", _))
-        s3.credentials.foreach { configuredCredentials =>
-          AwsUtils.computeFinalCredentials(Some(configuredCredentials), None, s3.region).foreach {
-            credentials =>
-              val credentialOptions =
-                Seq(
-                  "fs.s3a.access.key" -> credentials.accessKey,
-                  "fs.s3a.secret.key" -> credentials.secretKey
-                ) ++ credentials.maybeSessionToken.toSeq.map { sessionToken =>
-                  "fs.s3a.session.token" -> sessionToken
-                }
-
-              ensureHadoopKeysRedacted(credentialOptions.map(_._1))
-              credentialOptions.foreach { case (key, value) => conf.set(key, value) }
-              credentials.maybeSessionToken match {
-                case Some(_) =>
-                  conf.set("fs.s3a.aws.credentials.provider", S3ATemporaryCredentialsProvider)
-                case None =>
-                  conf.set("fs.s3a.aws.credentials.provider", S3ASimpleCredentialsProvider)
-                  conf.unset("fs.s3a.session.token")
-              }
-          }
-        }
-      case gcs: SavepointsTarget.GCS =>
-        gcs.projectId.foreach(conf.set("fs.gs.project.id", _))
-        gcs.credentials.foreach { credentials =>
-          ensureHadoopKeysRedacted(Seq("fs.gs.auth.service.account.json.keyfile"))
-          conf.set("fs.gs.auth.type", GcsServiceAccountJsonKeyfileAuthType)
-          conf.set(
-            "fs.gs.auth.service.account.json.keyfile",
-            credentials.serviceAccountJsonKeyfile
-          )
-        }
-      case _ => ()
-    }
-
-    conf
-  }
-
-  private def ensureHadoopKeysRedacted(keys: Iterable[String]): Unit =
-    SparkSecretRedaction.ensureKeysRedacted(
-      redactionRegex,
-      keys,
-      "savepoint Hadoop configuration"
-    )
 
   private def createSavepointsDirectory(): Unit = {
     val savepointsDirectory = savepointsPath
@@ -377,7 +324,12 @@ abstract class SavepointsManager(
       savepointFilename(savepointsPath)
 
     val modifiedConfig = updateConfigWithMigrationState()
-    val payload = modifiedConfig.render.getBytes(StandardCharsets.UTF_8)
+    // Persist a redacted copy: savepoint files live in long-lived object storage (GCS/S3) or on
+    // disk and must not leak source/target credentials in the clear. The skip-state fields
+    // (skipTokenRanges/skipSegments/skipParquetFiles) are not secrets and are preserved, so the
+    // startup auto-resume resolver can still recover progress; the live config supplies the real
+    // credentials on resume. See `SavepointsResume`.
+    val payload = modifiedConfig.renderRedacted.getBytes(StandardCharsets.UTF_8)
 
     pathIO.writeUtf8Atomically(finalPath, payload)
 
@@ -445,14 +397,6 @@ object SavepointsManager {
   // after the bounded wait, even if a scheduled dump is wedged on slow/unhealthy storage.
   private[migrator] val SignalDumpLockTimeoutMillis: Long = 5_000L
 
-  private val S3ASimpleCredentialsProvider =
-    "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
-
-  private val S3ATemporaryCredentialsProvider =
-    "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider"
-
-  private val GcsServiceAccountJsonKeyfileAuthType = "SERVICE_ACCOUNT_JSON_KEYFILE"
-
   // Sanity ceiling for values read from filenames during seed. Any field at or above this
   // threshold is treated as hostile / corrupted: ignoring it keeps a single planted file from
   // poisoning `lastSavepointMillis` / `savepointSequence` to within one increment of
@@ -469,4 +413,63 @@ object SavepointsManager {
   // writes.
   private[migrator] val SavepointName: scala.util.matching.Regex =
     """^savepoint_(\d+)(?:_(\d+))?\.yaml$""".r
+
+  /** Parse a savepoint filename into its chronological sort key `(millis, seq)`.
+    *
+    * Returns `None` for names that do not match the savepoint grammar, for numeric fields that
+    * overflow `Long`, and for hostile near-`Long.MAX_VALUE` values (see `MaxReasonableSeedValue`).
+    * Legacy single-component filenames (`savepoint_<epochSeconds>.yaml`) are scaled to millis with
+    * a `0` sequence so they order before the two-component files written within the same second.
+    *
+    * This mirrors the parsing in `seedStateFromExistingSavepoints` so that the startup auto-resume
+    * resolver picks exactly the same "newest" file that seeding accounts for.
+    */
+  private[migrator] def savepointSortKey(name: String): Option[(Long, Long)] =
+    name match {
+      case SavepointName(head, tailOrNull) =>
+        val millisOpt =
+          try
+            Some(
+              if (tailOrNull == null)
+                java.lang.Math.multiplyExact(java.lang.Long.parseLong(head), 1000L)
+              else java.lang.Long.parseLong(head)
+            )
+          catch {
+            case _: NumberFormatException | _: ArithmeticException => None
+          }
+        val seqOpt =
+          if (tailOrNull == null) Some(0L)
+          else
+            try Some(java.lang.Long.parseLong(tailOrNull))
+            catch { case _: NumberFormatException => None }
+        for {
+          millis <- millisOpt
+          seq    <- seqOpt
+          if millis < MaxReasonableSeedValue && seq < MaxReasonableSeedValue
+        } yield (millis, seq)
+      case _ => None
+    }
+
+  /** @return
+    *   the newest savepoint filename from `names` by `(millis, seq)` order, or `None` if none of
+    *   the names match the savepoint grammar.
+    */
+  private[migrator] def latestSavepointName(names: Iterable[String]): Option[String] =
+    savepointNamesNewestFirst(names).headOption
+
+  /** All savepoint names from `names` that match the grammar, ordered newest-first by
+    * `(millis, seq)`.
+    *
+    * Single source of truth for "newest savepoint" selection: the startup auto-resume resolver
+    * iterates this order to fall back to an older savepoint when the newest one cannot be read or
+    * parsed (corruption, an in-flight/partial object-store write), and `latestSavepointName` is
+    * just its head. Keeping one ordering here prevents the resolver from ever disagreeing with the
+    * seed logic about which file is newest.
+    */
+  private[migrator] def savepointNamesNewestFirst(names: Iterable[String]): Seq[String] =
+    names.iterator
+      .flatMap(name => savepointSortKey(name).map(key => key -> name))
+      .toSeq
+      .sortBy(_._1)(Ordering[(Long, Long)].reverse)
+      .map(_._2)
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/SavepointsResume.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/SavepointsResume.scala
@@ -1,0 +1,116 @@
+package com.scylladb.migrator
+
+import com.scylladb.migrator.config.MigratorConfig
+import org.apache.hadoop.conf.Configuration
+import org.apache.logging.log4j.LogManager
+
+import scala.util.control.NonFatal
+
+/** Startup auto-resume.
+  *
+  * Merges the skip-state of the most recent savepoint into the running configuration so that
+  * re-running the same configuration continues where the previous run left off, without the
+  * operator having to repoint the configuration at the latest savepoint file by hand.
+  *
+  * Only the skip-state fields (`skipTokenRanges`/`skipSegments`/`skipParquetFiles`) are taken from
+  * the savepoint. Every other setting - crucially the source/target credentials - comes from the
+  * live configuration, so this works even though savepoint files are written with secrets redacted
+  * (see `SavepointsManager.doDump`).
+  *
+  * Any failure to read or parse prior savepoints is non-fatal: the migration simply proceeds with
+  * the provided configuration rather than aborting.
+  */
+object SavepointsResume {
+  private val log = LogManager.getLogger(getClass)
+
+  def resume(
+    config: MigratorConfig,
+    baseHadoopConfiguration: Option[Configuration],
+    redactionRegex: Option[String]
+  ): MigratorConfig =
+    if (!config.source.supportsSavepoints || !config.savepoints.autoResume) config
+    else
+      try {
+        val hadoopConfiguration =
+          SavepointStorage.hadoopConfiguration(config, baseHadoopConfiguration, redactionRegex)
+        val storagePath = config.savepoints.storagePath
+        val pathIO = PathIO.forPath(storagePath, Some(hadoopConfiguration))
+
+        if (!pathIO.exists(storagePath)) {
+          log.info(
+            s"Auto-resume: savepoints location ${pathIO.normalize(storagePath)} does not exist " +
+              s"yet; starting from the provided configuration."
+          )
+          config
+        } else {
+          // Walk savepoints newest-first and resume from the first one that parses. A single
+          // corrupt or partially-written latest savepoint (e.g. an in-flight object-store write)
+          // must not discard older, still-recoverable progress, so per-file read/parse errors are
+          // logged and skipped rather than aborting the whole resume.
+          val firstValidSavepoint =
+            SavepointsManager
+              .savepointNamesNewestFirst(pathIO.listFileNames(storagePath))
+              .iterator
+              .flatMap { name =>
+                val candidatePath = s"${storagePath}/${name}"
+                try
+                  Some(candidatePath -> MigratorConfig.loadFrom(candidatePath, hadoopConfiguration))
+                catch {
+                  case NonFatal(e) =>
+                    log.warn(
+                      s"Auto-resume: skipping unreadable savepoint " +
+                        s"${pathIO.normalize(candidatePath)}; trying an older one.",
+                      e
+                    )
+                    None
+                }
+              }
+              .nextOption()
+
+          firstValidSavepoint match {
+            case None =>
+              log.info(
+                s"Auto-resume: no usable savepoint found in ${pathIO.normalize(storagePath)}; " +
+                  s"starting from the provided configuration."
+              )
+              config
+            case Some((latestPath, savepoint)) =>
+              val merged = mergeSkipState(config, savepoint)
+              log.info(
+                s"Auto-resume: merged skip-state from ${pathIO.normalize(latestPath)} " +
+                  s"(skipTokenRanges=${merged.skipTokenRanges.fold(0)(_.size)}, " +
+                  s"skipSegments=${merged.skipSegments.fold(0)(_.size)}, " +
+                  s"skipParquetFiles=${merged.skipParquetFiles.fold(0)(_.size)})."
+              )
+              merged
+          }
+        }
+      } catch {
+        case NonFatal(e) =>
+          log.warn(
+            s"Auto-resume: could not load prior savepoint state from " +
+              s"${config.savepoints.storagePath}; starting from the provided configuration.",
+            e
+          )
+          config
+      }
+
+  /** Union the skip-state of `savepoint` into `config`. A field stays `None` only when both sides
+    * are `None`, so a freshly merged config never spuriously gains an empty skip set.
+    */
+  private[migrator] def mergeSkipState(
+    config: MigratorConfig,
+    savepoint: MigratorConfig
+  ): MigratorConfig =
+    config.copy(
+      skipTokenRanges  = unionOption(config.skipTokenRanges, savepoint.skipTokenRanges),
+      skipSegments     = unionOption(config.skipSegments, savepoint.skipSegments),
+      skipParquetFiles = unionOption(config.skipParquetFiles, savepoint.skipParquetFiles)
+    )
+
+  private def unionOption[A](left: Option[Set[A]], right: Option[Set[A]]): Option[Set[A]] =
+    (left, right) match {
+      case (None, None) => None
+      case _            => Some(left.getOrElse(Set.empty) ++ right.getOrElse(Set.empty))
+    }
+}

--- a/migrator/src/main/scala/com/scylladb/migrator/config/Savepoints.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/Savepoints.scala
@@ -202,12 +202,19 @@ object SavepointsTarget {
   * @param target
   *   Optional typed savepoint destination. When omitted, the legacy `path` field is interpreted as
   *   a filesystem/Hadoop URI destination.
+  * @param autoResume
+  *   When `true` (the default), the migrator scans this savepoints location on startup and merges
+  *   the skip-state (`skipTokenRanges`/`skipSegments`/`skipParquetFiles`) of the most recent
+  *   savepoint into the running configuration, so re-running the same config resumes where the
+  *   previous run left off. Set to `false` to always start from the configuration as written (for
+  *   example, to force a full re-migration while reusing the same savepoints directory).
   */
 case class Savepoints(
   intervalSeconds: Int,
   path: String,
   enableParquetFileTracking: Boolean = true,
-  target: Option[SavepointsTarget] = None
+  target: Option[SavepointsTarget] = None,
+  autoResume: Boolean = true
 ) {
   def effectiveTarget: SavepointsTarget.StoragePathTarget =
     target match {
@@ -227,6 +234,7 @@ object Savepoints {
         intervalSeconds <- cursor.get[Int]("intervalSeconds")
         enableParquetFileTracking <-
           cursor.getOrElse[Boolean]("enableParquetFileTracking")(true)
+        autoResume  <- cursor.getOrElse[Boolean]("autoResume")(true)
         maybePath   <- cursor.get[Option[String]]("path")
         maybeTarget <- cursor.get[Option[SavepointsTarget]]("target")
         _ <- Either.cond(
@@ -257,7 +265,7 @@ object Savepoints {
                         )
                       )
                 }
-      } yield Savepoints(intervalSeconds, path, enableParquetFileTracking, maybeTarget)
+      } yield Savepoints(intervalSeconds, path, enableParquetFileTracking, maybeTarget, autoResume)
     }
 
   implicit val encoder: Encoder[Savepoints] =
@@ -268,11 +276,17 @@ object Savepoints {
           case None         => List("path" -> savepoints.path.asJson)
         }
 
+      // Only emit `autoResume` when it diverges from the default so that configurations that do
+      // not set it (the vast majority) round-trip byte-for-byte as before.
+      val autoResumeField =
+        if (savepoints.autoResume) Nil
+        else List("autoResume" -> savepoints.autoResume.asJson)
+
       Json.obj(
         (
           List("intervalSeconds" -> savepoints.intervalSeconds.asJson) ++ targetField ++ List(
             "enableParquetFileTracking" -> savepoints.enableParquetFileTracking.asJson
-          )
+          ) ++ autoResumeField
         ): _*
       )
     }

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointsResumeTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointsResumeTest.scala
@@ -1,0 +1,209 @@
+package com.scylladb.migrator
+
+import com.scylladb.migrator.config.{
+  Credentials,
+  MigratorConfig,
+  Savepoints,
+  SourceSettings,
+  TargetSettings
+}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Path }
+import scala.jdk.CollectionConverters._
+import scala.util.Using
+
+/** Unit tests for the startup auto-resume resolver ([[SavepointsResume]]) and for the secret
+  * redaction applied when savepoints are written. None of these require Spark or external services.
+  */
+class SavepointsResumeTest extends munit.FunSuite {
+
+  private def baseConfig(
+    savepointsPath: String,
+    targetCredentials: Option[Credentials] = None
+  ): MigratorConfig =
+    MigratorConfig(
+      source = SourceSettings.Parquet(
+        path        = "dummy",
+        credentials = None,
+        region      = None,
+        endpoint    = None
+      ),
+      target = TargetSettings.Scylla(
+        host                          = "localhost",
+        port                          = 9042,
+        localDC                       = None,
+        credentials                   = targetCredentials,
+        sslOptions                    = None,
+        keyspace                      = "ks",
+        table                         = "t",
+        connections                   = None,
+        stripTrailingZerosForDecimals = false,
+        writeTTLInS                   = None,
+        writeWritetimestampInuS       = None,
+        consistencyLevel              = "LOCAL_QUORUM"
+      ),
+      renames          = None,
+      savepoints       = Savepoints(intervalSeconds = 3600, path = savepointsPath),
+      skipTokenRanges  = None,
+      skipSegments     = None,
+      skipParquetFiles = None,
+      validation       = None
+    )
+
+  private def savepointFileName(millis: Long, seq: Long): String =
+    f"savepoint_${millis}%013d_${seq}%010d.yaml"
+
+  /** Render a savepoint with the given processed files under the standard filename. */
+  private def writeSavepoint(dir: Path, millis: Long, seq: Long, skip: Set[String]): Unit = {
+    val cfg = baseConfig(dir.toString).copy(skipParquetFiles = Some(skip))
+    Files.write(
+      dir.resolve(savepointFileName(millis, seq)),
+      cfg.renderRedacted.getBytes(StandardCharsets.UTF_8)
+    )
+  }
+
+  private def deleteRecursively(dir: Path): Unit =
+    if (Files.exists(dir))
+      Files.walk(dir).sorted(java.util.Comparator.reverseOrder()).forEach(Files.delete)
+
+  private def withTempDir(name: String)(f: Path => Unit): Unit = {
+    val dir = Files.createTempDirectory(name)
+    try f(dir)
+    finally deleteRecursively(dir)
+  }
+
+  test("resume merges skip-state from the latest savepoint into a fresh config") {
+    withTempDir("resume-merge") { dir =>
+      writeSavepoint(dir, millis = 1000L, seq = 1L, skip = Set("a.parquet"))
+      writeSavepoint(dir, millis = 1000L, seq = 2L, skip = Set("a.parquet", "b.parquet"))
+
+      val merged = SavepointsResume.resume(baseConfig(dir.toString), None, None)
+
+      assertEquals(merged.skipParquetFiles, Some(Set("a.parquet", "b.parquet")))
+    }
+  }
+
+  test("resume picks the newest savepoint by (millis, seq), not an older one") {
+    withTempDir("resume-newest") { dir =>
+      // Older file lists a file that must NOT leak into the result if the newest is chosen.
+      writeSavepoint(dir, millis = 5000L, seq = 1L, skip = Set("stale.parquet"))
+      writeSavepoint(
+        dir,
+        millis = 5000L,
+        seq    = 2L,
+        skip   = Set("fresh-1.parquet", "fresh-2.parquet")
+      )
+
+      val merged = SavepointsResume.resume(baseConfig(dir.toString), None, None)
+
+      assertEquals(merged.skipParquetFiles, Some(Set("fresh-1.parquet", "fresh-2.parquet")))
+    }
+  }
+
+  test("resume skips a corrupt newest savepoint and falls back to an older valid one") {
+    withTempDir("resume-corrupt") { dir =>
+      writeSavepoint(dir, millis = 7000L, seq = 1L, skip = Set("older-good.parquet"))
+      // Newest filename by (millis, seq), but contents do not decode to a MigratorConfig.
+      Files.write(
+        dir.resolve(savepointFileName(7000L, 2L)),
+        "definitely not a valid migrator config".getBytes(StandardCharsets.UTF_8)
+      )
+
+      val merged = SavepointsResume.resume(baseConfig(dir.toString), None, None)
+
+      assertEquals(merged.skipParquetFiles, Some(Set("older-good.parquet")))
+    }
+  }
+
+  test("resume unions the savepoint skip-state with any skip-state already in the config") {
+    withTempDir("resume-union") { dir =>
+      writeSavepoint(dir, millis = 2000L, seq = 1L, skip = Set("from-savepoint.parquet"))
+
+      val configWithExisting =
+        baseConfig(dir.toString).copy(skipParquetFiles = Some(Set("from-config.parquet")))
+      val merged = SavepointsResume.resume(configWithExisting, None, None)
+
+      assertEquals(
+        merged.skipParquetFiles,
+        Some(Set("from-config.parquet", "from-savepoint.parquet"))
+      )
+    }
+  }
+
+  test("resume preserves the live source and target (including credentials)") {
+    withTempDir("resume-preserve-creds") { dir =>
+      writeSavepoint(dir, millis = 3000L, seq = 1L, skip = Set("done.parquet"))
+
+      val liveConfig =
+        baseConfig(dir.toString, targetCredentials = Some(Credentials("migrator", "live-secret")))
+      val merged = SavepointsResume.resume(liveConfig, None, None)
+
+      assertEquals(merged.target, liveConfig.target)
+      assertEquals(merged.source, liveConfig.source)
+      assertEquals(merged.skipParquetFiles, Some(Set("done.parquet")))
+    }
+  }
+
+  test("resume is a no-op when autoResume is disabled") {
+    withTempDir("resume-disabled") { dir =>
+      writeSavepoint(dir, millis = 4000L, seq = 1L, skip = Set("ignored.parquet"))
+
+      val base = baseConfig(dir.toString)
+      val config = base.copy(savepoints = base.savepoints.copy(autoResume = false))
+      val merged = SavepointsResume.resume(config, None, None)
+
+      assertEquals(merged.skipParquetFiles, None)
+    }
+  }
+
+  test("resume is a no-op when the savepoints directory has no savepoints") {
+    withTempDir("resume-empty") { dir =>
+      val merged = SavepointsResume.resume(baseConfig(dir.toString), None, None)
+      assertEquals(merged.skipParquetFiles, None)
+    }
+  }
+
+  test("resume is a no-op when the savepoints directory does not exist") {
+    withTempDir("resume-missing") { dir =>
+      val missing = dir.resolve("does-not-exist")
+      val merged = SavepointsResume.resume(baseConfig(missing.toString), None, None)
+      assertEquals(merged.skipParquetFiles, None)
+    }
+  }
+
+  private class WritingManager(cfg: MigratorConfig, processed: Set[String])
+      extends SavepointsManager(cfg) {
+    override def describeMigrationState(): String = s"Processed: ${processed.size}"
+    override def updateConfigWithMigrationState(): MigratorConfig =
+      cfg.copy(skipParquetFiles = Some(processed))
+  }
+
+  test("written savepoints redact credentials but preserve skip-state") {
+    withTempDir("savepoint-redaction") { dir =>
+      val secret = "TOP-SECRET-PASSWORD-123"
+      val cfg =
+        baseConfig(dir.toString, targetCredentials = Some(Credentials("migrator", secret)))
+      val manager = new WritingManager(cfg, Set("file-a.parquet"))
+      try manager.dumpMigrationState("test")
+      finally manager.close()
+
+      val names =
+        Using.resource(Files.list(dir)) { stream =>
+          stream.iterator().asScala.map(_.getFileName.toString).toList
+        }
+      val savepointFile = SavepointsManager
+        .latestSavepointName(names)
+        .map(dir.resolve)
+        .getOrElse(fail("no savepoint file was written"))
+
+      val text = new String(Files.readAllBytes(savepointFile), StandardCharsets.UTF_8)
+      assert(!text.contains(secret), s"savepoint leaked the credential in cleartext:\n$text")
+      assert(text.contains("<redacted>"), s"savepoint did not redact the credential:\n$text")
+
+      // Skip-state must survive redaction so that auto-resume can recover it.
+      val parsed = MigratorConfig.loadFrom(savepointFile.toString)
+      assertEquals(parsed.skipParquetFiles, Some(Set("file-a.parquet")))
+    }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/SavepointsResumeTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SavepointsResumeTest.scala
@@ -65,7 +65,9 @@ class SavepointsResumeTest extends munit.FunSuite {
 
   private def deleteRecursively(dir: Path): Unit =
     if (Files.exists(dir))
-      Files.walk(dir).sorted(java.util.Comparator.reverseOrder()).forEach(Files.delete)
+      Using.resource(Files.walk(dir)) { stream =>
+        stream.sorted(java.util.Comparator.reverseOrder()).forEach(Files.delete)
+      }
 
   private def withTempDir(name: String)(f: Path => Unit): Unit = {
     val dir = Files.createTempDirectory(name)

--- a/tests/src/test/scala/com/scylladb/migrator/config/SavepointsAutoResumeTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/config/SavepointsAutoResumeTest.scala
@@ -1,0 +1,45 @@
+package com.scylladb.migrator.config
+
+import io.circe.syntax._
+import io.circe.yaml.parser
+import io.circe.yaml.syntax._
+
+class SavepointsAutoResumeTest extends munit.FunSuite {
+
+  private def decode(yaml: String): Savepoints =
+    parser
+      .parse(yaml)
+      .flatMap(_.as[Savepoints])
+      .fold(throw _, identity)
+
+  test("autoResume defaults to true when absent") {
+    val savepoints = decode("""intervalSeconds: 300
+                              |path: /tmp/savepoints
+                              |""".stripMargin)
+    assert(savepoints.autoResume)
+  }
+
+  test("autoResume can be disabled explicitly") {
+    val savepoints = decode("""intervalSeconds: 300
+                              |path: /tmp/savepoints
+                              |autoResume: false
+                              |""".stripMargin)
+    assert(!savepoints.autoResume)
+  }
+
+  test("autoResume is omitted from the rendered output when left at the default") {
+    val rendered = Savepoints(intervalSeconds = 300, path = "/tmp/savepoints").asJson.asYaml.spaces2
+    assert(
+      !rendered.contains("autoResume"),
+      s"default autoResume must not appear in the rendered savepoints block:\n$rendered"
+    )
+  }
+
+  test("autoResume is rendered when explicitly disabled and round-trips") {
+    val savepoints =
+      Savepoints(intervalSeconds = 300, path = "/tmp/savepoints", autoResume = false)
+    val rendered = savepoints.asJson.asYaml.spaces2
+    assert(rendered.contains("autoResume"), s"disabled autoResume must be rendered:\n$rendered")
+    assertEquals(decode(rendered).autoResume, false)
+  }
+}


### PR DESCRIPTION
This PR is to fix the reported issues:
1. The new job failed to pick up the savepoints written by the previous run even though they have essentially the same configuration with no changes that affect number of splits or source/destination.
2. The savepoint files contains credentials in the clear.

Fix 1: Startup auto-resume (load latest savepoint's skip-state)
Leverage the new rebase infra: MigratorConfig.loadFrom(path, hadoopConfiguration) already reads gs:///s3a:// via PathIO, and PathIO exposes listFileNames/readUtf8.

Fix 2: Stop persisting secrets in savepoints
- In doDump, write modifiedConfig.renderRedacted instead of render ([SavepointsManager.scala:380](https://github.com/scylladb/scylla-migrator/compare/master...kendrick-ren:scylla-migrator:fix/migrator/src/main/scala/com/scylladb/migrator/SavepointsManager.scala)) so secrets become <redacted>. Resume (Fix 1) ignores those fields and takes real secrets from the live config/env, so redaction is safe.
- Because redacted files can no longer be used directly as a resume config, auto-resume (Fix 1) becomes the supported path. Keep seeding and the filename grammar unchanged so old non-redacted savepoints remain selectable. Update the manual-resume integration tests that loadFrom a savepoint to instead rely on auto-resume (or supply secrets from the live config).

Tests
- Resume merge: latest savepoint with non-empty skipTokenRanges is merged into a fresh config; assert union and that newer savepoint wins; empty/missing dir is a no-op; malformed file is skipped.
- Selection: newest (millis, seq) chosen across legacy and new filenames (reuse SavepointName).
- Secret-free dump: assert written savepoint YAML contains no password/trustStorePassword values (only <redacted>), reusing patterns in SecurityHardeningTest / MySQLSourceSettingsParserTest.
- End-to-end-ish: round-trip a redacted savepoint through the resolver + live config and confirm working credentials + skip-state.
- Update existing manual-resume integration tests (ParquetGcsSavepointsIntegrationTest, ParquetResumeIntegrationTest, DynamoDBToS3ExportSavepointsTest, etc.) that loadFrom a savepoint file, since those files are now redacted.

Docs
Update [resume-interrupted-migration.rst](https://github.com/scylladb/scylla-migrator/compare/master...kendrick-ren:scylla-migrator:fix/docs/source/resume-interrupted-migration.rst): resume is now automatic from savepoints.path; savepoint files are redacted and must not be used as a standalone config; document savepoints.autoResume.