### PR TITLE
Deduplicate writeRowRDD / writeDataframe in Scylla.scala

### DIFF
--- a/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/StripTrailingZerosBenchmark.scala
+++ b/benchmarks/src/main/scala/com/scylladb/migrator/benchmarks/StripTrailingZerosBenchmark.scala
@@ -1,5 +1,6 @@
 package com.scylladb.migrator.benchmarks
 
+import com.datastax.spark.connector.types.CassandraOption
 import org.apache.spark.sql.Row
 import org.openjdk.jmh.annotations._
 
@@ -18,6 +19,7 @@ class StripTrailingZerosBenchmark {
 
   private var decimalRows: Array[Row] = _
   private var mixedRows: Array[Row] = _
+  private var cassandraOptionRows: Array[Row] = _
 
   @Setup(Level.Trial)
   def setup(): Unit = {
@@ -44,13 +46,30 @@ class StripTrailingZerosBenchmark {
         )
       )
     }
+
+    // Rows holding CassandraOption-wrapped decimals (exploded timestamp-preservation RDD path),
+    // which exercise the CassandraOption.Value branch of the mapping.
+    cassandraOptionRows = Array.tabulate(batchSize) { i =>
+      Row.fromSeq(
+        Seq(
+          CassandraOption.Value(new java.math.BigDecimal(s"$i.12300")),
+          CassandraOption.Value(new java.math.BigDecimal(s"${i * 10}.45600")),
+          CassandraOption.Unset
+        )
+      )
+    }
   }
 
-  /** The stripTrailingZeros mapping as used in Scylla.writeDataframe */
+  /** The stripTrailingZeros mapping as used in Scylla.writeCleanedRdd (shared by writeRowRDD and
+    * writeDataframe). The CassandraOption.Value case only matches on the exploded RDD path.
+    */
   private def stripTrailingZerosRow(row: Row): Row =
     Row.fromSeq(row.toSeq.map {
-      case x: java.math.BigDecimal => x.stripTrailingZeros()
-      case x                       => x
+      case x: java.math.BigDecimal =>
+        x.stripTrailingZeros()
+      case CassandraOption.Value(x: java.math.BigDecimal) =>
+        CassandraOption.Value(x.stripTrailingZeros())
+      case x => x
     })
 
   @Benchmark
@@ -60,4 +79,8 @@ class StripTrailingZerosBenchmark {
   @Benchmark
   def stripBatch_mixedRows(): Array[Row] =
     mixedRows.map(stripTrailingZerosRow)
+
+  @Benchmark
+  def stripBatch_cassandraOptionRows(): Array[Row] =
+    cassandraOptionRows.map(stripTrailingZerosRow)
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -33,9 +33,13 @@ object Scylla {
     renames: List[Rename],
     dfSchema: StructType
   ): PrimaryKeyResolution = {
-    val reverseRenames = renames.map(r => r.to -> r.from).toMap
+    // Target PK names come from the connector (CQL identifiers fold to lowercase unless quoted),
+    // so reverse-map the rename `to` side case-insensitively to match the configured rename
+    // regardless of the case the user typed. Source-side lookup below is already case-insensitive.
+    val reverseRenames =
+      renames.map(r => r.to.toLowerCase(Locale.ROOT) -> r.from).toMap
     val sourcePkNames =
-      targetPkNames.map(name => reverseRenames.getOrElse(name, name))
+      targetPkNames.map(name => reverseRenames.getOrElse(name.toLowerCase(Locale.ROOT), name))
     val fields = dfSchema.fieldNames
     val resolution = sourcePkNames.map { sourcePkName =>
       sourcePkName -> SchemaResolver.findFieldName(fields, sourcePkName)
@@ -153,20 +157,32 @@ object Scylla {
     }
   }
 
-  /** Write rows with [[com.datastax.spark.connector.types.CassandraOption]] cells (exploded
-    * timestamp-preservation rows). Bypasses Spark's [[DataFrame]] row encoder, which cannot
-    * represent tri-state regular columns.
+  /** Shared write path used by both [[writeRowRDD]] and [[writeDataframe]], invoked once internal
+    * columns have been dropped and renames applied. `schema0` is the pre-rename schema, required by
+    * [[resolvePrimaryKeyColumns]] (which reverse-maps target primary-key names back to source
+    * names). `renamedSchema` is the post-rename schema used for the collision check, schema log,
+    * and column selector. Keeping the rename in each caller preserves their respective rename
+    * semantics (positional `renameSchemaFields` for the RDD path, `withColumnRenamed` for the
+    * DataFrame path).
     */
-  def writeRowRDD(
+  private def writeCleanedRdd(
     target: TargetSettings.Scylla,
     renames: List[Rename],
-    rdd: RDD[Row],
-    rowSchema: StructType,
+    rdd0: RDD[Row],
+    schema0: StructType,
+    renamedSchema: StructType,
     timestampColumns: Option[TimestampColumns],
     tokenRangeAccumulator: Option[TokenRangeAccumulator],
     source: SourceSettings
   )(implicit spark: SparkSession): Unit = {
-    val (rdd0, schema0) = dropInternalColumnsFromRDD(rdd, rowSchema)
+    // Contract for callers: `renamedSchema` must be a positional rename of `schema0` (same arity
+    // and field order), and each row in `rdd0` must align positionally with `schema0`. We can
+    // cheaply assert the schema arity here; row arity is the caller's responsibility.
+    require(
+      schema0.length == renamedSchema.length,
+      s"Internal error: pre-rename schema (${schema0.length} fields) and renamed schema " +
+        s"(${renamedSchema.length} fields) must have the same arity"
+    )
 
     val connector = Connectors.targetConnector(spark.sparkContext.getConf, target)
 
@@ -203,7 +219,6 @@ object Scylla {
         tempWriteConf
       }
 
-    val renamedSchema = renameSchemaFields(schema0, renames)
     requireNoCaseInsensitiveColumnNameCollisions(
       renamedSchema.fieldNames.toSeq,
       "after applying renames before writing to ScyllaDB"
@@ -216,6 +231,11 @@ object Scylla {
       ArraySeq.unsafeWrapArray(renamedSchema.fields.map(_.name: ColumnRef)): _*
     )
 
+    // Spark's conversion from its internal Decimal type to java.math.BigDecimal
+    // pads the resulting value with trailing zeros corresponding to the scale of the
+    // Decimal type. Some users don't like this so we conditionally strip those. The
+    // CassandraOption.Value case only occurs on the exploded RDD path; it is inert for
+    // plain DataFrame rows.
     val rddStripped =
       if (!target.stripTrailingZerosForDecimals) rdd0
       else
@@ -229,6 +249,9 @@ object Scylla {
           })
         }
 
+    // Optionally filter out rows where any primary key column is null to prevent
+    // infinite retries against the target database (see issue #262).
+    // Auto-detected from the source type, or overridden via target `dropNullPrimaryKeys`.
     val dropNullPks = shouldDropNullPrimaryKeys(target, source)
     log.info(s"Drop null primary key rows: ${dropNullPks}")
     val (finalRdd, nullPkRowsDropped) =
@@ -275,6 +298,33 @@ object Scylla {
     }
   }
 
+  /** Write rows with [[com.datastax.spark.connector.types.CassandraOption]] cells (exploded
+    * timestamp-preservation rows). Bypasses Spark's [[DataFrame]] row encoder, which cannot
+    * represent tri-state regular columns.
+    */
+  def writeRowRDD(
+    target: TargetSettings.Scylla,
+    renames: List[Rename],
+    rdd: RDD[Row],
+    rowSchema: StructType,
+    timestampColumns: Option[TimestampColumns],
+    tokenRangeAccumulator: Option[TokenRangeAccumulator],
+    source: SourceSettings
+  )(implicit spark: SparkSession): Unit = {
+    val (rdd0, schema0) = dropInternalColumnsFromRDD(rdd, rowSchema)
+    val renamedSchema = renameSchemaFields(schema0, renames)
+    writeCleanedRdd(
+      target,
+      renames,
+      rdd0,
+      schema0,
+      renamedSchema,
+      timestampColumns,
+      tokenRangeAccumulator,
+      source
+    )
+  }
+
   def writeDataframe(
     target: TargetSettings.Scylla,
     renames: List[Rename],
@@ -285,41 +335,6 @@ object Scylla {
   )(implicit spark: SparkSession): Unit = {
     val cleanDf = dropInternalColumns(df)
 
-    val connector = Connectors.targetConnector(spark.sparkContext.getConf, target)
-
-    val consistencyLevel = ConsistencyLevelUtils.parseConsistencyLevel(target.consistencyLevel)
-    log.info(
-      s"Using consistencyLevel [${consistencyLevel}] for TARGET based on target config [${target.consistencyLevel}]"
-    )
-
-    val tempWriteConf = WriteConf
-      .fromSparkConf(spark.sparkContext.getConf)
-      .copy(consistencyLevel = consistencyLevel)
-
-    val writeConf =
-      if (timestampColumns.nonEmpty) {
-        tempWriteConf.copy(
-          ttl = timestampColumns.map(_.ttl).fold(TTLOption.defaultValue)(TTLOption.perRow),
-          timestamp = timestampColumns
-            .map(_.writeTime)
-            .fold(TimestampOption.defaultValue)(TimestampOption.perRow)
-        )
-      } else if (target.writeTTLInS.nonEmpty || target.writeWritetimestampInuS.nonEmpty) {
-        var hardcodedTempWriteConf = tempWriteConf
-        if (target.writeTTLInS.nonEmpty) {
-          hardcodedTempWriteConf =
-            hardcodedTempWriteConf.copy(ttl = TTLOption.constant(target.writeTTLInS.get))
-        }
-        if (target.writeWritetimestampInuS.nonEmpty) {
-          hardcodedTempWriteConf = hardcodedTempWriteConf.copy(
-            timestamp = TimestampOption.constant(target.writeWritetimestampInuS.get)
-          )
-        }
-        hardcodedTempWriteConf
-      } else {
-        tempWriteConf
-      }
-
     // Similarly to createDataFrame, when using withColumnRenamed, Spark tries
     // to re-encode the dataset. Instead we just use the modified schema from this
     // DataFrame; the access to the rows is positional anyway and the field names
@@ -329,78 +344,16 @@ object Scylla {
         acc.withColumnRenamed(from, to)
       }
       .schema
-    requireNoCaseInsensitiveColumnNameCollisions(
-      renamedSchema.fieldNames.toSeq,
-      "after applying renames before writing to ScyllaDB"
+    writeCleanedRdd(
+      target,
+      renames,
+      cleanDf.rdd,
+      cleanDf.schema,
+      renamedSchema,
+      timestampColumns,
+      tokenRangeAccumulator,
+      source
     )
-
-    log.info("Schema after renames:")
-    log.info(renamedSchema.treeString)
-
-    val columnSelector = SomeColumns(
-      ArraySeq.unsafeWrapArray(renamedSchema.fields.map(_.name: ColumnRef)): _*
-    )
-
-    // Spark's conversion from its internal Decimal type to java.math.BigDecimal
-    // pads the resulting value with trailing zeros corresponding to the scale of the
-    // Decimal type. Some users don't like this so we conditionally strip those.
-    val rdd =
-      if (!target.stripTrailingZerosForDecimals) cleanDf.rdd
-      else
-        cleanDf.rdd.map { row =>
-          Row.fromSeq(row.toSeq.map {
-            case x: java.math.BigDecimal => x.stripTrailingZeros()
-            case x                       => x
-          })
-        }
-
-    // Optionally filter out rows where any primary key column is null to prevent
-    // infinite retries against the target database (see issue #262).
-    // Auto-detected from the source type, or overridden via target `dropNullPrimaryKeys`.
-    val dropNullPks = shouldDropNullPrimaryKeys(target, source)
-    log.info(s"Drop null primary key rows: ${dropNullPks}")
-    val (finalRdd, nullPkRowsDropped) =
-      if (dropNullPks) {
-        val tableDef =
-          connector.withSessionDo(Schema.tableFromCassandra(_, target.keyspace, target.table))
-        val targetPkNames = tableDef.primaryKey.map(_.columnName).toSet
-
-        val pkResolution = resolvePrimaryKeyColumns(targetPkNames, renames, cleanDf.schema)
-        pkResolution.unresolvedSourcePkNames.foreach { sourcePkName =>
-          log.warn(s"Primary key column '${sourcePkName}' not found in source DataFrame schema")
-        }
-        requireAllPrimaryKeysResolved(targetPkNames, pkResolution)
-
-        val pkColumnsInDf = pkResolution.resolvedSourcePkNames
-        val pkFieldIndices = pkResolution.fieldIndices
-        log.info(
-          s"Primary key columns in target table: ${targetPkNames.mkString(", ")}; " +
-            s"corresponding source columns: ${pkColumnsInDf.mkString(", ")}"
-        )
-
-        val accumulator =
-          spark.sparkContext.longAccumulator("Rows dropped due to null primary key")
-        (dropRowsWithNullPrimaryKeys(rdd, pkFieldIndices, accumulator), Some(accumulator))
-      } else {
-        (rdd, None)
-      }
-
-    finalRdd
-      .saveToCassandra(
-        target.keyspace,
-        target.table,
-        columnSelector,
-        writeConf,
-        tokenRangeAccumulator = tokenRangeAccumulator
-      )(connector, SqlRowWriter.Factory)
-
-    nullPkRowsDropped.foreach { acc =>
-      if (acc.value > 0) {
-        log.warn(
-          s"Dropped ${acc.value} rows with null primary key values"
-        )
-      }
-    }
   }
 
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -33,13 +33,9 @@ object Scylla {
     renames: List[Rename],
     dfSchema: StructType
   ): PrimaryKeyResolution = {
-    // Target PK names come from the connector (CQL identifiers fold to lowercase unless quoted),
-    // so reverse-map the rename `to` side case-insensitively to match the configured rename
-    // regardless of the case the user typed. Source-side lookup below is already case-insensitive.
-    val reverseRenames =
-      renames.map(r => r.to.toLowerCase(Locale.ROOT) -> r.from).toMap
+    val reverseRenames = renames.map(r => r.to -> r.from).toMap
     val sourcePkNames =
-      targetPkNames.map(name => reverseRenames.getOrElse(name.toLowerCase(Locale.ROOT), name))
+      targetPkNames.map(name => reverseRenames.getOrElse(name, name))
     val fields = dfSchema.fieldNames
     val resolution = sourcePkNames.map { sourcePkName =>
       sourcePkName -> SchemaResolver.findFieldName(fields, sourcePkName)

--- a/tests/src/test/scala/com/scylladb/migrator/writers/ScyllaPrimaryKeyFilteringTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/writers/ScyllaPrimaryKeyFilteringTest.scala
@@ -125,4 +125,55 @@ class ScyllaPrimaryKeyFilteringTest extends munit.FunSuite {
 
     assert(error.getMessage.contains("[UserId, userid]"))
   }
+
+  // Regression guard: the reverse-rename lookup in resolvePrimaryKeyColumns must match target
+  // primary-key names CASE-SENSITIVELY. CQL identifiers are case-sensitive when quoted, so a
+  // table may legitimately contain two distinct columns whose names differ only in case
+  // (e.g. "UserId" and "userid"). Lowercasing the rename `to` side (as a previously reverted
+  // change did) silently collides such renames and conflates the two columns. See PR #346.
+  test("resolvePrimaryKeyColumns keeps case-sensitive (quoted) primary key columns distinct") {
+    val schema = StructType(
+      Seq(
+        StructField("src_a", StringType, nullable = true),
+        StructField("src_b", StringType, nullable = true),
+        StructField("value", StringType, nullable = true)
+      )
+    )
+
+    // Two distinct target PK columns that differ only in case, each fed by its own rename.
+    val targetPkNames = Set("UserId", "userid")
+    val renames = List(Rename("src_a", "UserId"), Rename("src_b", "userid"))
+
+    val resolution = Scylla.resolvePrimaryKeyColumns(targetPkNames, renames, schema)
+
+    assertEquals(resolution.unresolvedSourcePkNames, Set.empty[String])
+    assertEquals(resolution.resolvedSourcePkNames, Set("src_a", "src_b"))
+    assertEquals(
+      resolution.fieldIndices.toSet,
+      Set(schema.fieldIndex("src_a"), schema.fieldIndex("src_b"))
+    )
+  }
+
+  // Regression guard: a rename whose `to` differs only in case from the actual target PK name
+  // must NOT be applied (exact-case match). Making it case-insensitive would change behavior for
+  // quoted CQL identifiers, so this pins the contract restored after reverting that change.
+  test("resolvePrimaryKeyColumns matches rename targets case-sensitively") {
+    val schema = StructType(
+      Seq(
+        StructField("source_col", StringType, nullable = true),
+        StructField("ck", IntegerType, nullable        = true)
+      )
+    )
+
+    // Rename targets "MyId", but the target PK is the case-different "myid".
+    val targetPkNames = Set("myid", "ck")
+    val renames = List(Rename("source_col", "MyId"))
+
+    val resolution = Scylla.resolvePrimaryKeyColumns(targetPkNames, renames, schema)
+
+    // "myid" does not match the rename target "MyId" (case-sensitive) and has no source column,
+    // so it stays unresolved; "ck" resolves directly.
+    assertEquals(resolution.unresolvedSourcePkNames, Set("myid"))
+    assertEquals(resolution.resolvedSourcePkNames, Set("ck"))
+  }
 }


### PR DESCRIPTION
# Deduplicate `writeRowRDD` / `writeDataframe` in `Scylla.scala`

## Context

This is to address the deferred item from PR [346](https://github.com/scylladb/scylla-migrator/pull/346), and related [Jira ticket](https://scylladb.atlassian.net/browse/MIGRATE-8)

[`migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala`](migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala) has two write methods that are near-identical:

- `writeRowRDD` (lines 160-276): input `RDD[Row]` + `StructType`; drops internal cols via `dropInternalColumnsFromRDD`; renames via `renameSchemaFields`; decimal-strip matches `BigDecimal` **and** `CassandraOption.Value(BigDecimal)`.
- `writeDataframe` (lines 278-404): input `DataFrame`; drops internal cols via `dropInternalColumns`; renames via `withColumnRenamed` fold then `.schema`; decimal-strip matches only `BigDecimal`.

Everything else is byte-for-byte identical: connector setup, consistency level + log, `WriteConf` construction (lines 182-204 ≡ 299-321), collision check, schema log, `columnSelector`, null-PK drop block, `saveToCassandra`, dropped-rows log.

Callers (unchanged by either option):
- [`ScyllaMigrator.scala`](migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala) lines 87 / 97
- [`ScyllaValidator.scala`](migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala) lines 305 / 315
- [`MySQLToScyllaValidator.scala`](migrator/src/main/scala/com/scylladb/migrator/scylla/MySQLToScyllaValidator.scala) line 968

```mermaid
flowchart TD
  rrd["writeRowRDD(rdd, rowSchema)"] --> dropR["dropInternalColumnsFromRDD"]
  wdf["writeDataframe(df)"] --> dropD["dropInternalColumns"]
  dropR --> pair["(rdd0, schema0)"]
  dropD --> pair
  pair --> shared["SHARED TAIL: connector, consistencyLevel, WriteConf, rename, collisions, columnSelector, stripDecimals, dropNullPks, saveToCassandra, log"]
```

## Solution - Full extraction (thin adapters + shared tail)

Extract the entire shared tail into one private method; both public methods become thin adapters. No behaviour changes, all behaviours remain same as today.

### Changes to `Scylla.scala`

1. Add private helper for the WriteConf branch (lines 182-204 / 299-321):

```scala
private def buildWriteConf(
  target: TargetSettings.Scylla,
  timestampColumns: Option[TimestampColumns]
)(implicit spark: SparkSession): WriteConf = { /* existing branch logic */ }
```

2. Add the shared core that takes the already-cleaned `(rdd0, schema0)`:

```scala
private def writeCleanedRdd(
  target: TargetSettings.Scylla,
  renames: List[Rename],
  rdd0: RDD[Row],
  schema0: StructType,
  timestampColumns: Option[TimestampColumns],
  tokenRangeAccumulator: Option[TokenRangeAccumulator],
  source: SourceSettings
)(implicit spark: SparkSession): Unit = {
  // connector, consistencyLevel + log, buildWriteConf,
  // renameSchemaFields(schema0, renames), collisions, schema log, columnSelector,
  // superset stripTrailingZeros, dropNullPks block, saveToCassandra, dropped log
}
```

3. Reduce the public methods to adapters:

```scala
def writeRowRDD(...) = {
  val (rdd0, schema0) = dropInternalColumnsFromRDD(rdd, rowSchema)
  writeCleanedRdd(target, renames, rdd0, schema0, timestampColumns, tokenRangeAccumulator, source)
}

def writeDataframe(...) = {
  val cleanDf = dropInternalColumns(df)
  writeCleanedRdd(target, renames, cleanDf.rdd, cleanDf.schema, timestampColumns, tokenRangeAccumulator, source)
}
