### PR TITLE
Preserve ttl frozen collections

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,6 +122,52 @@ jobs:
             tests/target/scala-2.13/scoverage-report/
             migrator/target/scala-2.13/scoverage-report/
 
+  test-integration-scylla2026:
+    name: Integration tests (Scylla 2026.2 collection timestamps)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+      - uses: sbt/setup-sbt@af116cce31c00823d3903ce687f9cda3a4f19f1b # v1.2.1
+      - name: Cache SBT compilation artifacts
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            target/
+            migrator/target/scala-2.13/classes/
+            tests/target/scala-2.13/classes/
+            spark-kinesis-dynamodb/target/scala-2.13/classes/
+            project/target/
+          key: sbt-target-${{ runner.os }}-${{ hashFiles('**/*.scala', '**/*.sbt', 'project/build.properties') }}
+          restore-keys: |
+            sbt-target-${{ runner.os }}-
+      - name: Start services
+        run: make start-services-scylla2026
+      - name: Wait for services
+        run: make wait-for-services-scylla2026
+      - name: Dump container logs on failure
+        if: failure()
+        run: make dump-logs-scylla2026
+      - name: Run Scylla 2026.2 collection-timestamp tests
+        run: make test-integration-scylla2026
+        env:
+          COVERAGE: ${{ github.event_name == 'push' && 'true' || 'false' }}
+      - name: Stop services
+        if: always()
+        run: make stop-services-scylla2026
+      - name: Upload coverage report
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-report-scylla2026
+          path: |
+            tests/target/scala-2.13/scoverage-report/
+            migrator/target/scala-2.13/scoverage-report/
+
   test-integration-dynamodb:
     name: Integration tests (DynamoDB ${{ matrix.name }})
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@ SHELL := bash
         spark-image start-services stop-services wait-for-services \
         start-services-scylla wait-for-services-scylla \
         start-services-scylla-gcs wait-for-services-scylla-gcs \
+        start-services-scylla2026 wait-for-services-scylla2026 stop-services-scylla2026 dump-logs-scylla2026 \
         start-services-cassandra wait-for-services-cassandra test-integration-cassandra \
         start-services-alternator wait-for-services-alternator \
-        test test-unit test-integration test-integration-scylla \
+        test test-unit test-integration test-integration-scylla test-integration-scylla2026 \
         test-integration-alternator \
         test-integration-aws \
         test-benchmark test-benchmark-jmh test-benchmark-jmh-quick \
@@ -163,6 +164,18 @@ start-services-scylla-gcs: ## Start services needed for Scylla integration tests
 	$(Q)sudo chmod -R 777 $(DOCKER_SPARK_BIND_DIRS) $(DOCKER_GCS_BIND_DIRS) ./tests/docker/scylla ./tests/docker/scylla-source
 	docker compose $(COMPOSE_SCYLLA_FILES) up -d mysql cassandra scylla-source scylla gcs
 
+start-services-scylla2026: ## Start the pinned ScyllaDB 2026.2 service for collection-timestamp tests
+	docker compose -f $(COMPOSE_FILE) up -d scylla2026
+
+wait-for-services-scylla2026: ## Wait for the ScyllaDB 2026.2 service to become ready
+	$(Q)$(call wait-for-cql,scylla2026)
+
+stop-services-scylla2026: ## Stop the ScyllaDB 2026.2 service
+	$(Q)docker compose -f $(COMPOSE_FILE) rm -sf scylla2026
+
+dump-logs-scylla2026: ## Dump the ScyllaDB 2026.2 service logs
+	$(Q)docker compose -f $(COMPOSE_FILE) logs --tail=100 scylla2026 2>&1 || true
+
 start-services-dynamodb: ## Start services for DynamoDB integration tests (SCYLLA_VERSION=..., TABLETS_MODE=...)
 	$(Q)mkdir -p $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla
 	$(Q)sudo chmod -R 777 $(DOCKER_SPARK_BIND_DIRS) ./tests/docker/scylla
@@ -272,8 +285,11 @@ test-unit: ## Run unit tests (no services required)
 test-integration: ## Run integration tests (requires services, excludes AWS, benchmarks, and E2E)
 	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.AWS,com.scylladb.migrator.E2E" $(SBT_COVERAGE_SUFFIX)
 
-test-integration-scylla: ## Run Scylla and reader integration tests (Cassandra compat tests run in their own matrix job)
-	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.scylla.* com.scylladb.migrator.readers.* -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.E2E,com.scylladb.migrator.CassandraCompat" $(SBT_COVERAGE_SUFFIX)
+test-integration-scylla: ## Run Scylla and reader integration tests (Cassandra/Scylla2026 compat tests run in their own jobs)
+	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.scylla.* com.scylladb.migrator.readers.* -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.E2E,com.scylladb.migrator.CassandraCompat,com.scylladb.migrator.Scylla2026Compat" $(SBT_COVERAGE_SUFFIX)
+
+test-integration-scylla2026: ## Run ScyllaDB 2026.2+ collection-timestamp integration tests (requires the scylla2026 service)
+	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.scylla.Scylla2026* -- --include-categories=com.scylladb.migrator.Scylla2026Compat --exclude-categories=com.scylladb.migrator.E2E" $(SBT_COVERAGE_SUFFIX)
 
 test-integration-dynamodb: ## Run DynamoDB/Alternator integration tests (excludes AWS and E2E)
 	$(Q)sbt $(SBT_COVERAGE_PREFIX) "testOnly com.scylladb.migrator.alternator.* com.scylladb.migrator.writers.* -- --include-categories=com.scylladb.migrator.Integration --exclude-categories=com.scylladb.migrator.AWS,com.scylladb.migrator.E2E" $(SBT_COVERAGE_SUFFIX)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -30,9 +30,19 @@ source:
   # Connector driver default is LOCAL_ONE. Our recommendation is LOCAL_QUORUM.
   # If using ONE or LOCAL_ONE, ensure the source system is fully repaired.
   consistencyLevel: LOCAL_QUORUM
-  # Preserve TTLs and WRITETIMEs of cells in the source database. Note that this
-  # option is *incompatible* when copying tables with collections (lists, maps, sets).
+  # Preserve TTLs and WRITETIMEs of cells in the source database. Frozen collections
+  # (frozen<list/map/set>) are stored as a single cell and ARE supported. By default this
+  # option is *incompatible* with non-frozen (multi-cell) collections (lists, maps, sets),
+  # whose elements each carry their own TTL/WRITETIME (see preserveCollectionTimestamps).
   preserveTimestamps: true
+  # Opt-in: also preserve the per-element TTL/WRITETIME of non-frozen (multi-cell) collection
+  # columns. When enabled, each element's original TTL/WRITETIME is re-applied via collection
+  # appends after the base row write. Requires a source that can read collection-element metadata
+  # (Cassandra 5.0+ / modern ScyllaDB). Supported for non-frozen sets and maps whose element/key
+  # type has a well-defined order (text/ascii/varchar and integer types); non-frozen lists and
+  # other key/element types remain unsupported (freeze them, or leave this disabled). Has no effect
+  # unless preserveTimestamps is also true. Defaults to false.
+  preserveCollectionTimestamps: false
   # Number of splits to use - this should be at minimum the amount of cores
   # available in the Spark cluster, and optimally more; higher splits will lead
   # to more fine-grained resumes. Aim for 8 * (Spark cores).

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -37,8 +37,9 @@ source:
   preserveTimestamps: true
   # Opt-in: also preserve the per-element TTL/WRITETIME of non-frozen (multi-cell) collection
   # columns. When enabled, each element's original TTL/WRITETIME is re-applied via collection
-  # appends after the base row write. Requires a source that can read collection-element metadata
-  # (Cassandra 5.0+ / modern ScyllaDB). Supported for non-frozen sets and maps whose element/key
+  # appends after the base row write. Requires a source that can read collection-element metadata:
+  # Cassandra 5.0+ (via WRITETIME(col)/TTL(col)) or ScyllaDB 2026.2+ (via the per-element subscript
+  # form WRITETIME(col[key])/TTL(col[key]), auto-detected). Supported for non-frozen sets and maps whose element/key
   # type has a well-defined order (text/ascii/varchar and integer types); non-frozen lists and
   # other key/element types remain unsupported (freeze them, or leave this disabled).
   # Because elements are restored with collection appends (col = col + ?), this only converges

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -48,6 +48,18 @@ source:
   # on the source or pre-existing on the target are not reconciled. Very large non-frozen
   # collections are expanded into up to one update per distinct element TTL/WRITETIME, which can be
   # memory- and throughput-intensive. Has no effect unless preserveTimestamps is also true.
+  #
+  # Source-quiescence is REQUIRED. On the ScyllaDB 2026.2+ subscript path values and metadata are read
+  # in two phases (base scan + per-row point reads): a concurrent update can pair a stale value with a
+  # fresh writetime, and an element deleted between the reads is dropped (logged) rather than aborting.
+  # The Cassandra 5.0+ array path reads both in one scan. Stop source writes before migrating.
+  #
+  # TTLs are read as remaining seconds and re-applied on write, so the clock advances between read and
+  # write/compare on long runs; use validation's ttlToleranceMillis to absorb this drift.
+  #
+  # Validation compares per-element collection TTL/WRITETIME only on the collection-wide form
+  # (Cassandra 5.0+). Against ScyllaDB 2026.2+ (subscript only) it compares non-frozen collection
+  # columns by VALUE only, and copyMissingRows for such tables is rejected (re-run the migration).
   # Defaults to false.
   preserveCollectionTimestamps: false
   # Number of splits to use - this should be at minimum the amount of cores

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -40,8 +40,14 @@ source:
   # appends after the base row write. Requires a source that can read collection-element metadata
   # (Cassandra 5.0+ / modern ScyllaDB). Supported for non-frozen sets and maps whose element/key
   # type has a well-defined order (text/ascii/varchar and integer types); non-frozen lists and
-  # other key/element types remain unsupported (freeze them, or leave this disabled). Has no effect
-  # unless preserveTimestamps is also true. Defaults to false.
+  # other key/element types remain unsupported (freeze them, or leave this disabled).
+  # Because elements are restored with collection appends (col = col + ?), this only converges
+  # correctly when the target collection starts empty (a fresh migration into an empty/nonexistent
+  # target) and the source is not concurrently modified: appends never delete, so elements deleted
+  # on the source or pre-existing on the target are not reconciled. Very large non-frozen
+  # collections are expanded into up to one update per distinct element TTL/WRITETIME, which can be
+  # memory- and throughput-intensive. Has no effect unless preserveTimestamps is also true.
+  # Defaults to false.
   preserveCollectionTimestamps: false
   # Number of splits to use - this should be at minimum the amount of cores
   # available in the Spark cluster, and optimally more; higher splits will lead

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -50,12 +50,17 @@ source:
   # memory- and throughput-intensive. Has no effect unless preserveTimestamps is also true.
   #
   # Source-quiescence is REQUIRED. On the ScyllaDB 2026.2+ subscript path values and metadata are read
-  # in two phases (base scan + per-row point reads): a concurrent update can pair a stale value with a
-  # fresh writetime, and an element deleted between the reads is dropped (logged) rather than aborting.
-  # The Cassandra 5.0+ array path reads both in one scan. Stop source writes before migrating.
+  # in two phases (base scan + per-row point reads), so a concurrent write in between can: delete an
+  # element (dropped + logged), add an element (never queried, silently absent, not counted in the
+  # dropped-element warning), or update a MAP value in place (a stale value can be paired with the
+  # newer writetime and then permanently shadow the correct value on the target). Sets are immune to
+  # the last case since an element's value is its identity. The Cassandra 5.0+ array path reads values
+  # and metadata in one scan and is unaffected. Stop source writes before migrating.
   #
   # TTLs are read as remaining seconds and re-applied on write, so the clock advances between read and
-  # write/compare on long runs; use validation's ttlToleranceMillis to absorb this drift.
+  # write/compare on long runs; use validation's ttlToleranceMillis to absorb this drift. A short-lived
+  # element can expire on the source between read and append and still be written to the target, where
+  # it briefly reappears; prefer collection TTLs comfortably longer than the job duration.
   #
   # Validation compares per-element collection TTL/WRITETIME only on the collection-wide form
   # (Cassandra 5.0+). Against ScyllaDB 2026.2+ (subscript only) it compares non-frozen collection

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -97,6 +97,22 @@ services:
       --alternator-port 8000
       --alternator-write-isolation only_rmw_uses_lwt
 
+  # Pinned to 2026.2: the first ScyllaDB release that can read back per-element non-frozen
+  # collection WRITETIME()/TTL() (via the subscript form WRITETIME(col[key])). Used only by the
+  # Scylla-source collection-timestamp integration test; NOT the shared scylla/scylla-source
+  # services (which follow SCYLLA_VERSION and may be older, and use SimpleStrategy fixtures that
+  # 2026.2 rejects). Kept on a dedicated host port so it can run independently.
+  scylla2026:
+    image: scylladb/scylla:2026.2
+    ports:
+      - "9048:9042"
+    expose:
+      - 9048
+    command: >
+      --smp 1
+      --developer-mode 1
+      --overprovisioned 1
+
   s3:
     image: localstack/localstack:s3-community-archive
     ports:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -107,14 +107,21 @@ A source of type ``cassandra`` can be used together with a target of type ``cass
     # be memory- and throughput-intensive. Has no effect unless preserveTimestamps is also true.
     #
     # Source-quiescence is REQUIRED. On the ScyllaDB 2026.2+ subscript path, element values and their
-    # metadata are read in two phases (a base scan then per-row point reads); a concurrent update can
-    # yield a stale value with a fresh writetime, and an element deleted between the two reads is
-    # dropped (logged) rather than aborting the run. On the Cassandra 5.0+ array path both are read in
-    # one scan. Either way, stop writes to the source before migrating.
+    # metadata are read in two phases (a base scan then per-row point reads), so a concurrent write in
+    # between can: (a) delete an element -> it is dropped from the migrated row and logged; (b) add an
+    # element -> it is never queried and is silently absent (it is not in the base scan, so it is not
+    # counted in the dropped-element warning); (c) update a MAP value in place -> the older value can
+    # be paired with the newer writetime, which then permanently shadows the correct value on the
+    # target. Sets are immune to (c) because an element's value IS its identity. On the Cassandra 5.0+
+    # array path values and metadata come from one scan, so none of these apply. Stop writes to the
+    # source before migrating.
     #
     # TTL note: TTLs are read as remaining seconds and re-applied on write, so long-running migrations
     # (and validation) see the clock advance between read and write/compare; use validation's
-    # ttlToleranceMillis to absorb this drift.
+    # ttlToleranceMillis to absorb this drift. A short-lived element can even expire on the source
+    # between the read and the append, in which case it is still written to the target with its
+    # remaining-TTL-at-read-time and briefly reappears there. Prefer migrating tables whose collection
+    # TTLs are comfortably longer than the expected job duration.
     #
     # Validation: per-element collection TTL/WRITETIME are compared only when the endpoints accept the
     # collection-wide WRITETIME(col)/TTL(col) form (Cassandra 5.0+). Against ScyllaDB 2026.2+ (subscript

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -94,8 +94,9 @@ A source of type ``cassandra`` can be used together with a target of type ``cass
     preserveTimestamps: true
     # Opt-in: also preserve the per-element TTL/WRITETIME of non-frozen (multi-cell) collection
     # columns. Each element's original TTL/WRITETIME is re-applied via collection appends after the
-    # base row write. Requires a source that can read collection-element metadata (Cassandra 5.0+ /
-    # modern ScyllaDB). Supported for non-frozen sets and maps whose element/key type has a
+    # base row write. Requires a source that can read collection-element metadata: Cassandra 5.0+
+    # (WRITETIME(col)/TTL(col)) or ScyllaDB 2026.2+ (per-element subscript WRITETIME(col[key]),
+    # auto-detected). Supported for non-frozen sets and maps whose element/key type has a
     # well-defined order (text/ascii/varchar and integer types); non-frozen lists and other
     # key/element types remain unsupported.
     # Because elements are restored with collection appends (col = col + ?), this only converges

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -87,9 +87,19 @@ A source of type ``cassandra`` can be used together with a target of type ``cass
     # Options are: LOCAL_ONE, ONE, LOCAL_QUORUM, QUORUM.
     # We recommend using LOCAL_QUORUM. If using ONE or LOCAL_ONE, ensure the source system is fully repaired.
     consistencyLevel: LOCAL_QUORUM
-    # Preserve TTLs and WRITETIMEs of cells in the source database. Note that this
-    # option is *incompatible* when copying tables with collections (lists, maps, sets).
+    # Preserve TTLs and WRITETIMEs of cells in the source database. Frozen collections
+    # (frozen<list/map/set>) are stored as a single cell and ARE supported. By default this
+    # option is *incompatible* with non-frozen (multi-cell) collections (lists, maps, sets),
+    # whose elements each carry their own TTL/WRITETIME (see preserveCollectionTimestamps).
     preserveTimestamps: true
+    # Opt-in: also preserve the per-element TTL/WRITETIME of non-frozen (multi-cell) collection
+    # columns. Each element's original TTL/WRITETIME is re-applied via collection appends after the
+    # base row write. Requires a source that can read collection-element metadata (Cassandra 5.0+ /
+    # modern ScyllaDB). Supported for non-frozen sets and maps whose element/key type has a
+    # well-defined order (text/ascii/varchar and integer types); non-frozen lists and other
+    # key/element types remain unsupported. Has no effect unless preserveTimestamps is also true.
+    # Defaults to false.
+    preserveCollectionTimestamps: false
     # Number of splits to use - this should be at minimum the amount of cores
     # available in the Spark cluster, and optimally more; higher splits will lead
     # to more fine-grained resumes. Aim for 8 * (Spark cores).

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -105,6 +105,21 @@ A source of type ``cassandra`` can be used together with a target of type ``cass
     # on the source or pre-existing on the target are not reconciled. Very large non-frozen
     # collections are expanded into up to one update per distinct element TTL/WRITETIME, which can
     # be memory- and throughput-intensive. Has no effect unless preserveTimestamps is also true.
+    #
+    # Source-quiescence is REQUIRED. On the ScyllaDB 2026.2+ subscript path, element values and their
+    # metadata are read in two phases (a base scan then per-row point reads); a concurrent update can
+    # yield a stale value with a fresh writetime, and an element deleted between the two reads is
+    # dropped (logged) rather than aborting the run. On the Cassandra 5.0+ array path both are read in
+    # one scan. Either way, stop writes to the source before migrating.
+    #
+    # TTL note: TTLs are read as remaining seconds and re-applied on write, so long-running migrations
+    # (and validation) see the clock advance between read and write/compare; use validation's
+    # ttlToleranceMillis to absorb this drift.
+    #
+    # Validation: per-element collection TTL/WRITETIME are compared only when the endpoints accept the
+    # collection-wide WRITETIME(col)/TTL(col) form (Cassandra 5.0+). Against ScyllaDB 2026.2+ (subscript
+    # only), the validator compares non-frozen collection columns by VALUE only and copyMissingRows for
+    # such tables is rejected (re-run the migration to converge instead).
     # Defaults to false.
     preserveCollectionTimestamps: false
     # Number of splits to use - this should be at minimum the amount of cores

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -97,7 +97,13 @@ A source of type ``cassandra`` can be used together with a target of type ``cass
     # base row write. Requires a source that can read collection-element metadata (Cassandra 5.0+ /
     # modern ScyllaDB). Supported for non-frozen sets and maps whose element/key type has a
     # well-defined order (text/ascii/varchar and integer types); non-frozen lists and other
-    # key/element types remain unsupported. Has no effect unless preserveTimestamps is also true.
+    # key/element types remain unsupported.
+    # Because elements are restored with collection appends (col = col + ?), this only converges
+    # correctly when the target collection starts empty (a fresh migration into an empty/nonexistent
+    # target) and the source is not concurrently modified: appends never delete, so elements deleted
+    # on the source or pre-existing on the target are not reconciled. Very large non-frozen
+    # collections are expanded into up to one update per distinct element TTL/WRITETIME, which can
+    # be memory- and throughput-intensive. Has no effect unless preserveTimestamps is also true.
     # Defaults to false.
     preserveCollectionTimestamps: false
     # Number of splits to use - this should be at minimum the amount of cores

--- a/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala
@@ -77,7 +77,11 @@ object SourceSettings {
     preserveTimestamps: Boolean,
     where: Option[String],
     consistencyLevel: String,
-    cloud: Option[CloudConfig] = None
+    cloud: Option[CloudConfig] = None,
+    // Opt-in: preserve per-element TTL/WRITETIME of non-frozen collection columns (maps, sets).
+    // Requires a source that supports reading collection-element metadata (Cassandra 5.0+ /
+    // modern ScyllaDB). Has no effect unless `preserveTimestamps` is also true.
+    preserveCollectionTimestamps: Boolean = false
   ) extends SourceSettings {
     val supportsSavepoints: Boolean = true
   }
@@ -124,19 +128,20 @@ object SourceSettings {
                  )
                case (true, false, false) => Right(())
              }
-        host               <- c.getOrElse[String]("host")(SentinelHost)
-        port               <- c.getOrElse[Int]("port")(SentinelPort)
-        localDC            <- c.get[Option[String]]("localDC")
-        credentials        <- c.get[Option[Credentials]]("credentials")
-        sslOptions         <- c.get[Option[SSLOptions]]("sslOptions")
-        keyspace           <- c.get[String]("keyspace")
-        table              <- c.get[String]("table")
-        splitCount         <- c.get[Option[Int]]("splitCount")
-        connections        <- c.get[Option[Int]]("connections")
-        fetchSize          <- c.get[Int]("fetchSize")
-        preserveTimestamps <- c.get[Boolean]("preserveTimestamps")
-        where              <- c.get[Option[String]]("where")
-        consistencyLevel   <- c.get[String]("consistencyLevel")
+        host                         <- c.getOrElse[String]("host")(SentinelHost)
+        port                         <- c.getOrElse[Int]("port")(SentinelPort)
+        localDC                      <- c.get[Option[String]]("localDC")
+        credentials                  <- c.get[Option[Credentials]]("credentials")
+        sslOptions                   <- c.get[Option[SSLOptions]]("sslOptions")
+        keyspace                     <- c.get[String]("keyspace")
+        table                        <- c.get[String]("table")
+        splitCount                   <- c.get[Option[Int]]("splitCount")
+        connections                  <- c.get[Option[Int]]("connections")
+        fetchSize                    <- c.get[Int]("fetchSize")
+        preserveTimestamps           <- c.get[Boolean]("preserveTimestamps")
+        preserveCollectionTimestamps <- c.getOrElse[Boolean]("preserveCollectionTimestamps")(false)
+        where                        <- c.get[Option[String]]("where")
+        consistencyLevel             <- c.get[String]("consistencyLevel")
         _ <- if (cloud.isDefined && localDC.isDefined)
                Left(
                  DecodingFailure(
@@ -170,23 +175,25 @@ object SourceSettings {
         preserveTimestamps,
         where,
         consistencyLevel,
-        cloud
+        cloud,
+        preserveCollectionTimestamps
       )
     }
 
     implicit val encoder: Encoder.AsObject[Cassandra] = Encoder.AsObject.instance { c =>
       val common = io.circe.JsonObject(
-        "localDC"            -> c.localDC.asJson,
-        "credentials"        -> c.credentials.asJson,
-        "sslOptions"         -> c.sslOptions.asJson,
-        "keyspace"           -> c.keyspace.asJson,
-        "table"              -> c.table.asJson,
-        "splitCount"         -> c.splitCount.asJson,
-        "connections"        -> c.connections.asJson,
-        "fetchSize"          -> c.fetchSize.asJson,
-        "preserveTimestamps" -> c.preserveTimestamps.asJson,
-        "where"              -> c.where.asJson,
-        "consistencyLevel"   -> c.consistencyLevel.asJson
+        "localDC"                      -> c.localDC.asJson,
+        "credentials"                  -> c.credentials.asJson,
+        "sslOptions"                   -> c.sslOptions.asJson,
+        "keyspace"                     -> c.keyspace.asJson,
+        "table"                        -> c.table.asJson,
+        "splitCount"                   -> c.splitCount.asJson,
+        "connections"                  -> c.connections.asJson,
+        "fetchSize"                    -> c.fetchSize.asJson,
+        "preserveTimestamps"           -> c.preserveTimestamps.asJson,
+        "preserveCollectionTimestamps" -> c.preserveCollectionTimestamps.asJson,
+        "where"                        -> c.where.asJson,
+        "consistencyLevel"             -> c.consistencyLevel.asJson
       )
       c.cloud match {
         case Some(cloud) =>

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -70,6 +70,21 @@ object Cassandra {
       .flatMap(s => scala.util.Try(s.trim.toInt).toOption)
       .getOrElse(1000000)
 
+  /** Max number of collection keys read per subscript point-read statement (ScyllaDB 2026.2+ path).
+    * Each key contributes two bind markers (`WRITETIME(col[?]), TTL(col[?])`), so a single
+    * statement would otherwise mint `2*N` markers for an `N`-element cell and blow past the
+    * native-protocol limit (65535) around 32k elements — long before [[LargeCollectionHardLimit]].
+    * Reading in fixed-width chunks bounds both the marker count (`2*chunk`) and the number of
+    * distinct prepared statements (one per chunk length). Override with
+    * `-Dscylla.migrator.subscriptKeyChunkSize=<n>`.
+    */
+  private val SubscriptKeyChunkSize: Int =
+    sys.props
+      .get("scylla.migrator.subscriptKeyChunkSize")
+      .flatMap(s => scala.util.Try(s.trim.toInt).toOption)
+      .filter(_ > 0)
+      .getOrElse(100)
+
   case class Selection(
     columnRefs: List[ColumnRef],
     schema: StructType,
@@ -138,9 +153,11 @@ object Cassandra {
           )
     }
 
-  /** Bind a runtime value into a driver statement. Collection keys are limited to text/int-family
-    * (see [[mapKeyOrdering]]) and primary keys to types with default driver codecs; both bind by
-    * their Java runtime class, so no explicit codec handling is needed for the supported types.
+  /** Bind a runtime value into a driver statement by its Java runtime class. Collection keys are
+    * limited to the text/int family (see [[mapKeyOrdering]]), which already map to default driver
+    * codecs. Primary-key values are pre-converted by the caller for the two widened/decoded types
+    * that would otherwise miss a codec (`timestamp`->Instant, `blob`->ByteBuffer); all other PK
+    * types reach here already codec-compatible.
     */
   private def driverBindValue(v: Any): AnyRef = v match {
     case null                 => null
@@ -220,9 +237,22 @@ object Cassandra {
     // Everything below is captured by the executor closure, so keep it serializable (primitives,
     // Strings, the Serializable `ElementSorter`, and the Serializable `connector`).
     val baseFieldIndex: Map[String, Int] = baseSchema.fieldNames.zipWithIndex.toMap
-    val pkNames: Seq[String] =
-      (tableDef.partitionKey ++ tableDef.clusteringColumns).map(_.columnName)
+    val pkColumns: Seq[ColumnDef] = tableDef.partitionKey ++ tableDef.clusteringColumns
+    val pkNames: Seq[String] = pkColumns.map(_.columnName)
     val pkOrdinals: Seq[Int] = pkNames.map(baseFieldIndex)
+    // Per-PK bind conversion tag. The base scan already widened `timestamp`->Long(epoch-ms) and
+    // yields `blob`->Array[Byte], neither of which has a matching driver default codec, so binding
+    // them by runtime class fails (Long is bound as bigint, byte[] has no codec). Convert those two
+    // back to the driver-native type (Instant / ByteBuffer) before binding; everything else
+    // (text/int/bigint/uuid/inet/decimal/varint/boolean/float/double) is already codec-compatible.
+    //   0 = pass-through, 1 = timestamp(Long->Instant), 2 = blob(Array[Byte]->ByteBuffer)
+    val pkBindKinds: Seq[Int] = pkColumns.map { c =>
+      c.columnType match {
+        case com.datastax.spark.connector.types.TimestampType => 1
+        case com.datastax.spark.connector.types.BlobType      => 2
+        case _                                                => 0
+      }
+    }
     // (columnName, ordinal-in-base-row, isMap, elementSorter)
     val nfInfo: Seq[(String, Int, Boolean, ElementSorter[_])] =
       nonFrozen.map { c =>
@@ -242,6 +272,10 @@ object Cassandra {
     val keyspaceQ = quoteCqlIdentifier(source.keyspace)
     val tableQ = quoteCqlIdentifier(source.table)
     val whereClause = pkNames.map(n => s"${quoteCqlIdentifier(n)} = ?").mkString(" AND ")
+    // Point reads must honor the same source consistency level as the base scan; otherwise the
+    // driver's session default (LOCAL_ONE) is used, widening the read-consistency race window
+    // between the base scan and the metadata point read.
+    val pointReadConsistencyLevel = readConf.consistencyLevel
     val targetFields = selection.schema.fields
     // Map a target array-sidecar field name back to its collection column, if any.
     def collectionOfSidecar(fieldName: String): Option[(String, Boolean)] =
@@ -251,81 +285,153 @@ object Cassandra {
       }
 
     baseRdd.mapPartitions { rows =>
-      connector.withSessionDo { session =>
-        val stmtCache = mutable.Map.empty[(String, Int), PreparedStatement]
+      // Hold ONE session open for the whole partition and stream rows lazily (no `.toList`, which
+      // would materialize every output row of the partition in executor memory). The session is
+      // borrowed from the connector's pool and returned when the Spark task completes.
+      val session = connector.openSession()
+      val stmtCache = mutable.Map.empty[(String, Int), PreparedStatement]
+      val dropped = new java.util.concurrent.atomic.AtomicLong(0L)
+      val taskCtxOpt = Option(org.apache.spark.TaskContext.get())
+      taskCtxOpt.foreach(_.addTaskCompletionListener[Unit] { _ =>
+        if (dropped.get() > 0L)
+          log.warn(
+            s"Subscript metadata read dropped ${dropped.get()} collection element(s) whose " +
+              s"per-element WRITETIME was null at point-read time (element absent — e.g. a " +
+              s"concurrent delete). The migrator requires a quiescent source; resume/re-run once " +
+              s"writes have stopped if this is unexpected."
+          )
+        session.close()
+      })
 
-        def elementMetadata(row: Row): Map[String, (Seq[Integer], Seq[java.lang.Long])] =
-          nfInfo.map { case (name, ord, isMap, sorter) =>
-            if (row.isNullAt(ord)) name -> ((null: Seq[Integer]), (null: Seq[java.lang.Long]))
-            else {
-              val sortedKeys: IndexedSeq[Any] =
-                if (isMap)
-                  sorter
-                    .sortEntries(
-                      row.get(ord).asInstanceOf[scala.collection.Map[Any, Any]].toIndexedSeq
-                    )
-                    .map(_._1)
-                else
-                  sorter.sortElements(
-                    row.get(ord).asInstanceOf[scala.collection.Seq[Any]].toIndexedSeq
-                  )
+      val pkBindKindsArr = pkBindKinds.toArray
+      val pkOrdinalsArr = pkOrdinals.toArray
 
-              val n = sortedKeys.length
-              if (n == 0)
-                name -> ((IndexedSeq.empty[Integer], IndexedSeq.empty[java.lang.Long]))
-              else {
-                val colQ = quoteCqlIdentifier(name)
-                val projection =
-                  (0 until n)
-                    .map(_ => s"WRITETIME($colQ[?]), TTL($colQ[?])")
-                    .mkString(", ")
-                val cql =
-                  s"SELECT $projection FROM $keyspaceQ.$tableQ WHERE $whereClause"
-                val ps = stmtCache.getOrElseUpdate((name, n), session.prepare(cql))
+      // Per-column: the (possibly filtered) collection VALUE plus element-aligned TTL/WRITETIME
+      // arrays. Value and metadata are re-derived from the SAME sorted key set, so they always
+      // align; any element whose WRITETIME reads back null is dropped from both.
+      def readColumn(
+        row: Row,
+        name: String,
+        ord: Int,
+        isMap: Boolean,
+        sorter: ElementSorter[_],
+        pkBinds: Seq[AnyRef]
+      ): (Any, Seq[Integer], Seq[java.lang.Long]) = {
+        if (row.isNullAt(ord)) return (null, null, null)
 
-                // Bind order follows statement text: each key appears twice (WRITETIME, TTL),
-                // then the primary-key values for the WHERE clause.
-                val keyBinds = sortedKeys.flatMap(k => Seq(driverBindValue(k), driverBindValue(k)))
-                val pkBinds =
-                  pkOrdinals.map(o => driverBindValue(if (row.isNullAt(o)) null else row.get(o)))
-                val bound = ps.bind((keyBinds ++ pkBinds).toArray: _*)
+        // (subscript-key, retained-value): for a map the value is the map value; for a set/list the
+        // element is its own key and value.
+        val entries: IndexedSeq[(Any, Any)] =
+          if (isMap)
+            sorter.sortEntries(
+              row.get(ord).asInstanceOf[scala.collection.Map[Any, Any]].toIndexedSeq
+            )
+          else
+            sorter
+              .sortElements(row.get(ord).asInstanceOf[scala.collection.Seq[Any]].toIndexedSeq)
+              .map(e => (e, e))
 
-                val dr: DriverRow = session.execute(bound).one()
-                val ttls = new Array[Integer](n)
-                val wts = new Array[java.lang.Long](n)
-                var i = 0
-                while (i < n) {
-                  val wtIdx = 2 * i
-                  val ttlIdx = 2 * i + 1
-                  wts(i) =
-                    if (dr == null || dr.isNull(wtIdx)) null
-                    else java.lang.Long.valueOf(dr.getLong(wtIdx))
-                  ttls(i) =
-                    if (dr == null || dr.isNull(ttlIdx)) null
-                    else Integer.valueOf(dr.getInt(ttlIdx))
-                  i += 1
-                }
-                name -> ((ArraySeq.unsafeWrapArray(ttls), ArraySeq.unsafeWrapArray(wts)))
-              }
+        val n = entries.length
+        if (n == 0)
+          return (row.get(ord), IndexedSeq.empty[Integer], IndexedSeq.empty[java.lang.Long])
+
+        val colQ = quoteCqlIdentifier(name)
+        val ttls = new Array[Integer](n)
+        val wts = new Array[java.lang.Long](n)
+
+        // Read metadata in fixed-width chunks so a huge cell never exceeds the native-protocol bind
+        // marker limit and only mints a bounded set of prepared statements (one per chunk length).
+        var base = 0
+        while (base < n) {
+          val chunkLen = math.min(SubscriptKeyChunkSize, n - base)
+          val ps = stmtCache.getOrElseUpdate(
+            (name, chunkLen), {
+              val projection =
+                (0 until chunkLen).map(_ => s"WRITETIME($colQ[?]), TTL($colQ[?])").mkString(", ")
+              session.prepare(s"SELECT $projection FROM $keyspaceQ.$tableQ WHERE $whereClause")
             }
+          )
+          // Bind order follows statement text: each key twice (WRITETIME, TTL), then the PK values.
+          val keyBinds =
+            (0 until chunkLen).flatMap { j =>
+              val k = entries(base + j)._1
+              Seq(driverBindValue(k), driverBindValue(k))
+            }
+          val bound = ps
+            .bind((keyBinds ++ pkBinds).toArray: _*)
+            .setConsistencyLevel(pointReadConsistencyLevel)
+
+          val dr: DriverRow = session.execute(bound).one()
+          var j = 0
+          while (j < chunkLen) {
+            val wtIdx = 2 * j
+            val ttlIdx = 2 * j + 1
+            wts(base + j) =
+              if (dr == null || dr.isNull(wtIdx)) null
+              else java.lang.Long.valueOf(dr.getLong(wtIdx))
+            ttls(base + j) =
+              if (dr == null || dr.isNull(ttlIdx)) null
+              else Integer.valueOf(dr.getInt(ttlIdx))
+            j += 1
+          }
+          base += chunkLen
+        }
+
+        // A null WRITETIME means the element no longer exists at the point-read snapshot (element
+        // absent, e.g. a concurrent delete). Drop it from BOTH the value and the metadata so the
+        // arrays stay aligned and the job does not abort. Under a quiescent source (the documented
+        // requirement) `keep.length == n`, so the value/metadata are byte-for-byte the base scan.
+        // NOTE: a null TTL is retained — it legitimately means "no TTL / permanent element".
+        val keptIdx = (0 until n).filter(i => wts(i) != null)
+        if (keptIdx.length == n) {
+          (row.get(ord), ArraySeq.unsafeWrapArray(ttls), ArraySeq.unsafeWrapArray(wts))
+        } else {
+          dropped.addAndGet((n - keptIdx.length).toLong)
+          val value: Any =
+            if (isMap)
+              keptIdx.map(i => entries(i)._1 -> entries(i)._2).to(scala.collection.immutable.Map)
+            else
+              keptIdx.map(i => entries(i)._2).toVector
+          (
+            value,
+            ArraySeq.unsafeWrapArray(keptIdx.map(ttls).toArray),
+            ArraySeq.unsafeWrapArray(keptIdx.map(wts).toArray)
+          )
+        }
+      }
+
+      rows.map { row =>
+        // PK binds are identical for every collection column in a row, so compute them once.
+        val pkBinds: Seq[AnyRef] =
+          pkOrdinalsArr.indices.map { i =>
+            val o = pkOrdinalsArr(i)
+            val raw = if (row.isNullAt(o)) null else row.get(o)
+            val converted: Any = (pkBindKindsArr(i), raw) match {
+              case (_, null)              => null
+              case (1, l: Long)           => java.time.Instant.ofEpochMilli(l)
+              case (1, l: java.lang.Long) => java.time.Instant.ofEpochMilli(l.longValue)
+              case (2, b: Array[Byte])    => java.nio.ByteBuffer.wrap(b)
+              case (_, v)                 => v
+            }
+            driverBindValue(converted)
+          }
+
+        val meta: Map[String, (Any, Seq[Integer], Seq[java.lang.Long])] =
+          nfInfo.map { case (name, ord, isMap, sorter) =>
+            name -> readColumn(row, name, ord, isMap, sorter, pkBinds)
           }.toMap
 
-        rows
-          .map { row =>
-            val meta = elementMetadata(row)
-            val values = targetFields.map { f =>
-              collectionOfSidecar(f.name) match {
-                case Some((col, isTtl)) =>
-                  val (ttlArr, wtArr) = meta(col)
-                  if (isTtl) ttlArr else wtArr
-                case None =>
-                  row.get(baseFieldIndex(f.name))
-              }
-            }
-            Row.fromSeq(ArraySeq.unsafeWrapArray(values.asInstanceOf[Array[Any]]))
+        val values = targetFields.map { f =>
+          collectionOfSidecar(f.name) match {
+            case Some((col, isTtl)) =>
+              val (_, ttlArr, wtArr) = meta(col)
+              if (isTtl) ttlArr else wtArr
+            case None =>
+              if (nfNames.contains(f.name)) meta(f.name)._1
+              else row.get(baseFieldIndex(f.name))
           }
-          .toList
-          .iterator
+        }
+        Row.fromSeq(ArraySeq.unsafeWrapArray(values.asInstanceOf[Array[Any]]))
       }
     }
   }
@@ -854,8 +960,13 @@ object Cassandra {
     }
 
     def rowsFrom(elements: IndexedSeq[Any], rebuild: Seq[Any] => Any): Seq[Row] = {
+      // Both sidecars must be element-aligned. On every real read path `TTL(col)` returns a list the
+      // same length as the collection (null entries for elements with no TTL), so an empty/short TTL
+      // sidecar alongside real writetimes signals malformed input (e.g. foreign/hand-crafted
+      // Parquet). Do NOT treat a missing TTL array as "all permanent (TTL 0)" — that would silently
+      // strip expiry from every element; fail loudly instead.
       require(
-        wtSeq.length == elements.length && (ttlSeq.isEmpty || ttlSeq.length == elements.length),
+        wtSeq.length == elements.length && ttlSeq.length == elements.length,
         s"Collection metadata length mismatch for a per-element collection column: " +
           s"${elements.length} elements but ${wtSeq.length} writetimes / ${ttlSeq.length} ttls. " +
           "Element<->timestamp alignment cannot be guaranteed; aborting to avoid silent data loss."

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -1,10 +1,23 @@
 package com.scylladb.migrator.readers
 
 import com.datastax.spark.connector._
-import com.datastax.spark.connector.cql.{ Schema, TableDef }
+import com.datastax.spark.connector.cql.{ ColumnDef, Schema, TableDef }
 import com.datastax.spark.connector.rdd.ReadConf
 import com.datastax.spark.connector.rdd.partitioner.dht.Token
-import com.datastax.spark.connector.types.CassandraOption
+import com.datastax.spark.connector.types.{
+  AsciiType,
+  BigIntType,
+  CassandraOption,
+  ColumnType,
+  IntType,
+  ListType => CqlListType,
+  MapType => CqlMapType,
+  SetType => CqlSetType,
+  SmallIntType,
+  TextType,
+  TinyIntType,
+  VarCharType
+}
 import com.scylladb.migrator.Connectors
 import com.scylladb.migrator.config.{ CopyType, SourceSettings }
 import org.apache.logging.log4j.LogManager
@@ -23,10 +36,11 @@ import org.apache.spark.sql.types.{
 import org.apache.spark.sql.{ DataFrame, Row, SparkSession }
 import org.apache.spark.unsafe.types.UTF8String
 import com.scylladb.migrator.ConsistencyLevelUtils
-import com.scylladb.migrator.scylla.SourceDataFrame
+import com.scylladb.migrator.scylla.{ CollectionAppendWrite, SourceDataFrame }
 
 import scala.collection.immutable.ArraySeq
 import scala.collection.mutable.ArrayBuffer
+import java.nio.charset.StandardCharsets
 
 object Cassandra {
   val log = LogManager.getLogger("com.scylladb.migrator.readers.Cassandra")
@@ -37,30 +51,127 @@ object Cassandra {
     timestampColumns: Option[TimestampColumns]
   )
 
+  /** Regular columns that are non-frozen (multi-cell) collections. These keep per-element
+    * TTL/WRITETIME (one metadata value per element), so `TTL()`/`WRITETIME()` on them return a list
+    * aligned with the collection's elements rather than a scalar.
+    */
+  def nonFrozenCollectionColumns(tableDef: TableDef): Seq[ColumnDef] =
+    tableDef.regularColumns.filter(c => c.columnType.isCollection && c.columnType.isMultiCell)
+
+  /** Unsigned lexicographic ordering over byte arrays, matching Cassandra's `UTF8Type`/`AsciiType`
+    * comparator for text map keys.
+    */
+  private val unsignedBytesOrdering: Ordering[Array[Byte]] = new Ordering[Array[Byte]] {
+    def compare(a: Array[Byte], b: Array[Byte]): Int = {
+      val n = math.min(a.length, b.length)
+      var i = 0
+      while (i < n) {
+        val ai = a(i) & 0xff
+        val bi = b(i) & 0xff
+        if (ai != bi) return ai - bi
+        i += 1
+      }
+      a.length - b.length
+    }
+  }
+
+  /** Ordering over runtime map-key values that reproduces Cassandra's on-disk key order for the
+    * supported key types, so a decoded map (whose iteration order Spark/Catalyst does not preserve)
+    * can be re-aligned with the element-order `WRITETIME`/`TTL` lists. Returns `None` for key types
+    * whose Cassandra comparator we cannot faithfully reproduce here.
+    */
+  def mapKeyOrdering(keyType: ColumnType[_]): Option[Ordering[Any]] = keyType match {
+    case TextType | AsciiType | VarCharType =>
+      Some(
+        Ordering.by((k: Any) => k.toString.getBytes(StandardCharsets.UTF_8))(unsignedBytesOrdering)
+      )
+    case IntType | BigIntType | SmallIntType | TinyIntType =>
+      Some(Ordering.by((k: Any) => k.asInstanceOf[Number].longValue()))
+    case _ => None
+  }
+
+  /** Describe why a non-frozen collection column cannot have its per-element timestamps preserved,
+    * or `None` if it is supported. Non-frozen lists are unsupported (list cells are keyed by
+    * generated timeuuids, so append cannot reproduce element identity), and maps are supported only
+    * for key types with a reproducible ordering (see [[mapKeyOrdering]]).
+    */
+  private def unsupportedCollectionReason(column: ColumnDef): Option[String] =
+    column.columnType match {
+      case _: CqlListType[_] =>
+        Some(s"'${column.columnName}' (non-frozen list)")
+      case m: CqlMapType[_, _] if mapKeyOrdering(m.keyType).isEmpty =>
+        Some(s"'${column.columnName}' (non-frozen map with unsupported key type ${m.keyType})")
+      case s: CqlSetType[_] if mapKeyOrdering(s.elemType).isEmpty =>
+        Some(s"'${column.columnName}' (non-frozen set with unsupported element type ${s.elemType})")
+      case _ => None
+    }
+
+  /** The ordering used to re-align a non-frozen collection's decoded elements with its
+    * element-order `WRITETIME`/`TTL` lists: map keys for maps, element values for sets (Cassandra
+    * stores/returns both in that sorted order). `None` for unsupported element/key types.
+    */
+  private def collectionElementOrdering(columnType: ColumnType[_]): Option[Ordering[Any]] =
+    columnType match {
+      case m: CqlMapType[_, _] => mapKeyOrdering(m.keyType)
+      case s: CqlSetType[_]    => mapKeyOrdering(s.elemType)
+      case _                   => None
+    }
+
   def determineCopyType(
     tableDef: TableDef,
-    preserveTimesRequest: Boolean
-  ): Either[Throwable, CopyType] =
-    if (tableDef.columnTypes.exists(_.isCollection) && preserveTimesRequest)
+    preserveTimesRequest: Boolean,
+    preserveCollectionTimesRequest: Boolean = false
+  ): Either[Throwable, CopyType] = {
+    // Frozen collections are stored as a single cell, so CQL `TTL()`/`WRITETIME()` return one
+    // scalar value per column and flow through the existing scalar preservation path unchanged.
+    // Non-frozen (multi-cell) collections keep per-element TTL/writetime. They are rejected unless
+    // the opt-in `preserveCollectionTimestamps` is enabled, in which case supported ones (sets and
+    // maps with an orderable key type) are read as element-aligned lists and re-applied per element
+    // via collection-append writes.
+    val nonFrozen = nonFrozenCollectionColumns(tableDef)
+    if (nonFrozen.nonEmpty && preserveTimesRequest && !preserveCollectionTimesRequest)
       Left(
         new Exception(
-          "TTL/Writetime preservation is unsupported for tables with collection types. Please check in your config the option 'preserveTimestamps' and set it to false to continue."
+          "TTL/Writetime preservation is unsupported for tables with non-frozen (multi-cell) " +
+            "collection types (lists, maps, sets). Freeze the collection columns, enable the config " +
+            "option 'preserveCollectionTimestamps' to preserve per-element TTL/WRITETIME (supported " +
+            "for sets and maps on Cassandra 5.0+/modern ScyllaDB sources), or set the config option " +
+            "'preserveTimestamps' to false to continue."
         )
       )
-    else if (preserveTimesRequest && tableDef.regularColumns.nonEmpty)
+    else if (nonFrozen.nonEmpty && preserveTimesRequest && preserveCollectionTimesRequest) {
+      val unsupported = nonFrozen.flatMap(unsupportedCollectionReason)
+      if (unsupported.nonEmpty)
+        Left(
+          new Exception(
+            "Per-element TTL/Writetime preservation ('preserveCollectionTimestamps') is unsupported " +
+              s"for these columns: ${unsupported.mkString(", ")}. Freeze them, or set " +
+              "'preserveCollectionTimestamps' to false to continue."
+          )
+        )
+      else Right(CopyType.WithTimestampPreservation)
+    } else if (preserveTimesRequest && tableDef.regularColumns.nonEmpty)
       Right(CopyType.WithTimestampPreservation)
     else if (preserveTimesRequest && tableDef.regularColumns.isEmpty) {
       log.warn("No regular columns in the table - disabling timestamp preservation")
       Right(CopyType.NoTimestampPreservation)
     } else Right(CopyType.NoTimestampPreservation)
+  }
 
   def createSelection(
     tableDef: TableDef,
     origSchema: StructType,
-    preserveTimes: Boolean
+    preserveTimes: Boolean,
+    preserveCollectionTimes: Boolean = false
   ): Either[Throwable, Selection] =
-    determineCopyType(tableDef, preserveTimes) map {
+    determineCopyType(tableDef, preserveTimes, preserveCollectionTimes) map {
       case CopyType.WithTimestampPreservation =>
+        // When per-element preservation is enabled, non-frozen collection columns select their
+        // TTL()/WRITETIME() as element-aligned lists (ArrayType sidecars) instead of scalars.
+        val perElementCollectionNames =
+          if (preserveCollectionTimes) nonFrozenCollectionColumns(tableDef).map(_.columnName).toSet
+          else Set.empty[String]
+
         val columnRefs =
           tableDef.partitionKey.map(_.ref) ++
             tableDef.clusteringColumns.map(_.ref) ++
@@ -80,11 +191,14 @@ object Cassandra {
         val schema = StructType(for {
           origField <- origSchema.fields
           isRegular = tableDef.regularColumns.exists(_.ref.columnName == origField.name)
+          isPerElementCollection = perElementCollectionNames.contains(origField.name)
+          ttlType       = if (isPerElementCollection) ArrayType(IntegerType) else IntegerType
+          writetimeType = if (isPerElementCollection) ArrayType(LongType) else LongType
           field <- if (isRegular)
                      List(
                        origField,
-                       StructField(s"${origField.name}_ttl", IntegerType, true),
-                       StructField(s"${origField.name}_writetime", LongType, true)
+                       StructField(s"${origField.name}_ttl", ttlType, true),
+                       StructField(s"${origField.name}_writetime", writetimeType, true)
                      )
                    else List(origField)
         } yield field)
@@ -167,6 +281,164 @@ object Cassandra {
           Row(ArraySeq.unsafeWrapArray(newValues): _*)
         }
     }
+
+  /** Explode a wide row into base rows for the timestamp-preservation write, EXCLUDING non-frozen
+    * collection columns (whose per-element timestamps are handled by separate collection-append
+    * passes). `baseSchema` must already omit those columns. When there are no base regular columns
+    * (a table whose only regular columns are per-element collections), a single primary-key-only
+    * row is emitted so the base write establishes the partition; the collection appends carry the
+    * data.
+    */
+  def explodeBaseRow(
+    row: Row,
+    baseSchema: StructType,
+    primaryKeyOrdinals: Map[String, Int],
+    baseRegularKeyOrdinals: Map[String, (Int, Int, Int)]
+  ): Iterable[Row] =
+    if (baseRegularKeyOrdinals.nonEmpty)
+      explodeRow(row, baseSchema, primaryKeyOrdinals, baseRegularKeyOrdinals)
+    else {
+      val newValues = baseSchema.fields.map { field =>
+        primaryKeyOrdinals
+          .get(field.name)
+          .map(ord => if (row.isNullAt(ord)) null else convertValue(row.get(ord)))
+          .getOrElse(CassandraOption.Unset)
+      } ++ Seq(Integer.valueOf(0), CassandraOption.Unset)
+      List(Row(ArraySeq.unsafeWrapArray(newValues): _*))
+    }
+
+  private def asNumberSeq(v: Any): IndexedSeq[Any] = v match {
+    case s: scala.collection.Seq[Any] => s.toIndexedSeq
+    case a: Array[_]                  => ArraySeq.unsafeWrapArray(a.asInstanceOf[Array[Any]])
+    case _                            => IndexedSeq.empty
+  }
+
+  /** Build the per-element collection-append rows for one non-frozen collection column of a single
+    * wide source row. Each emitted row is `[primary key values..., grouped collection value, ttl,
+    * writetime]`. Elements are aligned with their element-order `TTL()`/`WRITETIME()` lists (sets
+    * by natural array order, maps by re-sorting entries with `keyOrdering` to match Cassandra's
+    * on-disk key order), then grouped by `(ttl, writetime)` so co-timestamped elements share one
+    * append.
+    */
+  def collectionAppendRows(
+    row: Row,
+    pkOrdinals: Array[Int],
+    colOrdinal: Int,
+    ttlOrdinal: Int,
+    writetimeOrdinal: Int,
+    isMap: Boolean,
+    elementOrdering: Option[Ordering[Any]]
+  ): Seq[Row] = {
+    if (row.isNullAt(colOrdinal)) return Nil
+
+    val pkValues: Seq[Any] =
+      pkOrdinals.toIndexedSeq.map(o => if (row.isNullAt(o)) null else row.get(o))
+
+    val ttlSeq =
+      if (row.isNullAt(ttlOrdinal)) IndexedSeq.empty else asNumberSeq(row.get(ttlOrdinal))
+    val wtSeq =
+      if (row.isNullAt(writetimeOrdinal)) IndexedSeq.empty
+      else asNumberSeq(row.get(writetimeOrdinal))
+
+    def ttlAt(i: Int): Int =
+      if (i < ttlSeq.length && ttlSeq(i) != null) ttlSeq(i).asInstanceOf[Number].intValue() else 0
+    def wtAt(i: Int): Option[Long] =
+      if (i < wtSeq.length && wtSeq(i) != null) Some(wtSeq(i).asInstanceOf[Number].longValue())
+      else None
+
+    def rowsFrom(elements: IndexedSeq[Any], rebuild: Seq[Any] => Any): Seq[Row] =
+      elements.indices
+        .groupBy(i => (ttlAt(i), wtAt(i)))
+        .toSeq
+        .flatMap { case ((ttl, wtOpt), indices) =>
+          wtOpt.map { wt =>
+            val collectionValue = rebuild(indices.map(elements))
+            Row.fromSeq(
+              pkValues ++ Seq(
+                collectionValue,
+                Integer.valueOf(ttl),
+                java.lang.Long.valueOf(wt)
+              )
+            )
+          }
+        }
+
+    // Both the connector's decoded set and map lose their server (sorted) order, while the
+    // WRITETIME()/TTL() lists arrive in that sorted order. Re-sort the elements/entries with the
+    // Cassandra-compatible ordering so element[i] pairs with its own metadata[i].
+    val ordering = elementOrdering.getOrElse(
+      throw new IllegalStateException(
+        "Missing element ordering for a per-element collection column; this should have been " +
+          "rejected earlier"
+      )
+    )
+
+    if (isMap) {
+      val m = row.get(colOrdinal).asInstanceOf[scala.collection.Map[Any, Any]]
+      if (m.isEmpty) Nil
+      else {
+        val entries = m.toIndexedSeq.sortBy(_._1)(ordering)
+        rowsFrom(
+          entries.asInstanceOf[IndexedSeq[Any]],
+          parts => parts.map(_.asInstanceOf[(Any, Any)]).toMap
+        )
+      }
+    } else {
+      val elems = row.get(colOrdinal).asInstanceOf[scala.collection.Seq[Any]].toIndexedSeq
+      if (elems.isEmpty) Nil
+      else rowsFrom(elems.sorted(ordering), parts => parts.toIndexedSeq)
+    }
+  }
+
+  /** Build one [[CollectionAppendWrite]] per supported non-frozen collection column, reading the
+    * per-element metadata from the wide `rawDataframe` and aligning it with each element.
+    */
+  def buildCollectionAppendWrites(
+    spark: SparkSession,
+    rawDataframe: DataFrame,
+    tableDef: TableDef,
+    origSchema: StructType,
+    primaryKeyOrdinals: Map[String, Int],
+    regularKeyOrdinals: Map[String, (Int, Int, Int)],
+    perElementNames: Set[String]
+  ): Seq[CollectionAppendWrite] = {
+    val pkOrder =
+      (tableDef.partitionKey ++ tableDef.clusteringColumns)
+        .map(_.columnName)
+        .filter(primaryKeyOrdinals.contains)
+    val pkOrdinalArray = pkOrder.map(primaryKeyOrdinals).toArray
+    val pkFields = pkOrder.map(name => origSchema(origSchema.fieldIndex(name)))
+
+    nonFrozenCollectionColumns(tableDef)
+      .filter(c => perElementNames.contains(c.columnName))
+      .map { column =>
+        val colName = column.columnName
+        val (colOrd, ttlOrd, wtOrd) = regularKeyOrdinals(colName)
+        val collectionField = origSchema(origSchema.fieldIndex(colName))
+        val appendSchema = StructType(
+          pkFields ++ Seq(
+            collectionField,
+            StructField("ttl", IntegerType, true),
+            StructField("writetime", LongType, true)
+          )
+        )
+        val isMap = column.columnType.isInstanceOf[CqlMapType[_, _]]
+        val elementOrdering = collectionElementOrdering(column.columnType)
+        val pkOrdinalsBroadcast = spark.sparkContext.broadcast(pkOrdinalArray)
+        val rdd = rawDataframe.rdd.flatMap { row =>
+          collectionAppendRows(
+            row,
+            pkOrdinalsBroadcast.value,
+            colOrd,
+            ttlOrd,
+            wtOrd,
+            isMap,
+            elementOrdering
+          )
+        }
+        CollectionAppendWrite(colName, rdd, appendSchema)
+      }
+  }
 
   /** Convert Cassandra-specific types to standard Spark types.
     *
@@ -372,7 +644,9 @@ object Cassandra {
     log.info("Original schema loaded:")
     origSchema.printTreeString()
 
-    val selection = createSelection(tableDef, origSchema, preserveTimes).fold(throw _, identity)
+    val selection =
+      createSelection(tableDef, origSchema, preserveTimes, source.preserveCollectionTimestamps)
+        .fold(throw _, identity)
 
     val selectCassandraRDD = spark.sparkContext
       .cassandraTable[CassandraSQLRow](
@@ -410,11 +684,23 @@ object Cassandra {
             tableDef
           )
 
+          // Non-frozen collection columns whose per-element TTL/WRITETIME we preserve via
+          // collection-append passes. They are excluded from the base (scalar/frozen) explode.
+          val perElementNames =
+            if (source.preserveCollectionTimestamps)
+              nonFrozenCollectionColumns(tableDef).map(_.columnName).toSet
+            else Set.empty[String]
+
+          val baseOrigSchema =
+            StructType(origSchema.fields.filterNot(f => perElementNames.contains(f.name)))
+          val baseRegularKeyOrdinals =
+            regularKeyOrdinals.filterNot { case (name, _) => perElementNames.contains(name) }
+
           val broadcastPrimaryKeyOrdinals = spark.sparkContext.broadcast(primaryKeyOrdinals)
-          val broadcastRegularKeyOrdinals = spark.sparkContext.broadcast(regularKeyOrdinals)
-          val broadcastSchema = spark.sparkContext.broadcast(origSchema)
+          val broadcastRegularKeyOrdinals = spark.sparkContext.broadcast(baseRegularKeyOrdinals)
+          val broadcastSchema = spark.sparkContext.broadcast(baseOrigSchema)
           val finalSchema = StructType(
-            origSchema.fields ++
+            baseOrigSchema.fields ++
               Seq(StructField(ttl, IntegerType, true), StructField(writeTime, LongType, true))
           )
 
@@ -422,7 +708,7 @@ object Cassandra {
           log.info(finalSchema.treeString)
 
           val explodedRdd = rawDataframe.rdd.flatMap { row =>
-            explodeRow(
+            explodeBaseRow(
               row,
               broadcastSchema.value,
               broadcastPrimaryKeyOrdinals.value,
@@ -430,11 +716,25 @@ object Cassandra {
             )
           }
 
+          val collectionAppendWrites =
+            if (perElementNames.isEmpty) Nil
+            else
+              buildCollectionAppendWrites(
+                spark,
+                rawDataframe,
+                tableDef,
+                origSchema,
+                primaryKeyOrdinals,
+                regularKeyOrdinals,
+                perElementNames
+              )
+
           SourceDataFrame(
             rawDataframe,
             selection.timestampColumns,
             source.supportsSavepoints,
-            Some((explodedRdd, finalSchema))
+            Some((explodedRdd, finalSchema)),
+            collectionAppendWrites
           )
       }
     }

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -1,7 +1,7 @@
 package com.scylladb.migrator.readers
 
 import com.datastax.spark.connector._
-import com.datastax.spark.connector.cql.{ ColumnDef, Schema, TableDef }
+import com.datastax.spark.connector.cql.{ CassandraConnector, ColumnDef, Schema, TableDef }
 import com.datastax.spark.connector.rdd.ReadConf
 import com.datastax.spark.connector.rdd.partitioner.dht.Token
 import com.datastax.spark.connector.types.{
@@ -40,10 +40,17 @@ import com.scylladb.migrator.scylla.{ CollectionAppendWrite, SourceDataFrame }
 
 import scala.collection.immutable.ArraySeq
 import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
 import java.nio.charset.StandardCharsets
 
 object Cassandra {
   val log = LogManager.getLogger("com.scylladb.migrator.readers.Cassandra")
+
+  /** Above this element count, a single non-frozen collection cell is logged as a potential
+    * memory/throughput hot spot: per-element TTL/WRITETIME preservation may expand it into up to
+    * this many separate collection-append updates (one per distinct TTL/WRITETIME group).
+    */
+  private val LargeCollectionWarnThreshold = 100000
 
   case class Selection(
     columnRefs: List[ColumnRef],
@@ -57,6 +64,37 @@ object Cassandra {
     */
   def nonFrozenCollectionColumns(tableDef: TableDef): Seq[ColumnDef] =
     tableDef.regularColumns.filter(c => c.columnType.isCollection && c.columnType.isMultiCell)
+
+  private def quoteCqlIdentifier(id: String): String =
+    "\"" + id.replace("\"", "\"\"") + "\""
+
+  /** Fail fast if the source server cannot return per-element `WRITETIME()`/`TTL()` for a
+    * non-frozen collection column. We only PREPARE the statement (no execution, no data read); on
+    * servers older than Cassandra 5.0 / older ScyllaDB this fails at semantic validation, letting
+    * us surface a clear, actionable error before launching the distributed read.
+    */
+  private def assertNonFrozenCollectionMetadataReadable(
+    connector: CassandraConnector,
+    keyspace: String,
+    table: String,
+    nonFrozen: Seq[ColumnDef]
+  ): Unit =
+    nonFrozen.headOption.foreach { col =>
+      val c = quoteCqlIdentifier(col.columnName)
+      val cql =
+        s"SELECT WRITETIME($c), TTL($c) FROM " +
+          s"${quoteCqlIdentifier(keyspace)}.${quoteCqlIdentifier(table)} LIMIT 1"
+      try connector.withSessionDo(_.prepare(cql))
+      catch {
+        case NonFatal(e) =>
+          throw new IllegalStateException(
+            s"preserveCollectionTimestamps is enabled, but the source cannot read per-element " +
+              s"WRITETIME()/TTL() on non-frozen collection column '${col.columnName}'. This " +
+              s"requires Cassandra 5.0+ or a modern ScyllaDB. Underlying error: ${e.getMessage}",
+            e
+          )
+      }
+    }
 
   /** Unsigned lexicographic ordering over byte arrays, matching Cassandra's `UTF8Type`/`AsciiType`
     * comparator for text map keys.
@@ -346,7 +384,20 @@ object Cassandra {
       if (i < wtSeq.length && wtSeq(i) != null) Some(wtSeq(i).asInstanceOf[Number].longValue())
       else None
 
-    def rowsFrom(elements: IndexedSeq[Any], rebuild: Seq[Any] => Any): Seq[Row] =
+    def rowsFrom(elements: IndexedSeq[Any], rebuild: Seq[Any] => Any): Seq[Row] = {
+      require(
+        wtSeq.length == elements.length && (ttlSeq.isEmpty || ttlSeq.length == elements.length),
+        s"Collection metadata length mismatch for a per-element collection column: " +
+          s"${elements.length} elements but ${wtSeq.length} writetimes / ${ttlSeq.length} ttls. " +
+          "Element<->timestamp alignment cannot be guaranteed; aborting to avoid silent data loss."
+      )
+      if (elements.length > LargeCollectionWarnThreshold)
+        log.warn(
+          s"Non-frozen collection cell has ${elements.length} elements; per-element TTL/WRITETIME " +
+            "preservation may expand it into up to that many separate collection-append updates " +
+            "(one per distinct TTL/WRITETIME group). Very large collections can cause high " +
+            "executor memory/GC pressure and slow writes."
+        )
       elements.indices
         .groupBy(i => (ttlAt(i), wtAt(i)))
         .toSeq
@@ -362,6 +413,7 @@ object Cassandra {
             )
           }
         }
+    }
 
     // Both the connector's decoded set and map lose their server (sorted) order, while the
     // WRITETIME()/TTL() lists arrive in that sorted order. Re-sort the elements/entries with the
@@ -647,6 +699,14 @@ object Cassandra {
     val selection =
       createSelection(tableDef, origSchema, preserveTimes, source.preserveCollectionTimestamps)
         .fold(throw _, identity)
+
+    if (preserveTimes && source.preserveCollectionTimestamps)
+      assertNonFrozenCollectionMetadataReadable(
+        connector,
+        source.keyspace,
+        source.table,
+        nonFrozenCollectionColumns(tableDef)
+      )
 
     val selectCassandraRDD = spark.sparkContext
       .cassandraTable[CassandraSQLRow](

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -78,12 +78,24 @@ object Cassandra {
     * distinct prepared statements (one per chunk length). Override with
     * `-Dscylla.migrator.subscriptKeyChunkSize=<n>`.
     */
-  private val SubscriptKeyChunkSize: Int =
-    sys.props
-      .get("scylla.migrator.subscriptKeyChunkSize")
-      .flatMap(s => scala.util.Try(s.trim.toInt).toOption)
-      .filter(_ > 0)
-      .getOrElse(100)
+  private val SubscriptKeyChunkSize: Int = {
+    // Each key contributes 2 markers, and the native protocol caps a statement at 65535, so anything
+    // at/above ~32K would reintroduce the very overflow this chunking prevents. Reject an
+    // out-of-range override loudly instead of silently falling back to the default.
+    val MaxChunk = 30000
+    sys.props.get("scylla.migrator.subscriptKeyChunkSize") match {
+      case None => 100
+      case Some(raw) =>
+        val parsed = scala.util.Try(raw.trim.toInt).toOption
+        parsed.filter(n => n > 0 && n <= MaxChunk).getOrElse {
+          throw new IllegalArgumentException(
+            s"-Dscylla.migrator.subscriptKeyChunkSize=$raw is invalid: expected an integer in " +
+              s"[1, $MaxChunk]. Each collection key uses 2 bind markers, so a larger chunk can " +
+              "exceed the native-protocol limit of 65535 markers per statement."
+          )
+        }
+    }
+  }
 
   case class Selection(
     columnRefs: List[ColumnRef],
@@ -112,6 +124,39 @@ object Cassandra {
 
   private def quoteCqlIdentifier(id: String): String =
     "\"" + id.replace("\"", "\"\"") + "\""
+
+  /** Enforce the element-count fail-safe on the RAW decoded collection size, BEFORE any
+    * copy/sort/group/point-read, so a pathological cell fails fast instead of OOMing (or issuing
+    * thousands of point reads) first. Object-level so every path that expands a non-frozen
+    * collection applies the same cap: the append builder ([[collectionAppendRows]]) and the
+    * ScyllaDB-2026.2 subscript metadata read ([[readRawRddSubscript]]).
+    */
+  private def enforceSizeLimits(size: Int): Unit = {
+    if (LargeCollectionHardLimit > 0 && size > LargeCollectionHardLimit)
+      throw new IllegalStateException(
+        s"Non-frozen collection cell has $size elements, exceeding the hard limit of " +
+          s"$LargeCollectionHardLimit. Per-element TTL/WRITETIME preservation expands each element " +
+          "into collection-append updates, and a collection this large risks executor OOM / write " +
+          "amplification. Raise or disable the cap with -Dscylla.migrator.maxCollectionElements=<n> " +
+          "(non-positive disables) if this size is expected. Note: the property must be set on the " +
+          "EXECUTORS (spark.executor.extraJavaOptions) — it is read where the expansion happens."
+      )
+    if (size > LargeCollectionWarnThreshold)
+      log.warn(
+        s"Non-frozen collection cell has $size elements; per-element TTL/WRITETIME " +
+          "preservation may expand it into up to that many separate collection-append updates " +
+          "(one per distinct TTL/WRITETIME group). Very large collections can cause high " +
+          "executor memory/GC pressure and slow writes."
+      )
+  }
+
+  /** Number of elements in a decoded non-frozen collection value (0 for anything unexpected). */
+  private def decodedCollectionSize(value: Any): Int = value match {
+    case m: scala.collection.Map[_, _] => m.size
+    case s: scala.collection.Seq[_]    => s.size
+    case s: scala.collection.Set[_]    => s.size
+    case _                             => 0
+  }
 
   /** Decide how to read per-element collection metadata from the source by PREPARing (no execution,
     * no data read) probe statements, so the choice is made before the distributed read:
@@ -155,9 +200,8 @@ object Cassandra {
 
   /** Bind a runtime value into a driver statement by its Java runtime class. Collection keys are
     * limited to the text/int family (see [[mapKeyOrdering]]), which already map to default driver
-    * codecs. Primary-key values are pre-converted by the caller for the two widened/decoded types
-    * that would otherwise miss a codec (`timestamp`->Instant, `blob`->ByteBuffer); all other PK
-    * types reach here already codec-compatible.
+    * codecs. Primary-key values must be pre-converted by [[driverPkBindValue]] first: the base scan
+    * decodes several CQL types into Java types the driver has no codec for.
     */
   private def driverBindValue(v: Any): AnyRef = v match {
     case null                 => null
@@ -169,6 +213,100 @@ object Cassandra {
     case i: Int               => java.lang.Integer.valueOf(i)
     case l: Long              => java.lang.Long.valueOf(l)
     case other                => other.asInstanceOf[AnyRef]
+  }
+
+  /** How a primary-key value must be converted before it can be bound into a subscript point read.
+    *
+    * The base scan hands us values already decoded by the connector's `CassandraSQLRow` (and then
+    * by [[convertValue]]/[[widenTimestampValue]]), which turns several CQL types into Java types
+    * the driver has NO codec for — binding them by runtime class throws `CodecNotFoundException`
+    * deep inside a Spark task. Verified against spark-scylladb-connector 4.1.3:
+    *
+    *   - `uuid`/`timeuuid` -> `String` (`UUID.toString`)
+    *   - `inet` -> `String` (`InetAddress.getHostAddress`)
+    *   - `timestamp` -> `java.sql.Timestamp` -> `Long` epoch-millis
+    *   - `date` -> `java.sql.Date` -> (a `java.util.Date`, so also) `Long` epoch-millis
+    *   - `time` -> `Long` nanoseconds-of-day
+    *   - `varint`/`decimal` -> `org.apache.spark.sql.types.Decimal`
+    *   - `blob` -> `Array[Byte]`
+    *
+    * Note that `bigint`, `timestamp`, `date` and `time` all arrive as `Long`, which is exactly why
+    * the conversion must be driven by the DECLARED column type rather than the runtime class.
+    */
+  private sealed trait PkBindKind
+  private object PkBindKind {
+    case object AsIs extends PkBindKind
+    case object TimestampMillis extends PkBindKind
+    case object Blob extends PkBindKind
+    case object Uuid extends PkBindKind
+    case object Inet extends PkBindKind
+    case object DateMillis extends PkBindKind
+    case object TimeNanos extends PkBindKind
+    case object VarInt extends PkBindKind
+    case object BigDecimal extends PkBindKind
+  }
+
+  /** Classify a primary-key column for point-read binding, failing fast on any type whose decoded
+    * representation we cannot map back to a driver-bindable value. Failing here (on the driver,
+    * before the distributed read) beats a `CodecNotFoundException` per task.
+    */
+  private def pkBindKindOf(column: ColumnDef): PkBindKind = {
+    // Qualified alias: several connector type names (e.g. TimestampType) collide with the
+    // `org.apache.spark.sql.types` names imported at the top of this file.
+    import com.datastax.spark.connector.{ types => cql }
+    column.columnType match {
+      case cql.TimestampType               => PkBindKind.TimestampMillis
+      case cql.BlobType                    => PkBindKind.Blob
+      case cql.UUIDType | cql.TimeUUIDType => PkBindKind.Uuid
+      case cql.InetType                    => PkBindKind.Inet
+      case cql.DateType                    => PkBindKind.DateMillis
+      case cql.TimeType                    => PkBindKind.TimeNanos
+      case cql.VarIntType                  => PkBindKind.VarInt
+      case cql.DecimalType                 => PkBindKind.BigDecimal
+      case cql.AsciiType | cql.TextType | cql.VarCharType | cql.IntType | cql.BigIntType |
+          cql.SmallIntType | cql.TinyIntType | cql.BooleanType | cql.FloatType | cql.DoubleType |
+          cql.CounterType =>
+        PkBindKind.AsIs
+      case other =>
+        throw new IllegalStateException(
+          s"preserveCollectionTimestamps against a subscript-only source (ScyllaDB 2026.2+) cannot " +
+            s"bind primary-key column '${column.columnName}' of type $other in the per-element " +
+            "metadata point read. Freeze the non-frozen collection column(s), disable " +
+            "preserveCollectionTimestamps, or migrate from a Cassandra 5.0+ source (which reads " +
+            "element metadata in a single scan and needs no point reads)."
+        )
+    }
+  }
+
+  /** Convert one decoded primary-key value into a driver-bindable value for its declared type. */
+  private def driverPkBindValue(kind: PkBindKind, raw: Any): AnyRef = {
+    val converted: Any = (kind, raw) match {
+      case (_, null)                                  => null
+      case (PkBindKind.AsIs, v)                       => v
+      case (PkBindKind.TimestampMillis, n: Number)    => java.time.Instant.ofEpochMilli(n.longValue)
+      case (PkBindKind.Blob, b: Array[Byte])          => java.nio.ByteBuffer.wrap(b)
+      case (PkBindKind.Uuid, s: String)               => java.util.UUID.fromString(s)
+      case (PkBindKind.Uuid, u: java.util.UUID)       => u
+      case (PkBindKind.Inet, s: String)               => java.net.InetAddress.getByName(s)
+      case (PkBindKind.Inet, a: java.net.InetAddress) => a
+      // `java.sql.Date.getTime` is midnight in the JVM default zone; `new java.sql.Date(millis)`
+      // is its exact inverse in that same zone, so the round-trip is lossless.
+      case (PkBindKind.DateMillis, n: Number)        => new java.sql.Date(n.longValue).toLocalDate
+      case (PkBindKind.DateMillis, d: java.sql.Date) => d.toLocalDate
+      case (PkBindKind.TimeNanos, n: Number)         => java.time.LocalTime.ofNanoOfDay(n.longValue)
+      case (PkBindKind.VarInt, d: org.apache.spark.sql.types.Decimal) =>
+        d.toJavaBigDecimal.toBigIntegerExact
+      case (PkBindKind.VarInt, b: java.math.BigInteger)                   => b
+      case (PkBindKind.BigDecimal, d: org.apache.spark.sql.types.Decimal) => d.toJavaBigDecimal
+      case (PkBindKind.BigDecimal, b: java.math.BigDecimal)               => b
+      case (kind, v) =>
+        throw new IllegalStateException(
+          s"Primary-key value of runtime type ${v.getClass.getName} does not match its expected " +
+            s"decoded representation for bind kind $kind. This is a migrator bug; please report it " +
+            "with the source table's schema."
+        )
+    }
+    driverBindValue(converted)
   }
 
   /** Read the source into an `RDD[Row]` matching `selection.schema` when the server only supports
@@ -240,19 +378,9 @@ object Cassandra {
     val pkColumns: Seq[ColumnDef] = tableDef.partitionKey ++ tableDef.clusteringColumns
     val pkNames: Seq[String] = pkColumns.map(_.columnName)
     val pkOrdinals: Seq[Int] = pkNames.map(baseFieldIndex)
-    // Per-PK bind conversion tag. The base scan already widened `timestamp`->Long(epoch-ms) and
-    // yields `blob`->Array[Byte], neither of which has a matching driver default codec, so binding
-    // them by runtime class fails (Long is bound as bigint, byte[] has no codec). Convert those two
-    // back to the driver-native type (Instant / ByteBuffer) before binding; everything else
-    // (text/int/bigint/uuid/inet/decimal/varint/boolean/float/double) is already codec-compatible.
-    //   0 = pass-through, 1 = timestamp(Long->Instant), 2 = blob(Array[Byte]->ByteBuffer)
-    val pkBindKinds: Seq[Int] = pkColumns.map { c =>
-      c.columnType match {
-        case com.datastax.spark.connector.types.TimestampType => 1
-        case com.datastax.spark.connector.types.BlobType      => 2
-        case _                                                => 0
-      }
-    }
+    // Per-PK bind conversion, driven by the DECLARED column type (see `pkBindKindOf`). Resolved on
+    // the driver so an unbindable primary-key type aborts before the distributed read starts.
+    val pkBindKinds: Seq[PkBindKind] = pkColumns.map(pkBindKindOf)
     // (columnName, ordinal-in-base-row, isMap, elementSorter)
     val nfInfo: Seq[(String, Int, Boolean, ElementSorter[_])] =
       nonFrozen.map { c =>
@@ -291,17 +419,31 @@ object Cassandra {
       val session = connector.openSession()
       val stmtCache = mutable.Map.empty[(String, Int), PreparedStatement]
       val dropped = new java.util.concurrent.atomic.AtomicLong(0L)
-      val taskCtxOpt = Option(org.apache.spark.TaskContext.get())
-      taskCtxOpt.foreach(_.addTaskCompletionListener[Unit] { _ =>
-        if (dropped.get() > 0L)
-          log.warn(
-            s"Subscript metadata read dropped ${dropped.get()} collection element(s) whose " +
-              s"per-element WRITETIME was null at point-read time (element absent — e.g. a " +
-              s"concurrent delete). The migrator requires a quiescent source; resume/re-run once " +
-              s"writes have stopped if this is unexpected."
+      // The session must outlive this method (rows are consumed lazily downstream), so it can only
+      // be released by a task-completion hook. Without a TaskContext nothing would ever close it —
+      // refuse rather than leak a pooled session, and rather than close it early and break the
+      // point reads mid-iteration.
+      org.apache.spark.TaskContext.get() match {
+        case null =>
+          session.close()
+          throw new IllegalStateException(
+            "Subscript per-element metadata read requires a Spark TaskContext (it holds a CQL " +
+              "session open for the lifetime of the partition). This partition was evaluated " +
+              "outside a Spark task, which is unsupported."
           )
-        session.close()
-      })
+        case ctx =>
+          ctx.addTaskCompletionListener[Unit] { _ =>
+            if (dropped.get() > 0L)
+              log.warn(
+                s"Subscript metadata read dropped ${dropped.get()} collection element(s) whose " +
+                  s"per-element WRITETIME was null at point-read time (element absent — e.g. a " +
+                  s"concurrent delete). NOTE: elements ADDED to the source after the base scan are " +
+                  s"invisible to this read and are not counted here. The migrator requires a " +
+                  s"quiescent source; re-run once writes have stopped if this is unexpected."
+              )
+            session.close()
+          }
+      }
 
       val pkBindKindsArr = pkBindKinds.toArray
       val pkOrdinalsArr = pkOrdinals.toArray
@@ -318,6 +460,12 @@ object Cassandra {
         pkBinds: Seq[AnyRef]
       ): (Any, Seq[Integer], Seq[java.lang.Long]) = {
         if (row.isNullAt(ord)) return (null, null, null)
+
+        // Apply the element-count fail-safe on the RAW decoded size FIRST. Everything below this
+        // line is proportional to the element count — the decorate-sort, two boxed metadata arrays,
+        // and ceil(n / SubscriptKeyChunkSize) synchronous point reads — so checking here (rather
+        // than later in `collectionAppendRows`) is what makes the cap actually protective.
+        enforceSizeLimits(decodedCollectionSize(row.get(ord)))
 
         // (subscript-key, retained-value): for a map the value is the map value; for a set/list the
         // element is its own key and value.
@@ -405,15 +553,7 @@ object Cassandra {
         val pkBinds: Seq[AnyRef] =
           pkOrdinalsArr.indices.map { i =>
             val o = pkOrdinalsArr(i)
-            val raw = if (row.isNullAt(o)) null else row.get(o)
-            val converted: Any = (pkBindKindsArr(i), raw) match {
-              case (_, null)              => null
-              case (1, l: Long)           => java.time.Instant.ofEpochMilli(l)
-              case (1, l: java.lang.Long) => java.time.Instant.ofEpochMilli(l.longValue)
-              case (2, b: Array[Byte])    => java.nio.ByteBuffer.wrap(b)
-              case (_, v)                 => v
-            }
-            driverBindValue(converted)
+            driverPkBindValue(pkBindKindsArr(i), if (row.isNullAt(o)) null else row.get(o))
           }
 
         val meta: Map[String, (Any, Seq[Integer], Seq[java.lang.Long])] =
@@ -502,15 +642,28 @@ object Cassandra {
     * for key types with a reproducible ordering (see [[mapKeyOrdering]]).
     */
   private def unsupportedCollectionReason(column: ColumnDef): Option[String] =
-    column.columnType match {
-      case _: CqlListType[_] =>
-        Some(s"'${column.columnName}' (non-frozen list)")
-      case m: CqlMapType[_, _] if mapKeyOrdering(m.keyType).isEmpty =>
-        Some(s"'${column.columnName}' (non-frozen map with unsupported key type ${m.keyType})")
-      case s: CqlSetType[_] if mapKeyOrdering(s.elemType).isEmpty =>
-        Some(s"'${column.columnName}' (non-frozen set with unsupported element type ${s.elemType})")
-      case _ => None
-    }
+    if (column.isStatic)
+      // A static cell belongs to the PARTITION, but the base scan yields it once per clustering row,
+      // so the append pass would replay it once per row. CQL also rejects an UPDATE that restricts
+      // clustering columns while modifying only static columns, which is exactly the statement the
+      // connector would emit here (the append schema carries the full primary key).
+      Some(
+        s"'${column.columnName}' (static non-frozen collection: per-element appends would be " +
+          "replayed once per clustering row, and CQL forbids restricting clustering columns in an " +
+          "UPDATE that modifies only static columns)"
+      )
+    else
+      column.columnType match {
+        case _: CqlListType[_] =>
+          Some(s"'${column.columnName}' (non-frozen list)")
+        case m: CqlMapType[_, _] if mapKeyOrdering(m.keyType).isEmpty =>
+          Some(s"'${column.columnName}' (non-frozen map with unsupported key type ${m.keyType})")
+        case s: CqlSetType[_] if mapKeyOrdering(s.elemType).isEmpty =>
+          Some(
+            s"'${column.columnName}' (non-frozen set with unsupported element type ${s.elemType})"
+          )
+        case _ => None
+      }
 
   /** The ordering used to re-align a non-frozen collection's decoded elements with its
     * element-order `WRITETIME`/`TTL` lists: map keys for maps, element values for sets (Cassandra
@@ -603,6 +756,15 @@ object Cassandra {
     // via collection-append writes.
     val nonFrozen = nonFrozenCollectionColumns(tableDef)
 
+    // Multi-cell columns that are NOT collections: non-frozen UDTs. The connector reports
+    // `isCollection == false` for `UserDefinedType` while `isMultiCell == !isFrozen`, so these are
+    // invisible to `nonFrozenCollectionColumns` yet their TTL()/WRITETIME() still return one value
+    // PER SUBFIELD. Left unguarded they would be declared with SCALAR metadata sidecars against
+    // list-valued metadata. The per-element machinery is collection-shaped (`col = col + ?`) and
+    // cannot reproduce UDT subfield identity, so reject rather than mis-handle.
+    val multiCellNonCollection =
+      tableDef.regularColumns.filter(c => c.columnType.isMultiCell && !c.columnType.isCollection)
+
     // Timestamp preservation appends internal metadata columns named `ttl`/`writetime`, plus a
     // `<col>_ttl`/`<col>_writetime` sidecar for every regular column. `ttl` and `writetime` are
     // non-reserved CQL keywords, so a real column may legitimately be named `ttl`/`writetime` (or
@@ -634,6 +796,16 @@ object Cassandra {
             "'<column>_ttl'/'<column>_writetime'. The source table has column(s) colliding with " +
             s"these reserved names: ${reservedNameCollisions.mkString(", ")}. Rename the source " +
             "column(s), or set 'preserveTimestamps' to false to continue."
+        )
+      )
+    else if (preserveTimesRequest && multiCellNonCollection.nonEmpty)
+      Left(
+        new Exception(
+          "TTL/Writetime preservation is unsupported for non-frozen (multi-cell) non-collection " +
+            s"column(s): ${multiCellNonCollection.map(_.columnName).mkString(", ")} (e.g. a " +
+            "non-frozen UDT). Their TTL()/WRITETIME() return one value per subfield, which cannot " +
+            "be represented as a scalar or replayed as a collection append. Freeze the column(s), " +
+            "or set 'preserveTimestamps' to false to continue."
         )
       )
     else if (nonFrozen.nonEmpty && preserveTimesRequest && !preserveCollectionTimesRequest)
@@ -813,6 +985,25 @@ object Cassandra {
     if (wts.hasNext) Some(wts.max) else None
   }
 
+  /** TTL to stamp on a base row whose liveness comes only from collection cells (no live scalar
+    * cell in its group). Row-marker liveness must reflect the LATEST cell expiry: permanent when
+    * any element is permanent (TTL 0/absent), otherwise the maximum finite element TTL. A hardcoded
+    * TTL 0 would leave the target with an empty, never-expiring row once every TTL'd element has
+    * expired, while the source — whose liveness came only from those cells — has none (C1).
+    */
+  private def markerTtlFor(row: Row, perElementTtlOrdinals: Seq[Int]): Integer = {
+    val ttls = perElementTtlOrdinals.iterator.flatMap { o =>
+      if (o < 0 || o >= row.length || row.isNullAt(o)) Iterator.empty
+      else
+        asNumberSeq(row.get(o)).iterator.map {
+          case n: Number => n.intValue()
+          case _         => 0 // null TTL slot => no TTL => permanent
+        }
+    }.toVector
+    if (ttls.isEmpty || ttls.exists(_ <= 0)) Integer.valueOf(0)
+    else Integer.valueOf(ttls.max)
+  }
+
   def explodeBaseRow(
     row: Row,
     baseSchema: StructType,
@@ -831,11 +1022,18 @@ object Cassandra {
       // columns were all null (a live scalar cell always has a writetime).
       maxPerElementWritetime(row, perElementWritetimeOrdinals) match {
         case Some(wt) =>
+          // C1 applies here too: such a group also carries `explodeRow`'s `ttl.getOrElse(0)` — i.e.
+          // TTL 0 = a permanently live row marker — even though its liveness comes solely from
+          // collection cells that DO expire. Stamp both dimensions from the collection, exactly as
+          // the collection-only branch below does, or the target keeps an empty never-expiring row.
+          val collectionTtl = markerTtlFor(row, perElementTtlOrdinals)
           rows.map { r =>
             val vals = r.toSeq.toArray
             val wtIdx = vals.length - 1
+            val ttlIdx = vals.length - 2
             if (vals(wtIdx) == CassandraOption.Unset) {
-              vals(wtIdx) = java.lang.Long.valueOf(wt)
+              vals(wtIdx)  = java.lang.Long.valueOf(wt)
+              vals(ttlIdx) = collectionTtl
               Row(ArraySeq.unsafeWrapArray(vals): _*)
             } else r
           }
@@ -852,23 +1050,8 @@ object Cassandra {
         maxPerElementWritetime(row, perElementWritetimeOrdinals)
           .map(java.lang.Long.valueOf)
           .getOrElse(CassandraOption.Unset)
-      // C1: mirror the marker's TTL to the collection's latest-cell expiry. A hardcoded TTL 0 (=no
-      // TTL) makes the primary-key marker permanently live, so after every TTL'd element expires the
-      // target keeps an empty, never-expiring row that the source (whose liveness came only from the
-      // now-expired cells) no longer has. Row-marker liveness must reflect the LATEST cell expiry:
-      // permanent if any element is permanent (TTL 0/absent), else the max finite element TTL.
-      val markerTtl: Integer = {
-        val ttls = perElementTtlOrdinals.iterator.flatMap { o =>
-          if (o < 0 || o >= row.length || row.isNullAt(o)) Iterator.empty
-          else
-            asNumberSeq(row.get(o)).iterator.map {
-              case n: Number => n.intValue()
-              case _         => 0 // null TTL slot => no TTL => permanent
-            }
-        }.toVector
-        if (ttls.isEmpty || ttls.exists(_ <= 0)) Integer.valueOf(0)
-        else Integer.valueOf(ttls.max)
-      }
+      // C1: mirror the marker's TTL to the collection's latest-cell expiry (see `markerTtlFor`).
+      val markerTtl: Integer = markerTtlFor(row, perElementTtlOrdinals)
       val newValues = baseSchema.fields.map { field =>
         primaryKeyOrdinals
           .get(field.name)
@@ -938,26 +1121,6 @@ object Cassandra {
               "timestamp. Aborting to avoid silently dropping it."
           )
       }
-
-    // Enforce the size cap on the RAW decoded collection size, before any copy/sort/group, so a
-    // pathological cell fails fast instead of OOMing during `toIndexedSeq`/`sortElements`.
-    def enforceSizeLimits(size: Int): Unit = {
-      if (LargeCollectionHardLimit > 0 && size > LargeCollectionHardLimit)
-        throw new IllegalStateException(
-          s"Non-frozen collection cell has $size elements, exceeding the hard limit of " +
-            s"$LargeCollectionHardLimit. Per-element TTL/WRITETIME preservation expands each element " +
-            "into collection-append updates, and a collection this large risks executor OOM / write " +
-            "amplification. Raise or disable the cap with -Dscylla.migrator.maxCollectionElements=<n> " +
-            "(non-positive disables) if this size is expected."
-        )
-      if (size > LargeCollectionWarnThreshold)
-        log.warn(
-          s"Non-frozen collection cell has $size elements; per-element TTL/WRITETIME " +
-            "preservation may expand it into up to that many separate collection-append updates " +
-            "(one per distinct TTL/WRITETIME group). Very large collections can cause high " +
-            "executor memory/GC pressure and slow writes."
-        )
-    }
 
     def rowsFrom(elements: IndexedSeq[Any], rebuild: Seq[Any] => Any): Seq[Row] = {
       // Both sidecars must be element-aligned. On every real read path `TTL(col)` returns a list the
@@ -1418,12 +1581,21 @@ object Cassandra {
         Seq(StructField("ttl", IntegerType, true), StructField("writetime", LongType, true))
     )
 
-    if (perElementNames.nonEmpty)
+    if (perElementNames.nonEmpty) {
       log.info(
         s"Parquet restore: per-element collection columns detected " +
           s"(${perElementNames.toSeq.sorted.mkString(", ")}); they will be replayed as " +
           "collection-append passes after the base write."
       )
+      // Same rationale as F5 in `readDataframe`: the base explode and each collection-append pass
+      // are SEPARATE Spark jobs derived from this one frame, so without caching the Parquet dataset
+      // is re-read 1 + K times (K = per-element collection columns). This path has no incremental
+      // savepointing to compensate — file-level tracking is deliberately disabled for multi-pass
+      // writes — so the re-read is pure waste. `ScyllaMigratorBase.migrate` unpersists
+      // `sourceDF.dataFrame` (this same frame) in its `finally`, and the validator repair path
+      // unpersists its own upstream, so this is self-cleaning.
+      df.persist(StorageLevel.MEMORY_AND_DISK)
+    }
     log.info("Base schema after explosion from per-column metadata:")
     log.info(finalSchema.treeString)
 
@@ -1579,7 +1751,12 @@ object Cassandra {
           // is re-read once per pass (1 + K scans for K collection columns), and worse, a source
           // mutated between passes could be observed inconsistently (base row from one snapshot,
           // appended elements from another). Persisting pins a single snapshot read once and shared
-          // across passes. Safe w.r.t. savepoints: the write-side TokenRangeAccumulator derives
+          // across passes. CAVEAT: `MEMORY_AND_DISK` is best-effort — if a block is evicted or an
+          // executor is lost, Spark recomputes that partition, and on the ScyllaDB-2026.2 subscript
+          // path recomputation re-issues point reads at a LATER wall-clock time (decayed TTLs, a
+          // different view of concurrent deletes). The single-snapshot property therefore holds for
+          // the common case, not unconditionally; a quiescent source is what makes it exact.
+          // Safe w.r.t. savepoints: the write-side TokenRangeAccumulator derives
           // ranges from each row's partition-key token, independent of how the read is
           // materialized. `migrate` unpersists it once all passes finish.
           if (perElementNames.nonEmpty)

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -3,6 +3,7 @@ package com.scylladb.migrator.readers
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.{ CassandraConnector, ColumnDef, Schema, TableDef }
 import com.datastax.spark.connector.rdd.ReadConf
+import com.datastax.oss.driver.api.core.cql.{ PreparedStatement, Row => DriverRow }
 import com.datastax.spark.connector.rdd.partitioner.dht.Token
 import com.datastax.spark.connector.types.{
   AsciiType,
@@ -44,8 +45,9 @@ import com.scylladb.migrator.ConsistencyLevelUtils
 import com.scylladb.migrator.scylla.{ CollectionAppendWrite, SourceDataFrame }
 
 import scala.collection.immutable.ArraySeq
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-import scala.util.control.NonFatal
+import scala.util.Try
 import java.nio.charset.StandardCharsets
 
 object Cassandra {
@@ -74,6 +76,18 @@ object Cassandra {
     timestampColumns: Option[TimestampColumns]
   )
 
+  /** How the source server exposes per-element `WRITETIME()`/`TTL()` for non-frozen collections.
+    *
+    *   - [[ArrayMetadataRead]]: Cassandra 5.0+ — the collection-wide `WRITETIME(col)`/`TTL(col)`
+    *     form returns element-aligned lists in a single scan (the default, cheapest path).
+    *   - [[SubscriptMetadataRead]]: ScyllaDB 2026.2+ — only the per-element subscript form
+    *     `WRITETIME(col[key])`/`TTL(col[key])` is accepted, so element metadata is fetched via a
+    *     per-row point read (see [[readRawRddSubscript]]).
+    */
+  sealed trait MetadataReadStrategy
+  case object ArrayMetadataRead extends MetadataReadStrategy
+  case object SubscriptMetadataRead extends MetadataReadStrategy
+
   /** Regular columns that are non-frozen (multi-cell) collections. These keep per-element
     * TTL/WRITETIME (one metadata value per element), so `TTL()`/`WRITETIME()` on them return a list
     * aligned with the collection's elements rather than a scalar.
@@ -84,33 +98,237 @@ object Cassandra {
   private def quoteCqlIdentifier(id: String): String =
     "\"" + id.replace("\"", "\"\"") + "\""
 
-  /** Fail fast if the source server cannot return per-element `WRITETIME()`/`TTL()` for a
-    * non-frozen collection column. We only PREPARE the statement (no execution, no data read); on
-    * servers older than Cassandra 5.0 / older ScyllaDB this fails at semantic validation, letting
-    * us surface a clear, actionable error before launching the distributed read.
+  /** Decide how to read per-element collection metadata from the source by PREPARing (no execution,
+    * no data read) probe statements, so the choice is made before the distributed read:
+    *
+    *   1. `WRITETIME(col), TTL(col)` (whole-collection list form) — Cassandra 5.0+ ⇒
+    *      [[ArrayMetadataRead]].
+    *   2. else `WRITETIME(col[?]), TTL(col[?])` (per-element subscript form) — ScyllaDB 2026.2+ ⇒
+    *      [[SubscriptMetadataRead]].
+    *   3. else neither is accepted ⇒ fail fast with the same actionable error as the array probe.
+    *
+    * `col` is the first non-frozen collection column; all such columns share the same server, so a
+    * single probe determines the strategy for the table.
     */
-  private def assertNonFrozenCollectionMetadataReadable(
+  private[migrator] def detectMetadataReadStrategy(
     connector: CassandraConnector,
     keyspace: String,
     table: String,
     nonFrozen: Seq[ColumnDef]
-  ): Unit =
-    nonFrozen.headOption.foreach { col =>
-      val c = quoteCqlIdentifier(col.columnName)
-      val cql =
-        s"SELECT WRITETIME($c), TTL($c) FROM " +
-          s"${quoteCqlIdentifier(keyspace)}.${quoteCqlIdentifier(table)} LIMIT 1"
-      try connector.withSessionDo(_.prepare(cql))
-      catch {
-        case NonFatal(e) =>
+  ): MetadataReadStrategy =
+    nonFrozen.headOption match {
+      case None => ArrayMetadataRead
+      case Some(col) =>
+        val c = quoteCqlIdentifier(col.columnName)
+        val from =
+          s"FROM ${quoteCqlIdentifier(keyspace)}.${quoteCqlIdentifier(table)} LIMIT 1"
+        def canPrepare(cql: String): Boolean =
+          Try(connector.withSessionDo(_.prepare(cql))).isSuccess
+
+        if (canPrepare(s"SELECT WRITETIME($c), TTL($c) $from"))
+          ArrayMetadataRead
+        else if (canPrepare(s"SELECT WRITETIME($c[?]), TTL($c[?]) $from"))
+          SubscriptMetadataRead
+        else
           throw new IllegalStateException(
             s"preserveCollectionTimestamps is enabled, but the source cannot read per-element " +
-              s"WRITETIME()/TTL() on non-frozen collection column '${col.columnName}'. This " +
-              s"requires Cassandra 5.0+ or a modern ScyllaDB. Underlying error: ${e.getMessage}",
-            e
+              s"WRITETIME()/TTL() on non-frozen collection column '${col.columnName}' via either " +
+              s"the collection-wide form (Cassandra 5.0+) or the element-subscript form " +
+              s"(ScyllaDB 2026.2+). This feature requires one of those source versions."
           )
+    }
+
+  /** Bind a runtime value into a driver statement. Collection keys are limited to text/int-family
+    * (see [[mapKeyOrdering]]) and primary keys to types with default driver codecs; both bind by
+    * their Java runtime class, so no explicit codec handling is needed for the supported types.
+    */
+  private def driverBindValue(v: Any): AnyRef = v match {
+    case null                 => null
+    case s: String            => s
+    case n: java.lang.Integer => n
+    case n: java.lang.Long    => n
+    case n: java.lang.Short   => n
+    case n: java.lang.Byte    => n
+    case i: Int               => java.lang.Integer.valueOf(i)
+    case l: Long              => java.lang.Long.valueOf(l)
+    case other                => other.asInstanceOf[AnyRef]
+  }
+
+  /** Read the source into an `RDD[Row]` matching `selection.schema` when the server only supports
+    * the per-element SUBSCRIPT form of `WRITETIME()`/`TTL()` (ScyllaDB 2026.2+).
+    *
+    * Two phases, producing exactly the same array-sidecar schema as the Cassandra 5.0 array path so
+    * every downstream stage (explode, multi-pass write, validation) is reused unchanged:
+    *   1. Base scan (connector): PK + all regular column VALUES + scalar `WRITETIME`/`TTL` sidecars
+    *      (Scylla supports scalar). Non-frozen collection metadata columns are omitted here.
+    *   2. Per-row point read (driver): for each non-frozen collection, sort its decoded
+    *      elements/entries with the column's ordering (so the arrays align with the order the
+    *      downstream explode re-sorts into), then one `SELECT WRITETIME(col[?]), TTL(col[?]), ...`
+    *      point read fetches all element metadata, assembled into element-aligned arrays.
+    */
+  private def readRawRddSubscript(
+    spark: SparkSession,
+    connector: CassandraConnector,
+    source: SourceSettings.Cassandra,
+    readConf: ReadConf,
+    tableDef: TableDef,
+    selection: Selection,
+    nonFrozen: Seq[ColumnDef],
+    tokenRangesToSkip: Set[(Token[_], Token[_])]
+  ): RDD[Row] = {
+    val nfNames = nonFrozen.map(_.columnName).toSet
+
+    // Phase 1 selection: keep every column value + scalar sidecars, but DROP the per-element
+    // collection sidecars (Scylla rejects `WRITETIME(col)`/`TTL(col)` on non-frozen collections).
+    val baseColumnRefs: List[ColumnRef] =
+      (tableDef.partitionKey.map(_.ref) ++
+        tableDef.clusteringColumns.map(_.ref) ++
+        tableDef.regularColumns.flatMap { column =>
+          val colName = column.columnName
+          if (nfNames.contains(colName)) List(column.ref)
+          else
+            List(
+              column.ref,
+              colName.ttl as s"${colName}_ttl",
+              colName.writeTime as s"${colName}_writetime"
+            )
+        }).toList
+
+    val baseSchema = StructType(selection.schema.fields.filterNot { f =>
+      nfNames.exists(n => f.name == s"${n}_ttl" || f.name == s"${n}_writetime")
+    })
+
+    val baseSelectRDD = spark.sparkContext
+      .cassandraTable[CassandraSQLRow](
+        source.keyspace,
+        source.table,
+        (s, e) => !tokenRangesToSkip.contains((s, e))
+      )
+      .withConnector(connector)
+      .withReadConf(readConf)
+      .select(baseColumnRefs: _*)
+
+    val baseFilteredRDD = source.where match {
+      case Some(filter) => baseSelectRDD.where(filter)
+      case None         => baseSelectRDD
+    }
+
+    val baseRdd = baseFilteredRDD
+      .asInstanceOf[RDD[Row]]
+      .map(row => Row.fromSeq(row.toSeq.map(v => widenTimestampValue(convertValue(v)))))
+
+    // Everything below is captured by the executor closure, so keep it serializable (primitives,
+    // Strings, the Serializable `ElementSorter`, and the Serializable `connector`).
+    val baseFieldIndex: Map[String, Int] = baseSchema.fieldNames.zipWithIndex.toMap
+    val pkNames: Seq[String] =
+      (tableDef.partitionKey ++ tableDef.clusteringColumns).map(_.columnName)
+    val pkOrdinals: Seq[Int] = pkNames.map(baseFieldIndex)
+    // (columnName, ordinal-in-base-row, isMap, elementSorter)
+    val nfInfo: Seq[(String, Int, Boolean, ElementSorter[_])] =
+      nonFrozen.map { c =>
+        val sorter = collectionElementOrdering(c.columnType).getOrElse(
+          throw new IllegalStateException(
+            s"Non-frozen collection '${c.columnName}' has no supported element ordering; " +
+              "this should have been rejected by determineCopyType."
+          )
+        )
+        (
+          c.columnName,
+          baseFieldIndex(c.columnName),
+          c.columnType.isInstanceOf[CqlMapType[_, _]],
+          sorter
+        )
+      }
+    val keyspaceQ = quoteCqlIdentifier(source.keyspace)
+    val tableQ = quoteCqlIdentifier(source.table)
+    val whereClause = pkNames.map(n => s"${quoteCqlIdentifier(n)} = ?").mkString(" AND ")
+    val targetFields = selection.schema.fields
+    // Map a target array-sidecar field name back to its collection column, if any.
+    def collectionOfSidecar(fieldName: String): Option[(String, Boolean)] =
+      nfNames.collectFirst {
+        case n if fieldName == s"${n}_ttl"       => (n, true)
+        case n if fieldName == s"${n}_writetime" => (n, false)
+      }
+
+    baseRdd.mapPartitions { rows =>
+      connector.withSessionDo { session =>
+        val stmtCache = mutable.Map.empty[(String, Int), PreparedStatement]
+
+        def elementMetadata(row: Row): Map[String, (Seq[Integer], Seq[java.lang.Long])] =
+          nfInfo.map { case (name, ord, isMap, sorter) =>
+            if (row.isNullAt(ord)) name -> ((null: Seq[Integer]), (null: Seq[java.lang.Long]))
+            else {
+              val sortedKeys: IndexedSeq[Any] =
+                if (isMap)
+                  sorter
+                    .sortEntries(
+                      row.get(ord).asInstanceOf[scala.collection.Map[Any, Any]].toIndexedSeq
+                    )
+                    .map(_._1)
+                else
+                  sorter.sortElements(
+                    row.get(ord).asInstanceOf[scala.collection.Seq[Any]].toIndexedSeq
+                  )
+
+              val n = sortedKeys.length
+              if (n == 0)
+                name -> ((IndexedSeq.empty[Integer], IndexedSeq.empty[java.lang.Long]))
+              else {
+                val colQ = quoteCqlIdentifier(name)
+                val projection =
+                  (0 until n)
+                    .map(_ => s"WRITETIME($colQ[?]), TTL($colQ[?])")
+                    .mkString(", ")
+                val cql =
+                  s"SELECT $projection FROM $keyspaceQ.$tableQ WHERE $whereClause"
+                val ps = stmtCache.getOrElseUpdate((name, n), session.prepare(cql))
+
+                // Bind order follows statement text: each key appears twice (WRITETIME, TTL),
+                // then the primary-key values for the WHERE clause.
+                val keyBinds = sortedKeys.flatMap(k => Seq(driverBindValue(k), driverBindValue(k)))
+                val pkBinds =
+                  pkOrdinals.map(o => driverBindValue(if (row.isNullAt(o)) null else row.get(o)))
+                val bound = ps.bind((keyBinds ++ pkBinds).toArray: _*)
+
+                val dr: DriverRow = session.execute(bound).one()
+                val ttls = new Array[Integer](n)
+                val wts = new Array[java.lang.Long](n)
+                var i = 0
+                while (i < n) {
+                  val wtIdx = 2 * i
+                  val ttlIdx = 2 * i + 1
+                  wts(i) =
+                    if (dr == null || dr.isNull(wtIdx)) null
+                    else java.lang.Long.valueOf(dr.getLong(wtIdx))
+                  ttls(i) =
+                    if (dr == null || dr.isNull(ttlIdx)) null
+                    else Integer.valueOf(dr.getInt(ttlIdx))
+                  i += 1
+                }
+                name -> ((ArraySeq.unsafeWrapArray(ttls), ArraySeq.unsafeWrapArray(wts)))
+              }
+            }
+          }.toMap
+
+        rows
+          .map { row =>
+            val meta = elementMetadata(row)
+            val values = targetFields.map { f =>
+              collectionOfSidecar(f.name) match {
+                case Some((col, isTtl)) =>
+                  val (ttlArr, wtArr) = meta(col)
+                  if (isTtl) ttlArr else wtArr
+                case None =>
+                  row.get(baseFieldIndex(f.name))
+              }
+            }
+            Row.fromSeq(ArraySeq.unsafeWrapArray(values.asInstanceOf[Array[Any]]))
+          }
+          .toList
+          .iterator
       }
     }
+  }
 
   /** Unsigned lexicographic ordering over byte arrays, matching Cassandra's `UTF8Type`/`AsciiType`
     * comparator for text map keys.
@@ -1168,34 +1386,55 @@ object Cassandra {
       createSelection(tableDef, origSchema, preserveTimes, source.preserveCollectionTimestamps)
         .fold(throw _, identity)
 
-    if (preserveTimes && source.preserveCollectionTimestamps)
-      assertNonFrozenCollectionMetadataReadable(
-        connector,
-        source.keyspace,
-        source.table,
-        nonFrozenCollectionColumns(tableDef)
-      )
+    val nonFrozen = nonFrozenCollectionColumns(tableDef)
 
-    val selectCassandraRDD = spark.sparkContext
-      .cassandraTable[CassandraSQLRow](
-        source.keyspace,
-        source.table,
-        (s, e) => !tokenRangesToSkip.contains((s, e))
-      )
-      .withConnector(connector)
-      .withReadConf(readConf)
-      .select(selection.columnRefs: _*)
+    // Choose how to read per-element collection metadata: the Cassandra 5.0 array form or the
+    // ScyllaDB 2026.2+ subscript form. Only relevant when per-element preservation is on AND the
+    // table actually has non-frozen collections.
+    val metadataReadStrategy =
+      if (preserveTimes && source.preserveCollectionTimestamps && nonFrozen.nonEmpty)
+        detectMetadataReadStrategy(connector, source.keyspace, source.table, nonFrozen)
+      else ArrayMetadataRead
 
-    val finalCassandraRDD = source.where match {
-      case Some(filter) => selectCassandraRDD.where(filter)
-      case None         => selectCassandraRDD
+    val rdd = metadataReadStrategy match {
+      case SubscriptMetadataRead =>
+        log.info(
+          "Source exposes per-element collection WRITETIME()/TTL() only via the subscript form " +
+            "(ScyllaDB 2026.2+); reading element metadata with per-row point reads."
+        )
+        readRawRddSubscript(
+          spark,
+          connector,
+          source,
+          readConf,
+          tableDef,
+          selection,
+          nonFrozen,
+          tokenRangesToSkip
+        )
+
+      case ArrayMetadataRead =>
+        val selectCassandraRDD = spark.sparkContext
+          .cassandraTable[CassandraSQLRow](
+            source.keyspace,
+            source.table,
+            (s, e) => !tokenRangesToSkip.contains((s, e))
+          )
+          .withConnector(connector)
+          .withReadConf(readConf)
+          .select(selection.columnRefs: _*)
+
+        val finalCassandraRDD = source.where match {
+          case Some(filter) => selectCassandraRDD.where(filter)
+          case None         => selectCassandraRDD
+        }
+
+        finalCassandraRDD
+          .asInstanceOf[RDD[Row]]
+          .map { row =>
+            Row.fromSeq(row.toSeq.map(v => widenTimestampValue(convertValue(v))))
+          }
     }
-
-    val rdd = finalCassandraRDD
-      .asInstanceOf[RDD[Row]]
-      .map { row =>
-        Row.fromSeq(row.toSeq.map(v => widenTimestampValue(convertValue(v))))
-      }
 
     val rawDataframe = spark.createDataFrame(rdd, selection.schema)
 

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala
@@ -22,13 +22,18 @@ import com.scylladb.migrator.Connectors
 import com.scylladb.migrator.config.{ CopyType, SourceSettings }
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
 import org.apache.spark.sql.cassandra.{ CassandraSQLRow, DataTypeConverter }
 import org.apache.spark.sql.types.{
   ArrayType,
+  ByteType,
   DataType,
   IntegerType,
   LongType,
   MapType,
+  MetadataBuilder,
+  ShortType,
+  StringType,
   StructField,
   StructType,
   TimestampType
@@ -51,6 +56,17 @@ object Cassandra {
     * this many separate collection-append updates (one per distinct TTL/WRITETIME group).
     */
   private val LargeCollectionWarnThreshold = 100000
+
+  /** Hard fail-safe on the number of elements in a single non-frozen collection cell. Beyond this,
+    * per-element expansion is treated as pathological (unbounded executor memory / write
+    * amplification) and the migration aborts rather than risking an OOM mid-run. Override with
+    * `-Dscylla.migrator.maxCollectionElements=<n>` (a non-positive value disables the cap).
+    */
+  private val LargeCollectionHardLimit: Int =
+    sys.props
+      .get("scylla.migrator.maxCollectionElements")
+      .flatMap(s => scala.util.Try(s.trim.toInt).toOption)
+      .getOrElse(1000000)
 
   case class Selection(
     columnRefs: List[ColumnRef],
@@ -113,20 +129,48 @@ object Cassandra {
     }
   }
 
-  /** Ordering over runtime map-key values that reproduces Cassandra's on-disk key order for the
+  /** Sorts a non-frozen collection's elements/entries into Cassandra's on-disk order using
+    * decorate-sort-undecorate: each value's comparison key (e.g. the UTF-8 bytes of a text key) is
+    * computed ONCE per element up front rather than re-derived on every pairwise comparison.
+    *
+    * A plain `Ordering.by(f)` runs `f` inside every `compare`, so an O(N log N) sort would call `f`
+    * ~2·N·log N times. For text keys `f` allocates a `String` + `byte[]` each call, so a 1000-key
+    * `map<text,_>` cell would churn ~20k transient arrays just to sort one cell. Decorating first
+    * makes that exactly N encodings.
+    */
+  private[migrator] final class ElementSorter[K](keyOf: Any => K)(implicit ord: Ordering[K])
+      extends Serializable {
+    private def sortByPrecomputedKey[V](xs: IndexedSeq[V], project: V => Any): IndexedSeq[V] =
+      xs.map(v => keyOf(project(v)) -> v).sortBy(_._1)(ord).map(_._2)
+
+    def sortEntries(entries: IndexedSeq[(Any, Any)]): IndexedSeq[(Any, Any)] =
+      sortByPrecomputedKey[(Any, Any)](entries, _._1)
+
+    def sortElements(elements: IndexedSeq[Any]): IndexedSeq[Any] =
+      sortByPrecomputedKey[Any](elements, identity)
+  }
+
+  private def textElementSorter: ElementSorter[Array[Byte]] =
+    new ElementSorter[Array[Byte]](_.toString.getBytes(StandardCharsets.UTF_8))(
+      unsignedBytesOrdering
+    )
+
+  private def longElementSorter: ElementSorter[Long] =
+    new ElementSorter[Long](_.asInstanceOf[Number].longValue())(Ordering.Long)
+
+  /** Sorter over runtime map-key values that reproduces Cassandra's on-disk key order for the
     * supported key types, so a decoded map (whose iteration order Spark/Catalyst does not preserve)
     * can be re-aligned with the element-order `WRITETIME`/`TTL` lists. Returns `None` for key types
     * whose Cassandra comparator we cannot faithfully reproduce here.
     */
-  def mapKeyOrdering(keyType: ColumnType[_]): Option[Ordering[Any]] = keyType match {
-    case TextType | AsciiType | VarCharType =>
-      Some(
-        Ordering.by((k: Any) => k.toString.getBytes(StandardCharsets.UTF_8))(unsignedBytesOrdering)
-      )
-    case IntType | BigIntType | SmallIntType | TinyIntType =>
-      Some(Ordering.by((k: Any) => k.asInstanceOf[Number].longValue()))
-    case _ => None
-  }
+  private[migrator] def mapKeyOrdering(keyType: ColumnType[_]): Option[ElementSorter[_]] =
+    keyType match {
+      case TextType | AsciiType | VarCharType =>
+        Some(textElementSorter)
+      case IntType | BigIntType | SmallIntType | TinyIntType =>
+        Some(longElementSorter)
+      case _ => None
+    }
 
   /** Describe why a non-frozen collection column cannot have its per-element timestamps preserved,
     * or `None` if it is supported. Non-frozen lists are unsupported (list cells are keyed by
@@ -148,12 +192,79 @@ object Cassandra {
     * element-order `WRITETIME`/`TTL` lists: map keys for maps, element values for sets (Cassandra
     * stores/returns both in that sorted order). `None` for unsupported element/key types.
     */
-  private def collectionElementOrdering(columnType: ColumnType[_]): Option[Ordering[Any]] =
+  private def collectionElementOrdering(columnType: ColumnType[_]): Option[ElementSorter[_]] =
     columnType match {
       case m: CqlMapType[_, _] => mapKeyOrdering(m.keyType)
       case s: CqlSetType[_]    => mapKeyOrdering(s.elemType)
       case _                   => None
     }
+
+  /** Spark-schema counterpart of [[mapKeyOrdering]]. When re-hydrating per-element collection
+    * metadata from Parquet we no longer have the Cassandra [[ColumnType]], only the Spark
+    * [[DataType]] of the collection's key (maps) or element (sets). Must stay byte-for-byte
+    * consistent with [[mapKeyOrdering]] so the Parquet round-trip re-aligns elements with their
+    * metadata exactly as the direct Cassandra->Scylla path does. Returns `None` for unsupported
+    * types (which are rejected before ever being written with array sidecars).
+    */
+  private def sparkKeyOrdering(dataType: DataType): Option[ElementSorter[_]] = dataType match {
+    case StringType =>
+      Some(textElementSorter)
+    case IntegerType | LongType | ShortType | ByteType =>
+      Some(longElementSorter)
+    case _ => None
+  }
+
+  /** Whether a Spark field carries per-element collection metadata, i.e. its companion `<name>_ttl`
+    * sidecar is an [[ArrayType]] (one TTL per collection element) rather than a scalar (frozen
+    * collection / scalar column). Used on the Parquet restore path to tell the two apart.
+    */
+  private def isPerElementCollectionMetaType(ttlFieldType: DataType): Boolean =
+    ttlFieldType.isInstanceOf[ArrayType]
+
+  /** Spark field-metadata key stamped on a non-frozen collection column when it is exported to
+    * Parquet with per-element TTL/WRITETIME array sidecars. Its value is the CQL collection kind
+    * ([[CollectionKindSet]]/[[CollectionKindMap]]). Spark persists field metadata in the Parquet
+    * footer schema, so it round-trips back on restore.
+    *
+    * This is the trust anchor for the Parquet restore path: an [[ArrayType]] alone cannot tell a
+    * CQL `set` (supported) from a `list` (unsupported — order/duplicate semantics differ) or from
+    * unrelated foreign array data. Requiring this marker means only Parquet actually produced by a
+    * `preserveCollectionTimestamps` export is ever replayed as a per-element collection-append.
+    */
+  private[migrator] val CollectionKindMetaKey = "scylla.migrator.collectionKind"
+  private[migrator] val CollectionKindSet = "set"
+  private[migrator] val CollectionKindMap = "map"
+
+  /** The CQL collection kind we stamp for a non-frozen collection column, or `None` for kinds we do
+    * not export with per-element metadata (e.g. lists are rejected earlier).
+    */
+  private def exportCollectionKind(columnType: ColumnType[_]): Option[String] =
+    columnType match {
+      case _: CqlMapType[_, _] => Some(CollectionKindMap)
+      case _: CqlSetType[_]    => Some(CollectionKindSet)
+      case _                   => None
+    }
+
+  /** Tag a non-frozen collection column's Spark field with its CQL kind so the Parquet restore path
+    * (and the validator repair path, which builds an equivalent schema) can validate it (see
+    * [[CollectionKindMetaKey]]). No-op for column types without a per-element collection kind.
+    */
+  private[migrator] def taggedCollectionField(
+    field: StructField,
+    columnType: ColumnType[_]
+  ): StructField =
+    exportCollectionKind(columnType).fold(field) { kind =>
+      val md = new MetadataBuilder()
+        .withMetadata(field.metadata)
+        .putString(CollectionKindMetaKey, kind)
+        .build()
+      field.copy(metadata = md)
+    }
+
+  private def tagCollectionKind(field: StructField, tableDef: TableDef): StructField =
+    tableDef.regularColumns
+      .find(_.columnName == field.name)
+      .fold(field)(c => taggedCollectionField(field, c.columnType))
 
   def determineCopyType(
     tableDef: TableDef,
@@ -167,7 +278,41 @@ object Cassandra {
     // maps with an orderable key type) are read as element-aligned lists and re-applied per element
     // via collection-append writes.
     val nonFrozen = nonFrozenCollectionColumns(tableDef)
-    if (nonFrozen.nonEmpty && preserveTimesRequest && !preserveCollectionTimesRequest)
+
+    // Timestamp preservation appends internal metadata columns named `ttl`/`writetime`, plus a
+    // `<col>_ttl`/`<col>_writetime` sidecar for every regular column. `ttl` and `writetime` are
+    // non-reserved CQL keywords, so a real column may legitimately be named `ttl`/`writetime` (or
+    // `<col>_ttl`-shaped). Such a collision silently misclassifies a real column as metadata
+    // (dropping it from the INSERT or misrouting the collection-append write), so reject it up
+    // front with a clear, actionable error instead of corrupting data.
+    val reservedInternalNames =
+      Set("ttl", "writetime") ++
+        tableDef.regularColumns.flatMap(c =>
+          Seq(s"${c.columnName}_ttl", s"${c.columnName}_writetime")
+        )
+    val reservedNameCollisions =
+      tableDef.columns.map(_.columnName).filter(reservedInternalNames.contains).distinct
+
+    // F12: `preserveCollectionTimestamps` only takes effect alongside `preserveTimestamps`. If the
+    // operator enabled it without the master switch, per-element collection TTL/WRITETIME would be
+    // silently NOT preserved; warn so the misconfiguration is visible.
+    if (preserveCollectionTimesRequest && !preserveTimesRequest)
+      log.warn(
+        "'preserveCollectionTimestamps' is enabled but 'preserveTimestamps' is disabled, so it has " +
+          "no effect: per-element collection TTL/WRITETIME will NOT be preserved. Set " +
+          "'preserveTimestamps' to true to enable it."
+      )
+
+    if (preserveTimesRequest && reservedNameCollisions.nonEmpty)
+      Left(
+        new Exception(
+          "TTL/Writetime preservation reserves the internal column names 'ttl', 'writetime', and " +
+            "'<column>_ttl'/'<column>_writetime'. The source table has column(s) colliding with " +
+            s"these reserved names: ${reservedNameCollisions.mkString(", ")}. Rename the source " +
+            "column(s), or set 'preserveTimestamps' to false to continue."
+        )
+      )
+    else if (nonFrozen.nonEmpty && preserveTimesRequest && !preserveCollectionTimesRequest)
       Left(
         new Exception(
           "TTL/Writetime preservation is unsupported for tables with non-frozen (multi-cell) " +
@@ -232,13 +377,18 @@ object Cassandra {
           isPerElementCollection = perElementCollectionNames.contains(origField.name)
           ttlType       = if (isPerElementCollection) ArrayType(IntegerType) else IntegerType
           writetimeType = if (isPerElementCollection) ArrayType(LongType) else LongType
+          // Stamp the CQL collection kind on per-element collection columns so the Parquet restore
+          // path can distinguish a genuine migrator export from foreign array data (see
+          // CollectionKindMetaKey). Inert on the direct Cassandra->Scylla path.
+          baseField = if (isPerElementCollection) tagCollectionKind(origField, tableDef)
+                      else origField
           field <- if (isRegular)
                      List(
-                       origField,
+                       baseField,
                        StructField(s"${origField.name}_ttl", ttlType, true),
                        StructField(s"${origField.name}_writetime", writetimeType, true)
                      )
-                   else List(origField)
+                   else List(baseField)
         } yield field)
 
         log.info("Schema generated with TTLs and Writetimes:")
@@ -327,21 +477,80 @@ object Cassandra {
     * row is emitted so the base write establishes the partition; the collection appends carry the
     * data.
     */
+  /** Largest per-element WRITETIME across the given per-element collection sidecar ordinals of a
+    * wide row, or `None` when no such collection is populated. Used to keep base marker rows
+    * consistent with the collection-append passes (F11 / A2).
+    */
+  private def maxPerElementWritetime(row: Row, ordinals: Seq[Int]): Option[Long] = {
+    val wts = ordinals.iterator.flatMap { o =>
+      if (o < 0 || o >= row.length || row.isNullAt(o)) Iterator.empty
+      else asNumberSeq(row.get(o)).iterator.collect { case n: Number => n.longValue() }
+    }
+    if (wts.hasNext) Some(wts.max) else None
+  }
+
   def explodeBaseRow(
     row: Row,
     baseSchema: StructType,
     primaryKeyOrdinals: Map[String, Int],
-    baseRegularKeyOrdinals: Map[String, (Int, Int, Int)]
+    baseRegularKeyOrdinals: Map[String, (Int, Int, Int)],
+    perElementWritetimeOrdinals: Seq[Int] = Nil,
+    perElementTtlOrdinals: Seq[Int] = Nil
   ): Iterable[Row] =
-    if (baseRegularKeyOrdinals.nonEmpty)
-      explodeRow(row, baseSchema, primaryKeyOrdinals, baseRegularKeyOrdinals)
-    else {
+    if (baseRegularKeyOrdinals.nonEmpty) {
+      val rows = explodeRow(row, baseSchema, primaryKeyOrdinals, baseRegularKeyOrdinals)
+      // A2: mixed scalar+collection table. A row whose scalar columns are all null yields a base
+      // marker whose WRITETIME group is `Unset` (server "now"), while its collection appends use the
+      // older source per-element WRITETIMEs — the same phantom-live-but-empty-row risk F11 fixes for
+      // collection-only tables. Floor any `Unset` marker writetime at the max per-element WRITETIME.
+      // The trailing element of each exploded row is its writetime; `Unset` there means the group's
+      // columns were all null (a live scalar cell always has a writetime).
+      maxPerElementWritetime(row, perElementWritetimeOrdinals) match {
+        case Some(wt) =>
+          rows.map { r =>
+            val vals = r.toSeq.toArray
+            val wtIdx = vals.length - 1
+            if (vals(wtIdx) == CassandraOption.Unset) {
+              vals(wtIdx) = java.lang.Long.valueOf(wt)
+              Row(ArraySeq.unsafeWrapArray(vals): _*)
+            } else r
+          }
+        case None => rows
+      }
+    } else {
+      // F11: collection-only table (the only regular columns are per-element collections). The base
+      // write emits a single primary-key-only row so the partition/row exists. Using an Unset
+      // writetime would stamp this marker with the server "now", which can beat a source-side
+      // tombstone that the source per-element WRITETIMEs (used by the appends) cannot beat, leaving
+      // a phantom live-but-empty row. Instead stamp the marker with the max per-element WRITETIME so
+      // it is consistent with the collection-append passes.
+      val markerWritetime: AnyRef =
+        maxPerElementWritetime(row, perElementWritetimeOrdinals)
+          .map(java.lang.Long.valueOf)
+          .getOrElse(CassandraOption.Unset)
+      // C1: mirror the marker's TTL to the collection's latest-cell expiry. A hardcoded TTL 0 (=no
+      // TTL) makes the primary-key marker permanently live, so after every TTL'd element expires the
+      // target keeps an empty, never-expiring row that the source (whose liveness came only from the
+      // now-expired cells) no longer has. Row-marker liveness must reflect the LATEST cell expiry:
+      // permanent if any element is permanent (TTL 0/absent), else the max finite element TTL.
+      val markerTtl: Integer = {
+        val ttls = perElementTtlOrdinals.iterator.flatMap { o =>
+          if (o < 0 || o >= row.length || row.isNullAt(o)) Iterator.empty
+          else
+            asNumberSeq(row.get(o)).iterator.map {
+              case n: Number => n.intValue()
+              case _         => 0 // null TTL slot => no TTL => permanent
+            }
+        }.toVector
+        if (ttls.isEmpty || ttls.exists(_ <= 0)) Integer.valueOf(0)
+        else Integer.valueOf(ttls.max)
+      }
       val newValues = baseSchema.fields.map { field =>
         primaryKeyOrdinals
           .get(field.name)
           .map(ord => if (row.isNullAt(ord)) null else convertValue(row.get(ord)))
           .getOrElse(CassandraOption.Unset)
-      } ++ Seq(Integer.valueOf(0), CassandraOption.Unset)
+      } ++ Seq(markerTtl, markerWritetime)
       List(Row(ArraySeq.unsafeWrapArray(newValues): _*))
     }
 
@@ -353,10 +562,10 @@ object Cassandra {
 
   /** Build the per-element collection-append rows for one non-frozen collection column of a single
     * wide source row. Each emitted row is `[primary key values..., grouped collection value, ttl,
-    * writetime]`. Elements are aligned with their element-order `TTL()`/`WRITETIME()` lists (sets
-    * by natural array order, maps by re-sorting entries with `keyOrdering` to match Cassandra's
-    * on-disk key order), then grouped by `(ttl, writetime)` so co-timestamped elements share one
-    * append.
+    * writetime]`. The decoded collection is re-sorted with `elementSorter` (set elements by value,
+    * map entries by key) to reproduce Cassandra's on-disk element order, so element[i] pairs with
+    * its own element-order `TTL()`/`WRITETIME()[i]`. Elements are then grouped by
+    * `(ttl, writetime)` so co-timestamped elements share one append.
     */
   def collectionAppendRows(
     row: Row,
@@ -365,7 +574,7 @@ object Cassandra {
     ttlOrdinal: Int,
     writetimeOrdinal: Int,
     isMap: Boolean,
-    elementOrdering: Option[Ordering[Any]]
+    elementSorter: Option[ElementSorter[_]]
   ): Seq[Row] = {
     if (row.isNullAt(colOrdinal)) return Nil
 
@@ -379,10 +588,52 @@ object Cassandra {
       else asNumberSeq(row.get(writetimeOrdinal))
 
     def ttlAt(i: Int): Int =
-      if (i < ttlSeq.length && ttlSeq(i) != null) ttlSeq(i).asInstanceOf[Number].intValue() else 0
-    def wtAt(i: Int): Option[Long] =
-      if (i < wtSeq.length && wtSeq(i) != null) Some(wtSeq(i).asInstanceOf[Number].longValue())
-      else None
+      if (i < ttlSeq.length && ttlSeq(i) != null) {
+        // Read as Long first: on the Parquet restore path the TTL sidecar may be a LongType array,
+        // and `intValue()` would silently wrap an out-of-range value. CQL TTL is a non-negative
+        // 32-bit second count, so anything outside [0, Int.MaxValue] is malformed (e.g. foreign /
+        // hand-crafted Parquet); fail loudly rather than truncate.
+        val n = ttlSeq(i).asInstanceOf[Number].longValue()
+        if (n < 0 || n > Int.MaxValue)
+          throw new IllegalStateException(
+            s"Per-element TTL at index $i is $n, outside the valid CQL TTL range " +
+              s"[0, ${Int.MaxValue}] seconds. Refusing to silently truncate a malformed TTL."
+          )
+        n.toInt
+      } else 0
+    // A present collection element always has a WRITETIME on Cassandra 5.0+/modern ScyllaDB. A
+    // null/non-numeric slot would leave the element with no timestamp to preserve; dropping it
+    // silently (the previous `Option`-in-`flatMap` behaviour) is data loss, so fail loudly instead.
+    def wtAt(i: Int): Long =
+      wtSeq(i) match {
+        case n: Number => n.longValue()
+        case other =>
+          throw new IllegalStateException(
+            s"Per-element WRITETIME at index $i was ${if (other == null) "null" else other} for a " +
+              "non-frozen collection element; the element cannot be written with its original " +
+              "timestamp. Aborting to avoid silently dropping it."
+          )
+      }
+
+    // Enforce the size cap on the RAW decoded collection size, before any copy/sort/group, so a
+    // pathological cell fails fast instead of OOMing during `toIndexedSeq`/`sortElements`.
+    def enforceSizeLimits(size: Int): Unit = {
+      if (LargeCollectionHardLimit > 0 && size > LargeCollectionHardLimit)
+        throw new IllegalStateException(
+          s"Non-frozen collection cell has $size elements, exceeding the hard limit of " +
+            s"$LargeCollectionHardLimit. Per-element TTL/WRITETIME preservation expands each element " +
+            "into collection-append updates, and a collection this large risks executor OOM / write " +
+            "amplification. Raise or disable the cap with -Dscylla.migrator.maxCollectionElements=<n> " +
+            "(non-positive disables) if this size is expected."
+        )
+      if (size > LargeCollectionWarnThreshold)
+        log.warn(
+          s"Non-frozen collection cell has $size elements; per-element TTL/WRITETIME " +
+            "preservation may expand it into up to that many separate collection-append updates " +
+            "(one per distinct TTL/WRITETIME group). Very large collections can cause high " +
+            "executor memory/GC pressure and slow writes."
+        )
+    }
 
     def rowsFrom(elements: IndexedSeq[Any], rebuild: Seq[Any] => Any): Seq[Row] = {
       require(
@@ -391,34 +642,25 @@ object Cassandra {
           s"${elements.length} elements but ${wtSeq.length} writetimes / ${ttlSeq.length} ttls. " +
           "Element<->timestamp alignment cannot be guaranteed; aborting to avoid silent data loss."
       )
-      if (elements.length > LargeCollectionWarnThreshold)
-        log.warn(
-          s"Non-frozen collection cell has ${elements.length} elements; per-element TTL/WRITETIME " +
-            "preservation may expand it into up to that many separate collection-append updates " +
-            "(one per distinct TTL/WRITETIME group). Very large collections can cause high " +
-            "executor memory/GC pressure and slow writes."
-        )
       elements.indices
         .groupBy(i => (ttlAt(i), wtAt(i)))
         .toSeq
-        .flatMap { case ((ttl, wtOpt), indices) =>
-          wtOpt.map { wt =>
-            val collectionValue = rebuild(indices.map(elements))
-            Row.fromSeq(
-              pkValues ++ Seq(
-                collectionValue,
-                Integer.valueOf(ttl),
-                java.lang.Long.valueOf(wt)
-              )
+        .map { case ((ttl, wt), indices) =>
+          val collectionValue = rebuild(indices.map(elements))
+          Row.fromSeq(
+            pkValues ++ Seq(
+              collectionValue,
+              Integer.valueOf(ttl),
+              java.lang.Long.valueOf(wt)
             )
-          }
+          )
         }
     }
 
     // Both the connector's decoded set and map lose their server (sorted) order, while the
     // WRITETIME()/TTL() lists arrive in that sorted order. Re-sort the elements/entries with the
     // Cassandra-compatible ordering so element[i] pairs with its own metadata[i].
-    val ordering = elementOrdering.getOrElse(
+    val sorter = elementSorter.getOrElse(
       throw new IllegalStateException(
         "Missing element ordering for a per-element collection column; this should have been " +
           "rejected earlier"
@@ -429,16 +671,20 @@ object Cassandra {
       val m = row.get(colOrdinal).asInstanceOf[scala.collection.Map[Any, Any]]
       if (m.isEmpty) Nil
       else {
-        val entries = m.toIndexedSeq.sortBy(_._1)(ordering)
+        enforceSizeLimits(m.size)
+        val entries = sorter.sortEntries(m.toIndexedSeq)
         rowsFrom(
           entries.asInstanceOf[IndexedSeq[Any]],
           parts => parts.map(_.asInstanceOf[(Any, Any)]).toMap
         )
       }
     } else {
-      val elems = row.get(colOrdinal).asInstanceOf[scala.collection.Seq[Any]].toIndexedSeq
-      if (elems.isEmpty) Nil
-      else rowsFrom(elems.sorted(ordering), parts => parts.toIndexedSeq)
+      val raw = row.get(colOrdinal).asInstanceOf[scala.collection.Seq[Any]]
+      if (raw.isEmpty) Nil
+      else {
+        enforceSizeLimits(raw.size)
+        rowsFrom(sorter.sortElements(raw.toIndexedSeq), parts => parts.toIndexedSeq)
+      }
     }
   }
 
@@ -475,7 +721,7 @@ object Cassandra {
           )
         )
         val isMap = column.columnType.isInstanceOf[CqlMapType[_, _]]
-        val elementOrdering = collectionElementOrdering(column.columnType)
+        val elementSorter = collectionElementOrdering(column.columnType)
         val pkOrdinalsBroadcast = spark.sparkContext.broadcast(pkOrdinalArray)
         val rdd = rawDataframe.rdd.flatMap { row =>
           collectionAppendRows(
@@ -485,7 +731,7 @@ object Cassandra {
             ttlOrd,
             wtOrd,
             isMap,
-            elementOrdering
+            elementSorter
           )
         }
         CollectionAppendWrite(colName, rdd, appendSchema)
@@ -656,6 +902,228 @@ object Cassandra {
     (explodedRdd, finalSchema, timestampColumns)
   }
 
+  /** Build one [[CollectionAppendWrite]] per per-element collection column found on the Parquet
+    * restore path, using the Spark schema (rather than a Cassandra `TableDef`) to derive element
+    * ordering and map/set shape. Mirrors [[buildCollectionAppendWrites]] but keyed off
+    * [[sparkKeyOrdering]] so it stays consistent with the direct Cassandra->Scylla read path.
+    */
+  private def buildCollectionAppendWritesFromSchema(
+    spark: SparkSession,
+    df: DataFrame,
+    origSchema: StructType,
+    primaryKeyOrdinals: Map[String, Int],
+    regularKeyOrdinals: Map[String, (Int, Int, Int)],
+    perElementNames: Set[String]
+  ): Seq[CollectionAppendWrite] = {
+    // Deterministic primary-key ordering (by their ordinal in the wide row). The PK order among
+    // themselves is irrelevant to the write (the column selector maps by name), it only needs to
+    // agree between `pkOrdinalArray` and `pkFields`.
+    val pkNames = primaryKeyOrdinals.toSeq.sortBy(_._2).map(_._1)
+    val pkOrdinalArray = pkNames.map(primaryKeyOrdinals).toArray
+    val pkFields = pkNames.map(name => origSchema(origSchema.fieldIndex(name)))
+
+    perElementNames.toSeq.sorted.map { colName =>
+      val (colOrd, ttlOrd, wtOrd) = regularKeyOrdinals(colName)
+      val collectionField = origSchema(origSchema.fieldIndex(colName))
+      val appendSchema = StructType(
+        pkFields ++ Seq(
+          collectionField,
+          StructField("ttl", IntegerType, true),
+          StructField("writetime", LongType, true)
+        )
+      )
+      val (isMap, elementSorter): (Boolean, Option[ElementSorter[_]]) =
+        collectionField.dataType match {
+          case m: MapType   => (true, sparkKeyOrdering(m.keyType))
+          case a: ArrayType => (false, sparkKeyOrdering(a.elementType))
+          case _            => (false, None)
+        }
+      val pkOrdinalsBroadcast = spark.sparkContext.broadcast(pkOrdinalArray)
+      val rdd = df.rdd.flatMap { row =>
+        collectionAppendRows(
+          row,
+          pkOrdinalsBroadcast.value,
+          colOrd,
+          ttlOrd,
+          wtOrd,
+          isMap,
+          elementSorter
+        )
+      }
+      CollectionAppendWrite(colName, rdd, appendSchema)
+    }
+  }
+
+  /** Collection-aware variant of [[explodeRowsFromPerColumnMeta]] for the Parquet restore path.
+    *
+    * Columns whose `<name>_ttl` sidecar is an [[ArrayType]] carry per-element collection metadata
+    * (written by a `preserveCollectionTimestamps` Parquet export). Those columns are excluded from
+    * the scalar base explode and instead replayed as per-element collection-append passes (matching
+    * the direct Cassandra->Scylla multi-pass write), so the base RDD only ever contains scalar and
+    * frozen-collection columns.
+    *
+    * When there are no such columns the base RDD/schema are identical to
+    * [[explodeRowsFromPerColumnMeta]] and `collectionAppendWrites` is empty.
+    *
+    * @return
+    *   base exploded rows, base write [[StructType]], [[TimestampColumns]], and the per-element
+    *   collection-append passes.
+    */
+  def explodeRowsFromPerColumnMetaCollectionAware(
+    spark: SparkSession,
+    df: DataFrame
+  ): (RDD[Row], StructType, TimestampColumns, Seq[CollectionAppendWrite]) = {
+    val (primaryKeyOrdinals, regularKeyOrdinals) = indexFieldsFromSchema(df.schema)
+
+    val metaColumns =
+      regularKeyOrdinals.keys.flatMap(name => Set(s"${name}_ttl", s"${name}_writetime")).toSet
+    val origSchema = StructType(df.schema.fields.filterNot(f => metaColumns.contains(f.name)))
+
+    val timestampColumns = TimestampColumns("ttl", "writetime")
+
+    // Regular columns whose TTL sidecar is an array => per-element collections. They are handled by
+    // separate collection-append passes and excluded from the base explode.
+    val perElementNames =
+      regularKeyOrdinals.collect {
+        case (name, (_, ttlOrd, _)) if isPerElementCollectionMetaType(df.schema(ttlOrd).dataType) =>
+          name
+      }.toSet
+
+    // H4: this path may run against foreign / hand-crafted Parquet. Before we trust the array-typed
+    // `<col>_ttl` sidecar as a per-element collection, validate that the sidecar pair and the base
+    // column are internally consistent, so a malformed export fails loudly here rather than
+    // producing silently corrupt appends (or an obscure crash) deep inside the write.
+    perElementNames.toSeq.sorted.foreach { name =>
+      val (colOrd, ttlOrd, wtOrd) = regularKeyOrdinals(name)
+      val baseField = df.schema(colOrd)
+      // H2/foreign-Parquet trust anchor: an ArrayType sidecar alone cannot tell a CQL set (safe to
+      // replay via `col = col + ?`) from a list (ordered, duplicate-preserving, NOT idempotent) or
+      // from unrelated foreign array data. Only Parquet produced by a preserveCollectionTimestamps
+      // export carries the collection-kind marker; require it and check it matches the base type.
+      val declaredKind =
+        if (baseField.metadata.contains(CollectionKindMetaKey))
+          Some(baseField.metadata.getString(CollectionKindMetaKey))
+        else None
+      require(
+        declaredKind.isDefined,
+        s"Parquet restore: column '$name' has array per-element metadata sidecars but no migrator " +
+          s"collection-kind marker ('$CollectionKindMetaKey'). This Parquet was not produced by a " +
+          "'preserveCollectionTimestamps' export (or was hand-crafted). Refusing to replay it as a " +
+          "per-element collection, because an array column cannot be safely distinguished as a CQL " +
+          "set vs list without it."
+      )
+      declaredKind.foreach { kind =>
+        val kindMatchesType = (kind, baseField.dataType) match {
+          case (CollectionKindMap, _: MapType)   => true
+          case (CollectionKindSet, _: ArrayType) => true
+          case _                                 => false
+        }
+        require(
+          kindMatchesType,
+          s"Parquet restore: column '$name' is marked as CQL '$kind' but its Spark type is " +
+            s"${baseField.dataType} (expected ${if (kind == CollectionKindMap) "map" else "array"}). " +
+            "Refusing to restore inconsistent per-element collection metadata."
+        )
+      }
+      val ttlType = df.schema(ttlOrd).dataType
+      val wtType = df.schema(wtOrd).dataType
+      require(
+        isPerElementCollectionMetaType(wtType),
+        s"Parquet restore: column '$name' has an array '${name}_ttl' sidecar (per-element " +
+          s"collection metadata) but its '${name}_writetime' sidecar is $wtType, not an array. The " +
+          "TTL and WRITETIME sidecars must both be arrays. Refusing to restore malformed metadata."
+      )
+      val (ttlElem, wtElem) = (ttlType, wtType) match {
+        case (t: ArrayType, w: ArrayType) => (t.elementType, w.elementType)
+        case _                            => (ttlType, wtType)
+      }
+      require(
+        ttlElem == IntegerType || ttlElem == LongType,
+        s"Parquet restore: '${name}_ttl' array elements are $ttlElem; expected integer/long TTLs."
+      )
+      require(
+        wtElem == IntegerType || wtElem == LongType,
+        s"Parquet restore: '${name}_writetime' array elements are $wtElem; expected long WRITETIMEs."
+      )
+      df.schema(colOrd).dataType match {
+        case m: MapType =>
+          require(
+            sparkKeyOrdering(m.keyType).isDefined,
+            s"Parquet restore: map column '$name' has key type ${m.keyType}, which has no supported " +
+              "element ordering; per-element metadata cannot be realigned. Refusing to restore."
+          )
+        case a: ArrayType =>
+          require(
+            sparkKeyOrdering(a.elementType).isDefined,
+            s"Parquet restore: collection column '$name' has element type ${a.elementType}, which " +
+              "has no supported ordering; per-element metadata cannot be realigned. Refusing to " +
+              "restore."
+          )
+        case other =>
+          throw new IllegalStateException(
+            s"Parquet restore: column '$name' has array per-element metadata sidecars but its own " +
+              s"type is $other, not a collection (map/list/set). Refusing to restore malformed data."
+          )
+      }
+    }
+
+    val baseRegularKeyOrdinals =
+      regularKeyOrdinals.filterNot { case (name, _) => perElementNames.contains(name) }
+    val baseOrigSchema =
+      StructType(origSchema.fields.filterNot(f => perElementNames.contains(f.name)))
+
+    // Per-element WRITETIME/TTL sidecar ordinals, used to stamp the collection-only base marker row
+    // consistently with the collection-append passes (F11 for writetime, C1 for TTL).
+    val perElementWritetimeOrdinals =
+      perElementNames.toSeq.map(name => regularKeyOrdinals(name)._3)
+    val perElementTtlOrdinals =
+      perElementNames.toSeq.map(name => regularKeyOrdinals(name)._2)
+
+    val broadcastPrimaryKeyOrdinals = spark.sparkContext.broadcast(primaryKeyOrdinals)
+    val broadcastRegularKeyOrdinals = spark.sparkContext.broadcast(baseRegularKeyOrdinals)
+    val broadcastSchema = spark.sparkContext.broadcast(baseOrigSchema)
+    val broadcastPerElementWtOrdinals = spark.sparkContext.broadcast(perElementWritetimeOrdinals)
+    val broadcastPerElementTtlOrdinals = spark.sparkContext.broadcast(perElementTtlOrdinals)
+    val finalSchema = StructType(
+      baseOrigSchema.fields ++
+        Seq(StructField("ttl", IntegerType, true), StructField("writetime", LongType, true))
+    )
+
+    if (perElementNames.nonEmpty)
+      log.info(
+        s"Parquet restore: per-element collection columns detected " +
+          s"(${perElementNames.toSeq.sorted.mkString(", ")}); they will be replayed as " +
+          "collection-append passes after the base write."
+      )
+    log.info("Base schema after explosion from per-column metadata:")
+    log.info(finalSchema.treeString)
+
+    val explodedRdd = df.rdd.flatMap { row =>
+      explodeBaseRow(
+        row,
+        broadcastSchema.value,
+        broadcastPrimaryKeyOrdinals.value,
+        broadcastRegularKeyOrdinals.value,
+        broadcastPerElementWtOrdinals.value,
+        broadcastPerElementTtlOrdinals.value
+      )
+    }
+
+    val collectionAppendWrites =
+      if (perElementNames.isEmpty) Nil
+      else
+        buildCollectionAppendWritesFromSchema(
+          spark,
+          df,
+          origSchema,
+          primaryKeyOrdinals,
+          regularKeyOrdinals,
+          perElementNames
+        )
+
+    (explodedRdd, finalSchema, timestampColumns, collectionAppendWrites)
+  }
+
   /** @param skipExplosion
     *   when `true`, return the raw DataFrame with per-column `_ttl`/`_writetime` columns (standard
     *   Spark types). When `false` and timestamps are preserved, [[cassandraExplodedWrite]] carries
@@ -756,9 +1224,31 @@ object Cassandra {
           val baseRegularKeyOrdinals =
             regularKeyOrdinals.filterNot { case (name, _) => perElementNames.contains(name) }
 
+          // F5: with per-element collections, the base explode and each collection-append pass are
+          // SEPARATE Spark jobs, all derived from `rawDataframe`. Without caching, the source table
+          // is re-read once per pass (1 + K scans for K collection columns), and worse, a source
+          // mutated between passes could be observed inconsistently (base row from one snapshot,
+          // appended elements from another). Persisting pins a single snapshot read once and shared
+          // across passes. Safe w.r.t. savepoints: the write-side TokenRangeAccumulator derives
+          // ranges from each row's partition-key token, independent of how the read is
+          // materialized. `migrate` unpersists it once all passes finish.
+          if (perElementNames.nonEmpty)
+            rawDataframe.persist(StorageLevel.MEMORY_AND_DISK)
+
+          // Per-element WRITETIME/TTL sidecar ordinals, used to stamp the collection-only base
+          // marker row consistently with the collection-append passes (F11 writetime, C1 TTL).
+          val perElementWritetimeOrdinals =
+            perElementNames.toSeq.flatMap(name => regularKeyOrdinals.get(name).map(_._3))
+          val perElementTtlOrdinals =
+            perElementNames.toSeq.flatMap(name => regularKeyOrdinals.get(name).map(_._2))
+
           val broadcastPrimaryKeyOrdinals = spark.sparkContext.broadcast(primaryKeyOrdinals)
           val broadcastRegularKeyOrdinals = spark.sparkContext.broadcast(baseRegularKeyOrdinals)
           val broadcastSchema = spark.sparkContext.broadcast(baseOrigSchema)
+          val broadcastPerElementWtOrdinals =
+            spark.sparkContext.broadcast(perElementWritetimeOrdinals)
+          val broadcastPerElementTtlOrdinals =
+            spark.sparkContext.broadcast(perElementTtlOrdinals)
           val finalSchema = StructType(
             baseOrigSchema.fields ++
               Seq(StructField(ttl, IntegerType, true), StructField(writeTime, LongType, true))
@@ -772,7 +1262,9 @@ object Cassandra {
               row,
               broadcastSchema.value,
               broadcastPrimaryKeyOrdinals.value,
-              broadcastRegularKeyOrdinals.value
+              broadcastRegularKeyOrdinals.value,
+              broadcastPerElementWtOrdinals.value,
+              broadcastPerElementTtlOrdinals.value
             )
           }
 

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/FileCompletionListener.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/FileCompletionListener.scala
@@ -72,15 +72,21 @@ class FileCompletionListener(
             savepointsManager.markFileAsProcessed(filename)
 
             val progress = s"${completedFiles.size}/${fileToPartitions.size}"
-            log.info(s"File completed: $filename (progress: $progress)")
+            log.info(s"File completed: ${Parquet.redactPathForLog(filename)} (progress: $progress)")
           }
         } else {
           val completedCount = allPartitions.count(completedPartitions.contains)
-          log.trace(s"File $filename: $completedCount/${allPartitions.size} partitions complete")
+          log.trace(
+            s"File ${Parquet.redactPathForLog(filename)}: $completedCount/${allPartitions.size} " +
+              "partitions complete"
+          )
         }
 
       case None =>
-        log.warn(s"File $filename not found in fileToPartitions map (this shouldn't happen)")
+        log.warn(
+          s"File ${Parquet.redactPathForLog(filename)} not found in fileToPartitions map " +
+            "(this shouldn't happen)"
+        )
     }
   }
 

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
@@ -23,7 +23,12 @@ object Parquet {
   private[readers] def redactPathForLog(path: String): String =
     try {
       val uri = new java.net.URI(path)
-      if (uri.getScheme == null) path
+      // Fail closed on anything carrying credentials or a signed query, INCLUDING schemeless inputs
+      // that still parse (e.g. `//user:secret@host/p`) — those would otherwise be echoed verbatim.
+      if (uri.getRawUserInfo != null || uri.getRawQuery != null || uri.getRawFragment != null)
+        "<redacted-path>"
+      else if (uri.getScheme == null)
+        if (path.contains("@") || path.contains("?")) "<redacted-path>" else path
       else {
         val authority =
           if (uri.getHost != null)

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
@@ -10,9 +10,29 @@ import com.scylladb.migrator.scylla.{ ScyllaMigrator, ScyllaParquetMigrator, Sou
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.sql.{ AnalysisException, SparkSession }
 import scala.util.Using
+import scala.util.control.NonFatal
 
 object Parquet {
   val log = LogManager.getLogger("com.scylladb.migrator.readers.Parquet")
+
+  /** Redact a source path/URI for logging: drop any `user:secret@` authority, query string, and
+    * fragment (e.g. `s3a://AKIA:secret@bucket/p?X-Amz-Signature=...`), keeping only
+    * scheme/host/port/path. Falls back to the raw string for plain local paths or unparseable
+    * inputs. Never use for the actual read — only for log output.
+    */
+  private[readers] def redactPathForLog(path: String): String =
+    try {
+      val uri = new java.net.URI(path)
+      if (uri.getScheme == null) path
+      else {
+        val authority =
+          if (uri.getHost != null)
+            uri.getHost + (if (uri.getPort >= 0) ":" + uri.getPort else "")
+          else if (uri.getAuthority != null) "<redacted-authority>"
+          else ""
+        s"${uri.getScheme}://$authority${Option(uri.getPath).getOrElse("")}"
+      }
+    } catch { case NonFatal(_) => path }
 
   def migrateToScylla(
     config: MigratorConfig,
@@ -78,56 +98,76 @@ object Parquet {
         SparkSecretRedaction.redactionRegex(spark)
       )
     ) { savepointsManager =>
-      val listener = new FileCompletionListener(
-        partitionToFiles,
-        fileToPartitions,
-        savepointsManager
-      )
-      spark.sparkContext.addSparkListener(listener)
+      val sourceDF = if (TimestampColumns.hasPerColumnMetaInParquet(df.schema)) {
+        log.info(
+          "Detected per-column CQL timestamp metadata in Parquet schema. " +
+            "Performing row explosion for TTL/writetime preservation."
+        )
+        val renamed = TimestampColumns.renameFromParquet(df)
+        val (explodedRdd, writeSchema, timestampColumns, collectionAppendWrites) =
+          Cassandra.explodeRowsFromPerColumnMetaCollectionAware(spark, renamed)
+        // `savepointsSupported = false` is hardcoded here on purpose: although Parquet sources
+        // *do* support savepoints (`SourceSettings.Parquet.supportsSavepoints == true`), the
+        // resume mechanism is the external `ParquetSavepointsManager` injected via
+        // `ScyllaParquetMigrator.externalSavepointsManager`. Marking the DataFrame as
+        // unsupported tells `ScyllaMigratorBase.createSavepointsManager` not to spin up an
+        // internal CQL manager that would race with the external one.
+        SourceDataFrame(
+          renamed,
+          Some(timestampColumns),
+          savepointsSupported    = false,
+          cassandraExplodedWrite = Some((explodedRdd, writeSchema)),
+          collectionAppendWrites = collectionAppendWrites
+        )
+      } else {
+        SourceDataFrame(df, None, savepointsSupported = false)
+      }
 
-      try {
-        val sourceDF = if (TimestampColumns.hasPerColumnMetaInParquet(df.schema)) {
-          log.info(
-            "Detected per-column CQL timestamp metadata in Parquet schema. " +
-              "Performing row explosion for TTL/writetime preservation."
-          )
-          val renamed = TimestampColumns.renameFromParquet(df)
-          val (explodedRdd, writeSchema, timestampColumns) =
-            Cassandra.explodeRowsFromPerColumnMeta(spark, renamed)
-          // `savepointsSupported = false` is hardcoded here on purpose: although Parquet sources
-          // *do* support savepoints (`SourceSettings.Parquet.supportsSavepoints == true`), the
-          // resume mechanism is the external `ParquetSavepointsManager` injected via
-          // `ScyllaParquetMigrator.externalSavepointsManager`. Marking the DataFrame as
-          // unsupported tells `ScyllaMigratorBase.createSavepointsManager` not to spin up an
-          // internal CQL manager that would race with the external one.
-          SourceDataFrame(
-            renamed,
-            Some(timestampColumns),
-            savepointsSupported    = false,
-            cassandraExplodedWrite = Some((explodedRdd, writeSchema))
-          )
+      // Incremental per-file savepoint marking (via `FileCompletionListener`) is only correct for
+      // a SINGLE-pass write. With per-element collection-append passes, the base write is a
+      // separate Spark job that reads every partition of every file and would make the listener
+      // mark all files complete BEFORE the append passes run. A crash mid-append would then
+      // persist those files as done and skip their un-appended collection elements on resume
+      // (silent data loss). For the multi-pass case we skip incremental tracking entirely and mark
+      // files only after ALL passes have succeeded (below). Re-running reprocesses the whole file
+      // set, which is safe because base inserts and collection appends are idempotent under
+      // `USING TIMESTAMP`. The common single-pass path keeps its fine-grained per-file resume.
+      val listener =
+        if (sourceDF.collectionAppendWrites.isEmpty) {
+          val l = new FileCompletionListener(partitionToFiles, fileToPartitions, savepointsManager)
+          spark.sparkContext.addSparkListener(l)
+          Some(l)
         } else {
-          SourceDataFrame(df, None, savepointsSupported = false)
+          log.info(
+            "Per-element collection-append passes detected; disabling incremental Parquet file " +
+              "savepoint tracking. Files are marked complete only after all write passes succeed; " +
+              "an interrupted run reprocesses the whole file set on resume (idempotent)."
+          )
+          None
         }
 
+      try {
         log.info("Created DataFrame from Parquet source")
 
         ScyllaParquetMigrator.migrate(config, target, sourceDF, savepointsManager)
 
         // Listener events can trail the completed Spark action; a successful write means every
-        // selected file was consumed, so make the final savepoint deterministic.
+        // selected file was consumed, so make the final savepoint deterministic. For the
+        // multi-pass path this is the ONLY point at which files are marked (see above).
         filesToProcess.foreach(savepointsManager.markFileAsProcessed)
         savepointsManager.dumpMigrationState("completed")
 
-        log.info(
-          s"Parquet migration completed successfully: " +
-            s"${listener.getCompletedFilesCount}/${listener.getTotalFilesCount} files processed"
-        )
-
-      } finally {
-        spark.sparkContext.removeSparkListener(listener)
-        log.info(s"Final progress: ${listener.getProgressReport}")
-      }
+        listener.foreach { l =>
+          log.info(
+            s"Parquet migration completed successfully: " +
+              s"${l.getCompletedFilesCount}/${l.getTotalFilesCount} files processed"
+          )
+        }
+      } finally
+        listener.foreach { l =>
+          spark.sparkContext.removeSparkListener(l)
+          log.info(s"Final progress: ${l.getProgressReport}")
+        }
     }
   }
 
@@ -146,7 +186,8 @@ object Parquet {
   }
 
   def listParquetFiles(spark: SparkSession, path: String): Seq[String] = {
-    log.info(s"Discovering Parquet files in $path")
+    val safePath = redactPathForLog(path)
+    log.info(s"Discovering Parquet files in $safePath")
 
     try {
       val dataFrame = spark.read
@@ -156,14 +197,14 @@ object Parquet {
       val files = dataFrame.inputFiles.toSeq.distinct.sorted
 
       if (files.isEmpty) {
-        throw new IllegalArgumentException(s"No Parquet files found in $path")
+        throw new IllegalArgumentException(s"No Parquet files found in $safePath")
       }
 
       log.info(s"Found ${files.size} Parquet file(s)")
       files
     } catch {
       case e: AnalysisException =>
-        val message = s"Failed to list Parquet files from $path: ${e.getMessage}"
+        val message = s"Failed to list Parquet files from $safePath"
         log.error(message)
         throw new IllegalArgumentException(message, e)
     }

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/Parquet.scala
@@ -32,7 +32,12 @@ object Parquet {
           else ""
         s"${uri.getScheme}://$authority${Option(uri.getPath).getOrElse("")}"
       }
-    } catch { case NonFatal(_) => path }
+    } catch {
+      // Fail closed: an unparseable input that carries credential/query markers must NOT be logged
+      // verbatim. Plain local paths (no `@`/`?`) are safe to echo as-is.
+      case NonFatal(_) =>
+        if (path.contains("@") || path.contains("?")) "<redacted-path>" else path
+    }
 
   def migrateToScylla(
     config: MigratorConfig,

--- a/migrator/src/main/scala/com/scylladb/migrator/readers/ParquetWithoutSavepoints.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/readers/ParquetWithoutSavepoints.scala
@@ -9,7 +9,10 @@ object ParquetWithoutSavepoints {
   val log = LogManager.getLogger("com.scylladb.migrator.readers.ParquetWithoutSavepoints")
 
   def readDataFrame(spark: SparkSession, source: SourceSettings.Parquet): SourceDataFrame = {
-    log.info(s"Reading Parquet files from ${source.path} (without savepoint tracking)")
+    log.info(
+      s"Reading Parquet files from ${Parquet.redactPathForLog(source.path)} " +
+        "(without savepoint tracking)"
+    )
 
     Parquet.configureHadoopCredentials(spark, source)
 
@@ -27,13 +30,14 @@ object ParquetWithoutSavepoints {
           "Performing row explosion for TTL/writetime preservation."
       )
       val renamed = TimestampColumns.renameFromParquet(df)
-      val (explodedRdd, writeSchema, timestampColumns) =
-        Cassandra.explodeRowsFromPerColumnMeta(spark, renamed)
+      val (explodedRdd, writeSchema, timestampColumns, collectionAppendWrites) =
+        Cassandra.explodeRowsFromPerColumnMetaCollectionAware(spark, renamed)
       SourceDataFrame(
         renamed,
         Some(timestampColumns),
         savepointsSupported    = false,
-        cassandraExplodedWrite = Some((explodedRdd, writeSchema))
+        cassandraExplodedWrite = Some((explodedRdd, writeSchema)),
+        collectionAppendWrites = collectionAppendWrites
       )
     } else {
       SourceDataFrame(df, None, savepointsSupported = false)

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
@@ -25,11 +25,29 @@ import scala.util.control.NonFatal
   *   vs unset). [[dataFrame]] stays the pre-explosion frame (e.g. wide Cassandra read) for
   *   partition metadata and logging.
   */
+/** A per-element collection-timestamp write pass. Each carries the singleton/grouped
+  * collection-append rows for one non-frozen collection column, written after the base row write
+  * with `col = col + ?` and per-row TTL/WRITETIME so element-level timestamps are preserved.
+  *
+  * @param columnName
+  *   the (source) collection column name; renames are applied by the writer.
+  * @param rdd
+  *   rows of `[primary key columns..., singleton/grouped collection value, ttl, writetime]`.
+  * @param schema
+  *   positional schema for `rdd`, ending in `ttl` (IntegerType) and `writetime` (LongType).
+  */
+case class CollectionAppendWrite(
+  columnName: String,
+  rdd: RDD[Row],
+  schema: StructType
+)
+
 case class SourceDataFrame(
   dataFrame: DataFrame,
   timestampColumns: Option[TimestampColumns],
   savepointsSupported: Boolean,
-  cassandraExplodedWrite: Option[(RDD[Row], StructType)] = None
+  cassandraExplodedWrite: Option[(RDD[Row], StructType)] = None,
+  collectionAppendWrites: Seq[CollectionAppendWrite] = Nil
 )
 
 trait ScyllaMigratorBase {
@@ -102,6 +120,27 @@ trait ScyllaMigratorBase {
             tokenRangeAccumulator,
             migratorConfig.source
           )
+      }
+
+      // Per-element collection timestamp preservation: after the base row write (scalars + frozen
+      // collections), replay each non-frozen collection column with `col = col + ?` and per-row
+      // TTL/WRITETIME. These appends are idempotent (set/map add), so they are safe to re-run and
+      // deliberately do not participate in token-range savepoints.
+      if (sourceDF.collectionAppendWrites.nonEmpty) {
+        log.info(
+          s"Applying ${sourceDF.collectionAppendWrites.size} per-element collection-append " +
+            s"pass(es): ${sourceDF.collectionAppendWrites.map(_.columnName).mkString(", ")}"
+        )
+        sourceDF.collectionAppendWrites.foreach { caw =>
+          writers.Scylla.writeCollectionAppendRDD(
+            target,
+            migratorConfig.getRenamesOrNil,
+            caw.columnName,
+            caw.rdd,
+            caw.schema,
+            migratorConfig.source
+          )
+        }
       }
     } catch {
       case NonFatal(e) => // Catching everything on purpose to try and dump the accumulator state

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
@@ -107,6 +107,16 @@ trait ScyllaMigratorBase {
       // makes a recorded "range done" mean "base + every append committed for that range". Ranges
       // reprocessed on resume are idempotent (INSERT/append with USING TIMESTAMP), so partial
       // ranges converge. With no append passes, the base write keeps the accumulator as before.
+      //
+      // M4 (accepted trade-off, not a correctness bug): the final append pass's RDD only contains
+      // rows whose last collection column is non-null, so token ranges in which every row has a
+      // null/empty last collection are NOT recorded even though they were fully written. On resume
+      // those ranges are reprocessed. This only ever OVER-processes (idempotent), never skips, so
+      // there is no data loss. The tempting alternative — recording ranges from the base write,
+      // which visits every range — would mark ranges done BEFORE the append passes run and thus
+      // reintroduce the C1/F1 data-loss-on-resume bug this design exists to prevent. Recording all
+      // ranges accurately AND only after every pass commits would need a dedicated final sweep pass
+      // over all partition keys; deferred as an efficiency-only improvement.
       val hasCollectionAppends = sourceDF.collectionAppendWrites.nonEmpty
       val baseAccumulator = if (hasCollectionAppends) None else tokenRangeAccumulator
 
@@ -154,6 +164,19 @@ trait ScyllaMigratorBase {
             migratorConfig.source
           )
         }
+
+        // C8/M4 visibility: the accumulator rides only the final append pass, which emits no rows
+        // for ranges whose last collection column is null/empty. If it recorded nothing, resume
+        // will reprocess the whole input (safe & idempotent, but with no savepoint speedup) — say
+        // so rather than let operators be surprised by a full re-run.
+        tokenRangeAccumulator.foreach { acc =>
+          if (acc.value.get.isEmpty)
+            log.warn(
+              "Collection-append savepoint pass recorded no token ranges (e.g. the last collection " +
+                "column was null/empty for every row). A resume will reprocess the whole input: " +
+                "safe and idempotent, but without savepoint speedup."
+            )
+        }
       }
     } catch {
       case NonFatal(e) => // Catching everything on purpose to try and dump the accumulator state
@@ -162,7 +185,12 @@ trait ScyllaMigratorBase {
           e
         )
         caughtError = Some(e)
-    } finally
+    } finally {
+      // Release the source frame cache (see F5 in readers.Cassandra.readDataframe). All write
+      // passes are eager actions that have run by now, so nothing still reads it. No-op when the
+      // frame was never persisted (e.g. single-pass or non-Cassandra sources).
+      try sourceDF.dataFrame.unpersist()
+      catch { case NonFatal(_) => () }
       for (savePointsManger <- maybeSavepointsManager) {
         try
           savePointsManger.dumpMigrationState("final")
@@ -181,6 +209,7 @@ trait ScyllaMigratorBase {
           }
         }
       }
+    }
     caughtError.foreach(throw _)
   }
 }
@@ -222,12 +251,9 @@ object ScyllaMigrator extends ScyllaMigratorBase {
     target: TargetSettings.Parquet,
     migratorConfig: MigratorConfig
   )(implicit spark: SparkSession): Unit = {
-    require(
-      !source.preserveCollectionTimestamps,
-      "preserveCollectionTimestamps is not supported with a Parquet target: per-element " +
-        "collection TTL/WRITETIME are written as array sidecars that the Parquet restore path " +
-        "cannot round-trip. Disable preserveCollectionTimestamps for Parquet migrations."
-    )
+    // Per-element collection TTL/WRITETIME are exported as array sidecars
+    // (`__migrator_meta_<col>_ttl/_writetime`) and re-hydrated into collection-append passes on
+    // the Parquet restore path (see `explodeRowsFromPerColumnMetaCollectionAware`).
     val sourceDF = readers.Cassandra.readDataframe(
       spark,
       source,
@@ -248,6 +274,7 @@ object ScyllaMigrator extends ScyllaMigratorBase {
         SparkSecretRedaction.redactionRegex(spark)
       )
     ) { savepointsManager =>
+      var caughtError: Option[Throwable] = None
       try
         writers.Parquet.writeDataframe(target, dfForParquet)
       catch {
@@ -256,8 +283,18 @@ object ScyllaMigrator extends ScyllaMigratorBase {
             "Caught error while writing Parquet. Will create a savepoint before exiting",
             e
           )
+          caughtError = Some(e)
       } finally
-        savepointsManager.dumpMigrationState("final")
+        try savepointsManager.dumpMigrationState("final")
+        catch {
+          case NonFatal(finallyEx) =>
+            caughtError.foreach(_.addSuppressed(finallyEx))
+            if (caughtError.isEmpty) caughtError = Some(finallyEx)
+        }
+      // Re-throw so the process exits non-zero on a failed/partial Parquet export (including the
+      // per-element collection array sidecars). Mirrors `ScyllaMigratorBase.migrate`; without this
+      // a truncated export would be silently restored as complete on the Parquet import path.
+      caughtError.foreach(throw _)
     }
   }
 }

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
@@ -170,11 +170,24 @@ trait ScyllaMigratorBase {
         // will reprocess the whole input (safe & idempotent, but with no savepoint speedup) — say
         // so rather than let operators be surprised by a full re-run.
         tokenRangeAccumulator.foreach { acc =>
-          if (acc.value.get.isEmpty)
+          val recorded = acc.value.get.size
+          val lastColumn = sourceDF.collectionAppendWrites.last.columnName
+          if (recorded == 0)
             log.warn(
               "Collection-append savepoint pass recorded no token ranges (e.g. the last collection " +
-                "column was null/empty for every row). A resume will reprocess the whole input: " +
-                "safe and idempotent, but without savepoint speedup."
+                s"column '$lastColumn' was null/empty for every row). A resume will reprocess the " +
+                "whole input: safe and idempotent, but without savepoint speedup."
+            )
+          else
+            // Report the count, not just the all-empty case: ranges are recorded only where the
+            // final append pass emitted rows, so a SPARSELY populated last collection column yields
+            // proportionally few savepoints and a resume re-does most of the table. Operators need
+            // the number to judge that, since it is safe-but-slow rather than incorrect.
+            log.info(
+              s"Collection-append savepoint pass recorded $recorded token range(s). Ranges are " +
+                s"recorded only where the final collection column ('$lastColumn') was non-empty, so " +
+                "a sparsely populated collection yields few savepoints and a resume will reprocess " +
+                "most of the input (safe and idempotent, but slow)."
             )
         }
       }

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala
@@ -100,6 +100,16 @@ trait ScyllaMigratorBase {
         case cqlManager: CqlSavepointsManager => Some(cqlManager.accumulator)
         case _                                => None
       }
+      // Savepoint correctness for multi-pass collection preservation (Approach 2): when there are
+      // collection-append passes, the base write and all but the FINAL append pass must not feed
+      // the token-range accumulator. Passes run sequentially, so a range is only truly complete
+      // after the final append pass finishes it — attaching the accumulator solely to that pass
+      // makes a recorded "range done" mean "base + every append committed for that range". Ranges
+      // reprocessed on resume are idempotent (INSERT/append with USING TIMESTAMP), so partial
+      // ranges converge. With no append passes, the base write keeps the accumulator as before.
+      val hasCollectionAppends = sourceDF.collectionAppendWrites.nonEmpty
+      val baseAccumulator = if (hasCollectionAppends) None else tokenRangeAccumulator
+
       sourceDF.cassandraExplodedWrite match {
         case Some((explodedRdd, writeSchema)) =>
           writers.Scylla.writeRowRDD(
@@ -108,7 +118,7 @@ trait ScyllaMigratorBase {
             explodedRdd,
             writeSchema,
             sourceDF.timestampColumns,
-            tokenRangeAccumulator,
+            baseAccumulator,
             migratorConfig.source
           )
         case None =>
@@ -117,27 +127,30 @@ trait ScyllaMigratorBase {
             migratorConfig.getRenamesOrNil,
             sourceDF.dataFrame,
             sourceDF.timestampColumns,
-            tokenRangeAccumulator,
+            baseAccumulator,
             migratorConfig.source
           )
       }
 
       // Per-element collection timestamp preservation: after the base row write (scalars + frozen
       // collections), replay each non-frozen collection column with `col = col + ?` and per-row
-      // TTL/WRITETIME. These appends are idempotent (set/map add), so they are safe to re-run and
-      // deliberately do not participate in token-range savepoints.
-      if (sourceDF.collectionAppendWrites.nonEmpty) {
+      // TTL/WRITETIME. Only the last pass carries the token-range accumulator (see above).
+      if (hasCollectionAppends) {
         log.info(
           s"Applying ${sourceDF.collectionAppendWrites.size} per-element collection-append " +
             s"pass(es): ${sourceDF.collectionAppendWrites.map(_.columnName).mkString(", ")}"
         )
-        sourceDF.collectionAppendWrites.foreach { caw =>
+        val lastIndex = sourceDF.collectionAppendWrites.size - 1
+        sourceDF.collectionAppendWrites.zipWithIndex.foreach { case (caw, index) =>
+          val accumulatorForPass =
+            if (index == lastIndex) tokenRangeAccumulator else None
           writers.Scylla.writeCollectionAppendRDD(
             target,
             migratorConfig.getRenamesOrNil,
             caw.columnName,
             caw.rdd,
             caw.schema,
+            accumulatorForPass,
             migratorConfig.source
           )
         }
@@ -209,6 +222,12 @@ object ScyllaMigrator extends ScyllaMigratorBase {
     target: TargetSettings.Parquet,
     migratorConfig: MigratorConfig
   )(implicit spark: SparkSession): Unit = {
+    require(
+      !source.preserveCollectionTimestamps,
+      "preserveCollectionTimestamps is not supported with a Parquet target: per-element " +
+        "collection TTL/WRITETIME are written as array sidecars that the Parquet restore path " +
+        "cannot round-trip. Disable preserveCollectionTimestamps for Parquet migrations."
+    )
     val sourceDF = readers.Cassandra.readDataframe(
       spark,
       source,

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala
@@ -112,13 +112,34 @@ object ScyllaValidator {
         Schema.tableFromCassandra(_, sourceSettings.keyspace, sourceSettings.table)
       )
 
+    val hasNonFrozenCollections =
+      readers.Cassandra.nonFrozenCollectionColumns(sourceTableDef).nonEmpty
+
     val includePerColumnMetadata =
-      readers.Cassandra
-        .determineCopyType(sourceTableDef, sourceSettings.preserveTimestamps)
-        .fold(
-          err => throw err,
-          copyType => copyType == CopyType.WithTimestampPreservation
+      if (
+        sourceSettings.preserveTimestamps &&
+        sourceSettings.preserveCollectionTimestamps &&
+        hasNonFrozenCollections
+      ) {
+        // Per-element collection TTL/WRITETIME come back as arrays, which the scalar per-column
+        // metadata comparison (`compareCassandraRows`) and repair paths (`buildRepairSchema`,
+        // `explodeRowsFromPerColumnMeta`) cannot handle. Element-level collection timestamp
+        // validation is a planned follow-up; until then, fall back to value-only comparison so
+        // these tables validate instead of crashing. (Without this, determineCopyType below throws
+        // for non-frozen collection tables when preserveTimestamps is on.)
+        log.warn(
+          "preserveCollectionTimestamps is enabled: per-element collection TTL/WRITETIME " +
+            "validation is not yet supported. Falling back to value-only comparison for this " +
+            "run; scalar column timestamps will not be validated either."
         )
+        false
+      } else
+        readers.Cassandra
+          .determineCopyType(sourceTableDef, sourceSettings.preserveTimestamps)
+          .fold(
+            err => throw err,
+            copyType => copyType == CopyType.WithTimestampPreservation
+          )
 
     val source = {
       val regularColumnsProjection =

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala
@@ -17,12 +17,20 @@ import com.scylladb.migrator.config.{
   SourceSettings,
   TargetSettings
 }
+import com.scylladb.migrator.readers.TimestampColumns
 import com.scylladb.migrator.validation.RowComparisonFailure
 import org.apache.logging.log4j.LogManager
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{ Row, SparkSession }
 import org.apache.spark.sql.cassandra.DataTypeConverter
-import org.apache.spark.sql.types.{ IntegerType, LongType, StructField, StructType }
+import org.apache.spark.sql.types.{
+  ArrayType,
+  DataType,
+  IntegerType,
+  LongType,
+  StructField,
+  StructType
+}
 import org.apache.spark.storage.StorageLevel
 
 import scala.collection.immutable.ArraySeq
@@ -35,7 +43,8 @@ object ScyllaValidator {
   private def buildRepairSchema(
     sourceTableDef: TableDef,
     renameColumn: String => String,
-    includePerColumnMetadata: Boolean
+    includePerColumnMetadata: Boolean,
+    nonFrozenCollectionNames: Set[String] = Set.empty
   ): StructType = {
     val primaryKeyFields =
       (sourceTableDef.partitionKey ++ sourceTableDef.clusteringColumns).map { colDef =>
@@ -51,17 +60,40 @@ object ScyllaValidator {
         val widenedField =
           field.copy(dataType = readers.Cassandra.widenCqlTimestamps(field.dataType))
 
-        if (includePerColumnMetadata)
+        if (includePerColumnMetadata) {
+          // Non-frozen collections carry one TTL/WRITETIME per element, so their sidecars are
+          // arrays; the collection-aware explode re-hydrates them into collection-append passes.
+          val isPerElement = nonFrozenCollectionNames.contains(colDef.columnName)
+          val ttlType = if (isPerElement) ArrayType(IntegerType) else IntegerType
+          val writetimeType = if (isPerElement) ArrayType(LongType) else LongType
+          // Stamp the same collection-kind marker the Parquet export writes, so the shared
+          // collection-aware explode accepts this trusted, migrator-built repair schema.
+          val baseField =
+            if (isPerElement)
+              readers.Cassandra.taggedCollectionField(widenedField, colDef.columnType)
+            else widenedField
           Seq(
-            widenedField,
-            StructField(s"${renamedColumn}_ttl", IntegerType, true),
-            StructField(s"${renamedColumn}_writetime", LongType, true)
+            baseField,
+            StructField(s"${renamedColumn}_ttl", ttlType, true),
+            StructField(s"${renamedColumn}_writetime", writetimeType, true)
           )
-        else Seq(widenedField)
+        } else Seq(widenedField)
       }
 
     StructType(primaryKeyFields ++ regularFields)
   }
+
+  /** Spark's `RowEncoder` expects a `Seq` for `ArrayType` columns, but a CQL set read from a plain
+    * `CassandraRow` (the validator join uses these, unlike the migration read which uses the
+    * connector's already-`Seq` `CassandraSQLRow`) decodes to a Scala `Set`. Coerce sets to an
+    * ordered `Seq` so `createDataFrame` can encode the repair rows; the collection-aware explode
+    * re-sorts elements by their ordering afterwards, so the interim order is irrelevant.
+    */
+  private def coerceRepairValue(dataType: DataType, value: Any): Any =
+    (dataType, value) match {
+      case (_: ArrayType, s: scala.collection.Set[_]) => s.toIndexedSeq
+      case _                                          => value
+    }
 
   /** Validates that the target Scylla database contains the same data as the source Cassandra
     * database.
@@ -112,34 +144,36 @@ object ScyllaValidator {
         Schema.tableFromCassandra(_, sourceSettings.keyspace, sourceSettings.table)
       )
 
-    val hasNonFrozenCollections =
-      readers.Cassandra.nonFrozenCollectionColumns(sourceTableDef).nonEmpty
+    val nonFrozenCollectionNames =
+      readers.Cassandra.nonFrozenCollectionColumns(sourceTableDef).map(_.columnName).toSet
+    val hasNonFrozenCollections = nonFrozenCollectionNames.nonEmpty
 
+    // Whether TTL()/WRITETIME() metadata is selected and compared. For scalar columns and frozen
+    // collections these are scalars; under `preserveCollectionTimestamps` non-frozen collection
+    // columns select them as per-element (array) lists. `compareCassandraRows` handles both.
     val includePerColumnMetadata =
-      if (
-        sourceSettings.preserveTimestamps &&
+      readers.Cassandra
+        .determineCopyType(
+          sourceTableDef,
+          sourceSettings.preserveTimestamps,
+          sourceSettings.preserveCollectionTimestamps
+        )
+        .fold(
+          err => throw err,
+          copyType => copyType == CopyType.WithTimestampPreservation
+        )
+
+    // Per-element collection metadata is array-typed. The scalar repair explosion
+    // (`explodeRowsFromPerColumnMeta`) cannot represent it, so copy-missing-rows repair for such
+    // tables uses the collection-aware explosion (`explodeRowsFromPerColumnMetaCollectionAware`):
+    // a scalar/frozen base write plus per-element collection-append passes.
+    val perElementCollectionMetadata =
+      includePerColumnMetadata &&
         sourceSettings.preserveCollectionTimestamps &&
         hasNonFrozenCollections
-      ) {
-        // Per-element collection TTL/WRITETIME come back as arrays, which the scalar per-column
-        // metadata comparison (`compareCassandraRows`) and repair paths (`buildRepairSchema`,
-        // `explodeRowsFromPerColumnMeta`) cannot handle. Element-level collection timestamp
-        // validation is a planned follow-up; until then, fall back to value-only comparison so
-        // these tables validate instead of crashing. (Without this, determineCopyType below throws
-        // for non-frozen collection tables when preserveTimestamps is on.)
-        log.warn(
-          "preserveCollectionTimestamps is enabled: per-element collection TTL/WRITETIME " +
-            "validation is not yet supported. Falling back to value-only comparison for this " +
-            "run; scalar column timestamps will not be validated either."
-        )
-        false
-      } else
-        readers.Cassandra
-          .determineCopyType(sourceTableDef, sourceSettings.preserveTimestamps)
-          .fold(
-            err => throw err,
-            copyType => copyType == CopyType.WithTimestampPreservation
-          )
+
+    // Repair uses the scalar explosion only when there are no per-element collections.
+    val repairWithScalarMetadata = includePerColumnMetadata && !perElementCollectionMetadata
 
     val source = {
       val regularColumnsProjection =
@@ -252,11 +286,38 @@ object ScyllaValidator {
               "repair writes and will be ignored for this run."
           )
         }
+        if (perElementCollectionMetadata) {
+          log.warn(
+            "copyMissingRows for a table with non-frozen (multi-cell) collections under " +
+              "preserveCollectionTimestamps: missing rows are repaired with a scalar/frozen base " +
+              "write plus per-element collection-append passes, restoring element TTL/WRITETIME. " +
+              "With repairWritetimeStrategy=source the original per-element WRITETIMEs are kept. " +
+              "With coordinator/config, the override is applied to BOTH the base write and the " +
+              "collection appends (per-element WRITETIME granularity is collapsed to the override) " +
+              "so the repaired row and its collection elements stay consistent."
+          )
+          // C2: state the convergence limits explicitly so operators do not treat
+          // --copyMissingRows as a general reconciliation tool for these tables.
+          log.warn(
+            "copyMissingRows LIMITATION for non-frozen collections: only rows entirely absent from " +
+              "the target are repaired. A row that already exists on the target but has a DIFFERENT " +
+              "collection (missing, extra, or stale elements) is reported by validation but NOT " +
+              "converged here — collection-append repair is additive (it can only add elements, " +
+              "never remove target-side extras) and re-adding could resurrect elements deleted on " +
+              "the target. To converge present-but-incomplete rows, resume the migration itself " +
+              "(base insert + appends are idempotent under USING TIMESTAMP) rather than relying on " +
+              "validation repair."
+          )
+        }
         log.info("Copying missing rows from source to target")
 
         val repairSchema =
-          buildRepairSchema(sourceTableDef, config.renamesMap, includePerColumnMetadata)
-        val repairFieldNames = repairSchema.fieldNames.toIndexedSeq
+          buildRepairSchema(
+            sourceTableDef,
+            config.renamesMap,
+            includePerColumnMetadata,
+            nonFrozenCollectionNames
+          )
 
         val missingRowsRdd =
           cachedJoined.filter { case (_, r) => r.isEmpty }.persist(StorageLevel.MEMORY_AND_DISK)
@@ -264,12 +325,16 @@ object ScyllaValidator {
           val missingSourceRowCount = missingRowsRdd.count()
 
           if (missingSourceRowCount > 0) {
+            val repairFields = repairSchema.fields.toIndexedSeq
             val rawRepairDf = spark.createDataFrame(
               missingRowsRdd.map { case (sourceRow, _) =>
                 Row.fromSeq(
-                  repairFieldNames.map { fieldName =>
-                    readers.Cassandra.widenTimestampValue(
-                      readers.Cassandra.convertValue(sourceRow.getRaw(fieldName))
+                  repairFields.map { field =>
+                    coerceRepairValue(
+                      field.dataType,
+                      readers.Cassandra.widenTimestampValue(
+                        readers.Cassandra.convertValue(sourceRow.getRaw(field.name))
+                      )
                     )
                   }
                 )
@@ -277,56 +342,105 @@ object ScyllaValidator {
               repairSchema
             )
 
-            if (includePerColumnMetadata) {
-              val (repairRdd, writeRepairSchema, timestampColumns) =
-                readers.Cassandra.explodeRowsFromPerColumnMeta(spark, rawRepairDf)
-              val writetimeIdx = writeRepairSchema.fieldIndex(timestampColumns.writeTime)
-
-              def overrideWritetime(rdd: RDD[Row], micros: Long): RDD[Row] =
-                rdd.map { row =>
-                  val values = row.toSeq.toArray
-                  values(writetimeIdx) match {
-                    case com.datastax.spark.connector.types.CassandraOption.Unset =>
-                    case _ =>
-                      values(writetimeIdx) = java.lang.Long.valueOf(micros)
-                  }
-                  Row(ArraySeq.unsafeWrapArray(values): _*)
-                }
-
-              val rddForWrite = validationConfig.repairWritetimeStrategy match {
+            // Precompute the writetime override (if any) ONCE so the scalar/frozen base write and
+            // every collection-append pass are stamped consistently. Lazy so the value-only repair
+            // path (no metadata) neither logs nor triggers the `config` validation error.
+            //   - source: no override; base + appends keep original per-cell/per-element WRITETIME.
+            //   - coordinator/config: override applied to BOTH base and appends. This collapses the
+            //     per-element WRITETIMEs to a single value, but keeping the appends on source
+            //     WRITETIME while overriding the base would leave the base "resurrected" (live) with
+            //     collection elements that are still shadowed by their older tombstones — an
+            //     inconsistent, partially-empty row. Consistency is preferred over per-element
+            //     granularity whenever the operator explicitly opts into an override strategy.
+            lazy val repairWritetimeOverrideMicros: Option[Long] =
+              validationConfig.repairWritetimeStrategy match {
                 case RepairWritetimeStrategy.Source =>
                   log.info(
-                    "repairWritetimeStrategy=source: using original source writetime. " +
+                    "repairWritetimeStrategy=source: using original source writetime(s). " +
                       "Repair writes may be shadowed by newer delete tombstones on the target."
                   )
-                  repairRdd
-
+                  None
                 case RepairWritetimeStrategy.Coordinator =>
-                  val repairTimeMicros = System.currentTimeMillis() * 1000L
+                  val micros = System.currentTimeMillis() * 1000L
                   log.info(
-                    s"repairWritetimeStrategy=coordinator: overriding writetime to $repairTimeMicros. " +
+                    s"repairWritetimeStrategy=coordinator: overriding writetime to $micros. " +
                       "Repair writes will beat most tombstones but may resurrect deleted rows."
                   )
-                  overrideWritetime(repairRdd, repairTimeMicros)
-
+                  Some(micros)
                 case RepairWritetimeStrategy.Config =>
-                  val configTimeMicros = targetSettings.writeWritetimestampInuS.getOrElse(
+                  val micros = targetSettings.writeWritetimestampInuS.getOrElse(
                     sys.error(
                       "repairWritetimeStrategy=config requires target.writeWritetimestampInuS " +
                         "to be set in the configuration."
                     )
                   )
                   log.info(
-                    s"repairWritetimeStrategy=config: overriding writetime to $configTimeMicros " +
+                    s"repairWritetimeStrategy=config: overriding writetime to $micros " +
                       "(from target.writeWritetimestampInuS)."
                   )
-                  overrideWritetime(repairRdd, configTimeMicros)
+                  Some(micros)
               }
+
+            def overrideWritetimeColumn(
+              rdd: RDD[Row],
+              writeSchema: StructType,
+              writetimeColumn: String
+            ): RDD[Row] =
+              repairWritetimeOverrideMicros match {
+                case None => rdd
+                case Some(micros) =>
+                  val writetimeIdx = writeSchema.fieldIndex(writetimeColumn)
+                  rdd.map { row =>
+                    val values = row.toSeq.toArray
+                    values(writetimeIdx) match {
+                      case com.datastax.spark.connector.types.CassandraOption.Unset =>
+                      case _ => values(writetimeIdx) = java.lang.Long.valueOf(micros)
+                    }
+                    Row(ArraySeq.unsafeWrapArray(values): _*)
+                  }
+              }
+
+            def applyRepairStrategy(
+              rdd: RDD[Row],
+              writeSchema: StructType,
+              timestampColumns: TimestampColumns
+            ): RDD[Row] = overrideWritetimeColumn(rdd, writeSchema, timestampColumns.writeTime)
+
+            if (perElementCollectionMetadata) {
+              // Scalar/frozen base write + per-element collection-append passes, mirroring the
+              // direct migration multi-pass write so missing rows regain element-level metadata.
+              val (baseRdd, baseSchema, timestampColumns, appendWrites) =
+                readers.Cassandra.explodeRowsFromPerColumnMetaCollectionAware(spark, rawRepairDf)
 
               writers.Scylla.writeRowRDD(
                 targetSettings,
                 Nil,
-                rddForWrite,
+                applyRepairStrategy(baseRdd, baseSchema, timestampColumns),
+                baseSchema,
+                Some(timestampColumns),
+                None,
+                sourceSettings
+              )
+
+              appendWrites.foreach { caw =>
+                writers.Scylla.writeCollectionAppendRDD(
+                  targetSettings,
+                  Nil,
+                  caw.columnName,
+                  overrideWritetimeColumn(caw.rdd, caw.schema, "writetime"),
+                  caw.schema,
+                  None,
+                  sourceSettings
+                )
+              }
+            } else if (repairWithScalarMetadata) {
+              val (repairRdd, writeRepairSchema, timestampColumns) =
+                readers.Cassandra.explodeRowsFromPerColumnMeta(spark, rawRepairDf)
+
+              writers.Scylla.writeRowRDD(
+                targetSettings,
+                Nil,
+                applyRepairStrategy(repairRdd, writeRepairSchema, timestampColumns),
                 writeRepairSchema,
                 Some(timestampColumns),
                 None,

--- a/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala
@@ -175,12 +175,70 @@ object ScyllaValidator {
     // Repair uses the scalar explosion only when there are no per-element collections.
     val repairWithScalarMetadata = includePerColumnMetadata && !perElementCollectionMetadata
 
+    // The source SELECT and target JOIN below project the collection-wide `WRITETIME(col)`/`TTL(col)`
+    // form for per-element metadata. ScyllaDB 2026.2+ only accepts the element-subscript form on
+    // non-frozen collections and REJECTS the collection-wide form, so emitting it against such an
+    // endpoint fails mid distributed-read. Detect it up front (same probe the migrate path uses):
+    // if EITHER endpoint is subscript-only, drop per-element metadata for non-frozen collection
+    // columns on BOTH projections and compare those columns by VALUE only (all scalar/frozen
+    // metadata is still validated). Comparison must stay symmetric, hence "both".
+    val collectionsValueOnly: Boolean =
+      if (!perElementCollectionMetadata) false
+      else {
+        val nonFrozenSource = readers.Cassandra.nonFrozenCollectionColumns(sourceTableDef)
+        val sourceStrategy =
+          readers.Cassandra.detectMetadataReadStrategy(
+            sourceConnector,
+            sourceSettings.keyspace,
+            sourceSettings.table,
+            nonFrozenSource
+          )
+        val targetTableDef =
+          targetConnector.withSessionDo(
+            Schema.tableFromCassandra(_, targetSettings.keyspace, targetSettings.table)
+          )
+        val targetStrategy =
+          readers.Cassandra.detectMetadataReadStrategy(
+            targetConnector,
+            targetSettings.keyspace,
+            targetSettings.table,
+            readers.Cassandra.nonFrozenCollectionColumns(targetTableDef)
+          )
+        sourceStrategy == readers.Cassandra.SubscriptMetadataRead ||
+        targetStrategy == readers.Cassandra.SubscriptMetadataRead
+      }
+
+    if (collectionsValueOnly) {
+      log.warn(
+        "Validation source/target exposes per-element collection WRITETIME()/TTL() only via the " +
+          "subscript form (ScyllaDB 2026.2+). The validator compares non-frozen collection columns " +
+          s"by VALUE only (${nonFrozenCollectionNames.mkString(", ")}); their per-element " +
+          "TTL/WRITETIME are NOT validated. Scalar and frozen-collection metadata are still compared."
+      )
+      // copyMissingRows repair for these tables reconstructs per-element collection TTL/WRITETIME
+      // from the source metadata read — which is unavailable in value-only mode — so it cannot run.
+      if (validationConfig.copyMissingRows)
+        sys.error(
+          "copyMissingRows is not supported for non-frozen collections when the source or target " +
+            "only exposes the subscript form of WRITETIME()/TTL() (ScyllaDB 2026.2+): per-element " +
+            "collection metadata cannot be read for repair. Re-run the migration itself (idempotent " +
+            "under USING TIMESTAMP) to converge missing rows, or disable copyMissingRows to validate " +
+            "values only."
+        )
+    }
+
+    // Whether to project per-element metadata for a given regular column. Non-frozen collections are
+    // dropped to value-only when the endpoint only supports the subscript form.
+    def projectMetadataFor(columnName: String): Boolean =
+      includePerColumnMetadata &&
+        !(collectionsValueOnly && nonFrozenCollectionNames.contains(columnName))
+
     val source = {
       val regularColumnsProjection =
         sourceTableDef.regularColumns.flatMap { colDef =>
           val alias = config.renamesMap(colDef.columnName)
 
-          if (includePerColumnMetadata)
+          if (projectMetadataFor(colDef.columnName))
             List(
               ColumnName(colDef.columnName, Some(alias)),
               TTL(colDef.columnName, Some(alias + "_ttl")),
@@ -219,7 +277,7 @@ object ScyllaValidator {
         sourceTableDef.regularColumns.flatMap { colDef =>
           val renamedColName = config.renamesMap(colDef.columnName)
 
-          if (includePerColumnMetadata)
+          if (projectMetadataFor(colDef.columnName))
             List(
               ColumnName(renamedColName),
               TTL(renamedColName, Some(renamedColName + "_ttl")),

--- a/migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala
@@ -65,6 +65,22 @@ object RowComparisonFailure {
               s"$fieldName ($writeTimeDiff millis)"
             }
             .mkString(", ")}")
+
+    /** A `_ttl`/`_writetime` column whose value is not a clean numeric scalar or numeric/null array
+      * (non-numeric element or wholly unexpected type). Reported separately from time differences
+      * because it is a data-integrity problem, not a "(N millis)" discrepancy.
+      */
+    case class MalformedMetadata(fields: List[String])
+        extends Item(s"Malformed TTL/WRITETIME metadata: ${fields.mkString(", ")}")
+
+    /** A per-element `_ttl`/`_writetime` array whose element count disagrees with its collection's
+      * element count, or differs between source and target (including one side missing it). Each
+      * detail describes the counts. Reported separately so it is not mistaken for a time delta.
+      */
+    case class MetadataCardinalityMismatch(details: List[(String, String)])
+        extends Item(s"Per-element metadata cardinality mismatch: ${details
+            .map { case (fieldName, detail) => s"$fieldName ($detail)" }
+            .mkString(", ")}")
     case class NumericTypeMismatch(fields: List[(String, String, String)])
         extends Item(s"Numeric type mismatches: ${fields
             .map { case (fieldName, srcType, tgtType) =>
@@ -142,7 +158,7 @@ object RowComparisonFailure {
               }
             }
 
-        val differingTtls =
+        val ttlResults =
           if (!compareTimestamps) Nil
           else
             for {
@@ -168,7 +184,7 @@ object RowComparisonFailure {
         // fails loudly instead of silently wrapping to a negative value (which would make every
         // element "exceed" and produce spurious diffs).
         val writetimeToleranceMicros = Math.multiplyExact(writetimeToleranceMillis, 1000L)
-        val differingWritetimes =
+        val writetimeResults =
           if (!compareTimestamps) Nil
           else
             for {
@@ -185,8 +201,21 @@ object RowComparisonFailure {
                         )
             } yield result
 
+        // Split real time/TTL deltas (reported in millis) from structural problems (malformed or
+        // cardinality mismatches), so the latter get their own, non-misleading failure items.
+        val differingTtls = ttlResults.collect { case MetadataDiff.TimeDiff(f, d) => f -> d }
+        val differingWritetimes =
+          writetimeResults.collect { case MetadataDiff.TimeDiff(f, d) => f -> d }
+        val malformedMetadata =
+          (ttlResults ++ writetimeResults).collect { case MetadataDiff.Malformed(f) => f }
+        val cardinalityMismatches =
+          (ttlResults ++ writetimeResults).collect {
+            case MetadataDiff.CardinalityMismatch(f, detail) => f -> detail
+          }
+
         if (
-          differingFieldValues.isEmpty && numericTypeMismatches.isEmpty && differingTtls.isEmpty && differingWritetimes.isEmpty
+          differingFieldValues.isEmpty && numericTypeMismatches.isEmpty && differingTtls.isEmpty &&
+          differingWritetimes.isEmpty && malformedMetadata.isEmpty && cardinalityMismatches.isEmpty
         )
           None
         else
@@ -204,6 +233,12 @@ object RowComparisonFailure {
                  else Nil) ++
                 (if (differingWritetimes.nonEmpty)
                    List(Item.DifferingWritetimes(differingWritetimes.toList))
+                 else Nil) ++
+                (if (malformedMetadata.nonEmpty)
+                   List(Item.MalformedMetadata(malformedMetadata.toList))
+                 else Nil) ++
+                (if (cardinalityMismatches.nonEmpty)
+                   List(Item.MetadataCardinalityMismatch(cardinalityMismatches.toList))
                  else Nil)
             )
           )
@@ -304,20 +339,31 @@ object RowComparisonFailure {
       case _                          => true
     }
 
-  /** For array-typed (per-element) metadata, the discrepancy between the metadata length and the
-    * associated collection's element count, if they disagree. Scalar metadata (raw is a `Number`)
-    * and non-collection base values are skipped.
+  /** For array-typed (per-element) metadata, the metadata length and its collection's element count
+    * when they disagree. Scalar metadata (raw is a `Number`) and non-collection base values yield
+    * `None` (nothing to reconcile).
     */
   private def cardinalityMismatch(
     row: CassandraRow,
     name: String,
     baseValue: Option[Any]
-  ): Option[Long] = {
+  ): Option[(Int, Int)] = {
     val metaLen = Option(row.getRaw(name)).collect { case s: scala.collection.Seq[_] => s.length }
     (metaLen, baseValue.flatMap(collectionSize)) match {
-      case (Some(m), Some(c)) if m != c => Some(math.abs(m.toLong - c.toLong))
+      case (Some(m), Some(c)) if m != c => Some((m, c))
       case _                            => None
     }
+  }
+
+  /** Outcome of comparing one `_ttl`/`_writetime` metadata column. Distinguishes a genuine time/TTL
+    * difference (reported in millis) from structural problems (malformed metadata, cardinality
+    * mismatch) so the latter are not mislabelled as a "(N millis)" delta.
+    */
+  private[migrator] sealed trait MetadataDiff { def field: String }
+  private[migrator] object MetadataDiff {
+    case class TimeDiff(field: String, diffMillis: Long) extends MetadataDiff
+    case class Malformed(field: String) extends MetadataDiff
+    case class CardinalityMismatch(field: String, detail: String) extends MetadataDiff
   }
 
   /** Compare a TTL/WRITETIME metadata column that may be scalar or per-element (array-typed).
@@ -325,9 +371,10 @@ object RowComparisonFailure {
     * Both source and target return the metadata in the same server (sorted) order, so elements are
     * compared positionally. Guards first against malformed metadata (non-numeric entries) and, for
     * per-element metadata, against a metadata/collection cardinality mismatch on either side — both
-    * would otherwise let corrupt data validate as equal. Returns the field name paired with the
-    * largest absolute per-element difference that exceeds `tolerance` (or the relevant count
-    * discrepancy), or `None` when the values match within tolerance.
+    * would otherwise let corrupt data validate as equal. Returns the largest absolute per-element
+    * difference that exceeds `tolerance` as a [[MetadataDiff.TimeDiff]], a structural
+    * [[MetadataDiff.Malformed]]/[[MetadataDiff.CardinalityMismatch]], or `None` when the values
+    * match within tolerance.
     */
   private[migrator] def diffTimestampMetadata(
     left: CassandraRow,
@@ -337,21 +384,43 @@ object RowComparisonFailure {
     leftBase: Option[Any] = None,
     rightBase: Option[Any] = None,
     valueScaleToMillis: Long = 1L
-  ): Option[(String, Long)] =
+  ): Option[MetadataDiff] =
     if (hasMalformedMetadata(left, name) || hasMalformedMetadata(right, name))
-      Some(name -> -1L) // sentinel: non-numeric/unexpected metadata type
+      Some(MetadataDiff.Malformed(name))
     else
       cardinalityMismatch(left, name, leftBase)
-        .orElse(cardinalityMismatch(right, name, rightBase))
-        .map(name -> _)
+        .map { case (m, c) => s"source metadata has $m entries for a collection of $c elements" }
+        .orElse(cardinalityMismatch(right, name, rightBase).map { case (m, c) =>
+          s"target metadata has $m entries for a collection of $c elements"
+        })
+        .map(detail => MetadataDiff.CardinalityMismatch(name, detail))
         .orElse {
           (metadataAsLongs(left, name), metadataAsLongs(right, name)) match {
-            case (None, None)     => None
-            case (Some(ls), None) => Some(name -> ls.headOption.getOrElse(0L))
-            case (None, Some(rs)) => Some(name -> rs.headOption.getOrElse(0L))
+            case (None, None) => None
+            case (Some(ls), None) =>
+              Some(
+                MetadataDiff
+                  .CardinalityMismatch(
+                    name,
+                    s"source has ${ls.length} metadata entries, target none"
+                  )
+              )
+            case (None, Some(rs)) =>
+              Some(
+                MetadataDiff
+                  .CardinalityMismatch(
+                    name,
+                    s"target has ${rs.length} metadata entries, source none"
+                  )
+              )
             case (Some(ls), Some(rs)) =>
               if (ls.length != rs.length)
-                Some(name -> math.abs(ls.length.toLong - rs.length.toLong))
+                Some(
+                  MetadataDiff.CardinalityMismatch(
+                    name,
+                    s"source has ${ls.length} entries, target has ${rs.length}"
+                  )
+                )
               else {
                 // Diffs are scaled to the tolerance's unit (millis) so the report and the tolerance
                 // agree; `valueScaleToMillis` is 1 for values already in the tolerance unit.
@@ -359,7 +428,8 @@ object RowComparisonFailure {
                   ls.zip(rs)
                     .map { case (l, r) => math.abs(l - r) * valueScaleToMillis }
                     .filter(_ > tolerance)
-                if (exceeding.isEmpty) None else Some(name -> exceeding.max)
+                if (exceeding.isEmpty) None
+                else Some(MetadataDiff.TimeDiff(name, exceeding.max))
               }
           }
         }

--- a/migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala
@@ -59,10 +59,15 @@ object RowComparisonFailure {
               s"$fieldName ($ttlDiff millis)"
             }
             .mkString(", ")}")
+
+    /** WRITETIME is stored in MICROseconds, and the diff is reported in that same unit (the
+      * `writetimeToleranceMillis` config is converted to micros for the comparison). Labelling it
+      * "millis" would overstate every difference by 1000x and cause the tolerance to be mis-tuned.
+      */
     case class DifferingWritetimes(details: List[(String, Long)])
         extends Item(s"Differing WRITETIMEs: ${details
             .map { case (fieldName, writeTimeDiff) =>
-              s"$fieldName ($writeTimeDiff millis)"
+              s"$fieldName ($writeTimeDiff micros)"
             }
             .mkString(", ")}")
 
@@ -426,13 +431,32 @@ object RowComparisonFailure {
                 // agree; `valueScaleToMillis` is 1 for values already in the tolerance unit.
                 val exceeding =
                   ls.zip(rs)
-                    .map { case (l, r) => math.abs(l - r) * valueScaleToMillis }
+                    .map { case (l, r) => saturatingScaledAbsDiff(l, r, valueScaleToMillis) }
                     .filter(_ > tolerance)
                 if (exceeding.isEmpty) None
                 else Some(MetadataDiff.TimeDiff(name, exceeding.max))
               }
           }
         }
+
+  /** `|l - r| * scale`, saturating at `Long.MaxValue` instead of wrapping.
+    *
+    * Plain `math.abs(l - r) * scale` can overflow on adversarial metadata (e.g. a hand-crafted
+    * Parquet writetime of `Long.MinValue`), and a wrapped NEGATIVE difference silently passes the
+    * `diff > tolerance` test — reporting a corrupt row as identical. Saturating keeps the
+    * comparison monotonic, and `Long.MaxValue` exceeds every valid tolerance so such a row is
+    * always flagged. The happy path allocates nothing (no `BigInt`), which matters because this
+    * runs per element of every per-element metadata array.
+    */
+  private def saturatingScaledAbsDiff(l: Long, r: Long, scale: Long): Long =
+    try {
+      val diff = Math.subtractExact(l, r)
+      // `math.abs(Long.MinValue)` is itself negative; `subtractExact` permits that exact value.
+      if (diff == Long.MinValue) Long.MaxValue
+      else Math.multiplyExact(math.abs(diff), scale)
+    } catch {
+      case _: ArithmeticException => Long.MaxValue
+    }
 
   /** @param leftValue
     *   First value to compare

--- a/migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala
@@ -148,36 +148,41 @@ object RowComparisonFailure {
             for {
               name <- names
               if name.endsWith("_ttl")
-              leftTtl  = left.getLongOption(name)
-              rightTtl = right.getLongOption(name)
-              result <- (leftTtl, rightTtl) match {
-                          case (Some(l), Some(r)) if math.abs(l - r) > ttlToleranceMillis =>
-                            Some(name -> math.abs(l - r))
-                          case (Some(l), None)    => Some(name -> l)
-                          case (None, Some(r))    => Some(name -> r)
-                          case (Some(l), Some(r)) => None
-                          case (None, None)       => None
-                        }
+              baseName = name.stripSuffix("_ttl")
+              // CQL TTL() is expressed in SECONDS, but the tolerance is configured in millis and the
+              // failure is reported "(… millis)". Scale each per-element TTL diff to millis so the
+              // comparison, the config unit, and the label all agree (previously seconds were
+              // compared against a millis tolerance, i.e. 1000x too lenient).
+              result <- diffTimestampMetadata(
+                          left,
+                          right,
+                          name,
+                          ttlToleranceMillis,
+                          leftMap.get(baseName),
+                          rightMap.get(baseName),
+                          valueScaleToMillis = 1000L
+                        )
             } yield result
 
-        // WRITETIME is expressed in microseconds
-        val writetimeToleranceMicros = writetimeToleranceMillis * 1000
+        // WRITETIME is expressed in microseconds. `multiplyExact` so an absurd tolerance config
+        // fails loudly instead of silently wrapping to a negative value (which would make every
+        // element "exceed" and produce spurious diffs).
+        val writetimeToleranceMicros = Math.multiplyExact(writetimeToleranceMillis, 1000L)
         val differingWritetimes =
           if (!compareTimestamps) Nil
           else
             for {
               name <- names
               if name.endsWith("_writetime")
-              leftWritetime  = left.getLongOption(name)
-              rightWritetime = right.getLongOption(name)
-              result <- (leftWritetime, rightWritetime) match {
-                          case (Some(l), Some(r)) if math.abs(l - r) > writetimeToleranceMicros =>
-                            Some(name -> math.abs(l - r))
-                          case (Some(l), None)    => Some(name -> l)
-                          case (None, Some(r))    => Some(name -> r)
-                          case (Some(l), Some(r)) => None
-                          case (None, None)       => None
-                        }
+              baseName = name.stripSuffix("_writetime")
+              result <- diffTimestampMetadata(
+                          left,
+                          right,
+                          name,
+                          writetimeToleranceMicros,
+                          leftMap.get(baseName),
+                          rightMap.get(baseName)
+                        )
             } yield result
 
         if (
@@ -259,6 +264,105 @@ object RowComparisonFailure {
             )
           )
     }
+
+  /** Extract a `_ttl`/`_writetime` metadata value as a sequence of `Long`s.
+    *
+    * Scalar metadata (scalar columns and frozen collections) becomes a single-element sequence;
+    * per-element collection metadata (non-frozen maps/sets under `preserveCollectionTimestamps`)
+    * arrives as a list, one value per collection element in server (sorted) order. Returns `None`
+    * when the value is absent/null (e.g. an empty or null collection has no metadata).
+    */
+  private[migrator] def metadataAsLongs(row: CassandraRow, name: String): Option[Seq[Long]] =
+    Option(row.getRaw(name)).flatMap {
+      case s: scala.collection.Seq[_] =>
+        Some(s.map {
+          case n: Number => n.longValue()
+          case _         => 0L
+        }.toSeq)
+      case n: Number => Some(Seq(n.longValue()))
+      case _         => None
+    }
+
+  /** Element count of a collection value (map/set/list), or `None` for scalar values. Used to
+    * validate that per-element (array-typed) metadata has one entry per collection element.
+    */
+  private def collectionSize(value: Any): Option[Int] = value match {
+    case m: scala.collection.Map[_, _] => Some(m.size)
+    case s: scala.collection.Set[_]    => Some(s.size)
+    case s: scala.collection.Seq[_]    => Some(s.size)
+    case _ => None // scalars, incl. blobs (Array[Byte]), are not collections here
+  }
+
+  /** True when a metadata value is present but not a clean numeric scalar or numeric/null array
+    * (e.g. a non-numeric element, or a wholly unexpected type). Such values must never be silently
+    * coerced to 0 and validate as equal (M5).
+    */
+  private def hasMalformedMetadata(row: CassandraRow, name: String): Boolean =
+    Option(row.getRaw(name)).exists {
+      case s: scala.collection.Seq[_] => s.exists(e => e != null && !e.isInstanceOf[Number])
+      case _: Number                  => false
+      case _                          => true
+    }
+
+  /** For array-typed (per-element) metadata, the discrepancy between the metadata length and the
+    * associated collection's element count, if they disagree. Scalar metadata (raw is a `Number`)
+    * and non-collection base values are skipped.
+    */
+  private def cardinalityMismatch(
+    row: CassandraRow,
+    name: String,
+    baseValue: Option[Any]
+  ): Option[Long] = {
+    val metaLen = Option(row.getRaw(name)).collect { case s: scala.collection.Seq[_] => s.length }
+    (metaLen, baseValue.flatMap(collectionSize)) match {
+      case (Some(m), Some(c)) if m != c => Some(math.abs(m.toLong - c.toLong))
+      case _                            => None
+    }
+  }
+
+  /** Compare a TTL/WRITETIME metadata column that may be scalar or per-element (array-typed).
+    *
+    * Both source and target return the metadata in the same server (sorted) order, so elements are
+    * compared positionally. Guards first against malformed metadata (non-numeric entries) and, for
+    * per-element metadata, against a metadata/collection cardinality mismatch on either side — both
+    * would otherwise let corrupt data validate as equal. Returns the field name paired with the
+    * largest absolute per-element difference that exceeds `tolerance` (or the relevant count
+    * discrepancy), or `None` when the values match within tolerance.
+    */
+  private[migrator] def diffTimestampMetadata(
+    left: CassandraRow,
+    right: CassandraRow,
+    name: String,
+    tolerance: Long,
+    leftBase: Option[Any] = None,
+    rightBase: Option[Any] = None,
+    valueScaleToMillis: Long = 1L
+  ): Option[(String, Long)] =
+    if (hasMalformedMetadata(left, name) || hasMalformedMetadata(right, name))
+      Some(name -> -1L) // sentinel: non-numeric/unexpected metadata type
+    else
+      cardinalityMismatch(left, name, leftBase)
+        .orElse(cardinalityMismatch(right, name, rightBase))
+        .map(name -> _)
+        .orElse {
+          (metadataAsLongs(left, name), metadataAsLongs(right, name)) match {
+            case (None, None)     => None
+            case (Some(ls), None) => Some(name -> ls.headOption.getOrElse(0L))
+            case (None, Some(rs)) => Some(name -> rs.headOption.getOrElse(0L))
+            case (Some(ls), Some(rs)) =>
+              if (ls.length != rs.length)
+                Some(name -> math.abs(ls.length.toLong - rs.length.toLong))
+              else {
+                // Diffs are scaled to the tolerance's unit (millis) so the report and the tolerance
+                // agree; `valueScaleToMillis` is 1 for values already in the tolerance unit.
+                val exceeding =
+                  ls.zip(rs)
+                    .map { case (l, r) => math.abs(l - r) * valueScaleToMillis }
+                    .filter(_ > tolerance)
+                if (exceeding.isEmpty) None else Some(name -> exceeding.max)
+              }
+          }
+        }
 
   /** @param leftValue
     *   First value to compare

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -321,6 +321,65 @@ object Scylla {
     )
   }
 
+  /** Write per-element collection-timestamp rows for a single non-frozen collection column.
+    *
+    * Each row is `[primary key columns..., singleton/grouped collection value, ttl, writetime]`
+    * (positionally aligned with `rowSchema`, whose last two fields are `ttl`/`writetime`). The
+    * collection column is written with `col = col + ?` (CQL append) so only the elements carried by
+    * that row are added, while the per-row `USING TTL ? AND TIMESTAMP ?` restores each element's
+    * original TTL/WRITETIME. Because appends are idempotent, this pass does not accumulate token
+    * ranges for savepoints.
+    */
+  def writeCollectionAppendRDD(
+    target: TargetSettings.Scylla,
+    renames: List[Rename],
+    columnName: String,
+    rdd: RDD[Row],
+    rowSchema: StructType,
+    source: SourceSettings
+  )(implicit spark: SparkSession): Unit = {
+    val renamedSchema = renameSchemaFields(rowSchema, renames)
+    val renamedCollectionName =
+      renames.collectFirst { case Rename(`columnName`, to) => to }.getOrElse(columnName)
+
+    requireNoCaseInsensitiveColumnNameCollisions(
+      renamedSchema.fieldNames.toSeq,
+      "after applying renames before a collection-append write to ScyllaDB"
+    )
+
+    val connector = Connectors.targetConnector(spark.sparkContext.getConf, target)
+    val consistencyLevel = ConsistencyLevelUtils.parseConsistencyLevel(target.consistencyLevel)
+    val writeConf = WriteConf
+      .fromSparkConf(spark.sparkContext.getConf)
+      .copy(
+        consistencyLevel = consistencyLevel,
+        ttl              = TTLOption.perRow("ttl"),
+        timestamp        = TimestampOption.perRow("writetime")
+      )
+
+    val columnSelector = SomeColumns(
+      ArraySeq.unsafeWrapArray(renamedSchema.fields.map { field =>
+        field.name match {
+          case "ttl" | "writetime"             => field.name: ColumnRef
+          case n if n == renamedCollectionName => CollectionColumnName(n, None, CollectionAppend)
+          case n                               => n: ColumnRef
+        }
+      }): _*
+    )
+
+    log.info(
+      s"Collection-append write for column '${columnName}' (target '${renamedCollectionName}'); schema:"
+    )
+    log.info(renamedSchema.treeString)
+
+    rdd.saveToCassandra(
+      target.keyspace,
+      target.table,
+      columnSelector,
+      writeConf
+    )(connector, SqlRowWriter.Factory)
+  }
+
   def writeDataframe(
     target: TargetSettings.Scylla,
     renames: List[Rename],

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -153,6 +153,30 @@ object Scylla {
     }
   }
 
+  /** Strip trailing zeros from decimal cells when the target requests it.
+    *
+    * Spark's conversion from its internal Decimal type to `java.math.BigDecimal` pads the value
+    * with trailing zeros matching the Decimal scale; some users don't want that. Handles both plain
+    * `java.math.BigDecimal` (DataFrame rows) and `CassandraOption.Value(BigDecimal)` (exploded RDD
+    * / collection-append rows). No-op when disabled. Shared by the base and collection-append write
+    * paths so they strip decimals symmetrically.
+    */
+  private def stripTrailingZerosIfEnabled(
+    target: TargetSettings.Scylla,
+    rdd: RDD[Row]
+  ): RDD[Row] =
+    if (!target.stripTrailingZerosForDecimals) rdd
+    else
+      rdd.map { row =>
+        Row.fromSeq(row.toSeq.map {
+          case x: java.math.BigDecimal =>
+            x.stripTrailingZeros()
+          case CassandraOption.Value(x: java.math.BigDecimal) =>
+            CassandraOption.Value(x.stripTrailingZeros())
+          case x => x
+        })
+      }
+
   /** Shared write path used by both [[writeRowRDD]] and [[writeDataframe]], invoked once internal
     * columns have been dropped and renames applied. `schema0` is the pre-rename schema, required by
     * [[resolvePrimaryKeyColumns]] (which reverse-maps target primary-key names back to source
@@ -227,23 +251,7 @@ object Scylla {
       ArraySeq.unsafeWrapArray(renamedSchema.fields.map(_.name: ColumnRef)): _*
     )
 
-    // Spark's conversion from its internal Decimal type to java.math.BigDecimal
-    // pads the resulting value with trailing zeros corresponding to the scale of the
-    // Decimal type. Some users don't like this so we conditionally strip those. The
-    // CassandraOption.Value case only occurs on the exploded RDD path; it is inert for
-    // plain DataFrame rows.
-    val rddStripped =
-      if (!target.stripTrailingZerosForDecimals) rdd0
-      else
-        rdd0.map { row =>
-          Row.fromSeq(row.toSeq.map {
-            case x: java.math.BigDecimal =>
-              x.stripTrailingZeros()
-            case CassandraOption.Value(x: java.math.BigDecimal) =>
-              CassandraOption.Value(x.stripTrailingZeros())
-            case x => x
-          })
-        }
+    val rddStripped = stripTrailingZerosIfEnabled(target, rdd0)
 
     // Optionally filter out rows where any primary key column is null to prevent
     // infinite retries against the target database (see issue #262).
@@ -384,13 +392,52 @@ object Scylla {
     )
     log.info(renamedSchema.treeString)
 
-    rdd.saveToCassandra(
+    // Mirror the safety steps `writeCleanedRdd` applies to the base write so the append pass does
+    // not behave asymmetrically. Without this, a Parquet source (where `dropNullPrimaryKeys`
+    // auto-defaults to true) drops null-PK rows in the base write but retries them forever here
+    // (issue #262), and set<decimal>/map<_,decimal> elements are appended without the trailing-zero
+    // stripping applied to scalar decimals, producing spurious validation diffs.
+    val rddStripped = stripTrailingZerosIfEnabled(target, rdd)
+
+    val (finalRdd, nullPkRowsDropped) =
+      if (!shouldDropNullPrimaryKeys(target, source)) (rddStripped, None)
+      else {
+        val tableDef =
+          connector.withSessionDo(Schema.tableFromCassandra(_, target.keyspace, target.table))
+        val targetPkNames = tableDef.primaryKey.map(_.columnName).toSet
+        val pkResolution = resolvePrimaryKeyColumns(targetPkNames, renames, rowSchema)
+        pkResolution.unresolvedSourcePkNames.foreach { sourcePkName =>
+          log.warn(
+            s"Primary key column '${sourcePkName}' not found in collection-append schema for " +
+              s"'${columnName}'"
+          )
+        }
+        requireAllPrimaryKeysResolved(targetPkNames, pkResolution)
+        val accumulator =
+          spark.sparkContext.longAccumulator(
+            s"Null primary key rows dropped (collection append: ${columnName})"
+          )
+        (
+          dropRowsWithNullPrimaryKeys(rddStripped, pkResolution.fieldIndices, accumulator),
+          Some(accumulator)
+        )
+      }
+
+    finalRdd.saveToCassandra(
       target.keyspace,
       target.table,
       columnSelector,
       writeConf,
       tokenRangeAccumulator = tokenRangeAccumulator
     )(connector, SqlRowWriter.Factory)
+
+    nullPkRowsDropped.foreach { acc =>
+      if (acc.value > 0)
+        log.warn(
+          s"Dropped ${acc.value} rows with null primary key values in the collection-append pass " +
+            s"for '${columnName}'"
+        )
+    }
   }
 
   def writeDataframe(

--- a/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
+++ b/migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala
@@ -327,8 +327,13 @@ object Scylla {
     * (positionally aligned with `rowSchema`, whose last two fields are `ttl`/`writetime`). The
     * collection column is written with `col = col + ?` (CQL append) so only the elements carried by
     * that row are added, while the per-row `USING TTL ? AND TIMESTAMP ?` restores each element's
-    * original TTL/WRITETIME. Because appends are idempotent, this pass does not accumulate token
-    * ranges for savepoints.
+    * original TTL/WRITETIME.
+    *
+    * `tokenRangeAccumulator` must be supplied ONLY for the final write pass of a migration (the
+    * last collection-append column). Because passes run sequentially, a token range is only truly
+    * complete after this last pass finishes it, at which point the base write and all earlier
+    * append passes have already committed that range. Ranges reprocessed on resume are idempotent
+    * (INSERT/append with `USING TIMESTAMP`), so partially-written ranges converge on re-run.
     */
   def writeCollectionAppendRDD(
     target: TargetSettings.Scylla,
@@ -336,11 +341,18 @@ object Scylla {
     columnName: String,
     rdd: RDD[Row],
     rowSchema: StructType,
+    tokenRangeAccumulator: Option[TokenRangeAccumulator],
     source: SourceSettings
   )(implicit spark: SparkSession): Unit = {
     val renamedSchema = renameSchemaFields(rowSchema, renames)
+    // Resolve the target column name with the SAME transitive fold as `renameSchemaFields`
+    // (renames apply sequentially: a->b then b->c yields "c"). A `collectFirst` on the first hop
+    // would stop at "b", mismatch the renamed field "c" in the selector below, and silently fall
+    // back to a plain ColumnRef (overwrite) instead of CollectionAppend.
     val renamedCollectionName =
-      renames.collectFirst { case Rename(`columnName`, to) => to }.getOrElse(columnName)
+      renames.foldLeft(columnName) { case (current, Rename(from, to)) =>
+        if (current == from) to else current
+      }
 
     requireNoCaseInsensitiveColumnNameCollisions(
       renamedSchema.fieldNames.toSeq,
@@ -376,7 +388,8 @@ object Scylla {
       target.keyspace,
       target.table,
       columnSelector,
-      writeConf
+      writeConf,
+      tokenRangeAccumulator = tokenRangeAccumulator
     )(connector, SqlRowWriter.Factory)
   }
 

--- a/tests/src/test/configurations/cassandra5-to-cassandra5-collection-timestamps-repair.yaml
+++ b/tests/src/test/configurations/cassandra5-to-cassandra5-collection-timestamps-repair.yaml
@@ -1,0 +1,49 @@
+source:
+  type: cassandra
+  host: cassandra5
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: collts_rep_src
+  consistencyLevel: LOCAL_QUORUM
+  preserveTimestamps: true
+  preserveCollectionTimestamps: true
+  splitCount: 8
+  connections: 8
+  fetchSize: 1000
+
+# Target points at the Cassandra 5.0 container (remapped to the cassandra5 host port by the test
+# harness) because ScyllaDB cannot read back WRITETIME()/TTL() of non-frozen collections for
+# verification, whereas Cassandra 5.0 can.
+target:
+  type: scylla
+  host: cassandra5
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: collts_rep_dst
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300
+
+validation:
+  compareTimestamps: true
+  ttlToleranceMillis: 60000
+  writetimeToleranceMillis: 1000
+  failuresToFetch: 100
+  floatingPointTolerance: 0.001
+  timestampMsTolerance: 0
+  copyMissingRows: true
+  # Keep source per-element timestamps intact on the repaired base write as well, so the test can
+  # assert exact WRITETIME preservation end to end.
+  repairWritetimeStrategy: source

--- a/tests/src/test/configurations/cassandra5-to-cassandra5-collection-timestamps.yaml
+++ b/tests/src/test/configurations/cassandra5-to-cassandra5-collection-timestamps.yaml
@@ -1,0 +1,46 @@
+source:
+  type: cassandra
+  host: cassandra5
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: collts_src
+  consistencyLevel: LOCAL_QUORUM
+  preserveTimestamps: true
+  preserveCollectionTimestamps: true
+  splitCount: 8
+  connections: 8
+  fetchSize: 1000
+
+# Target points at the Cassandra 5.0 container (remapped to the cassandra5 host port by the test
+# harness) because ScyllaDB cannot yet read back WRITETIME()/TTL() of non-frozen collections for
+# verification, whereas Cassandra 5.0 can. The write path is plain CQL, identical for either target.
+target:
+  type: scylla
+  host: cassandra5
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: collts_dst
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300
+
+validation:
+  compareTimestamps: true
+  ttlToleranceMillis: 60000
+  writetimeToleranceMillis: 1000
+  failuresToFetch: 100
+  floatingPointTolerance: 0.001
+  timestampMsTolerance: 0
+  copyMissingRows: false

--- a/tests/src/test/configurations/cassandra5-to-parquet-collection-timestamps.yaml
+++ b/tests/src/test/configurations/cassandra5-to-parquet-collection-timestamps.yaml
@@ -1,0 +1,28 @@
+source:
+  type: cassandra
+  host: cassandra5
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: collts_pq_src
+  consistencyLevel: LOCAL_QUORUM
+  preserveTimestamps: true
+  preserveCollectionTimestamps: true
+  splitCount: 8
+  connections: 8
+  fetchSize: 1000
+
+# Per-element collection TTL/WRITETIME are exported as array sidecars
+# (__migrator_meta_<col>_ttl / __migrator_meta_<col>_writetime) alongside the collection value.
+target:
+  type: parquet
+  path: /app/parquet/collection-timestamps
+  compression: gzip
+  mode: overwrite
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300

--- a/tests/src/test/configurations/parquet-to-cassandra5-collection-timestamps.yaml
+++ b/tests/src/test/configurations/parquet-to-cassandra5-collection-timestamps.yaml
@@ -1,0 +1,25 @@
+source:
+  type: parquet
+  path: /app/parquet/collection-timestamps
+
+# Target points at the Cassandra 5.0 container (remapped to the cassandra5 host port by the test
+# harness) because ScyllaDB cannot read back WRITETIME()/TTL() of non-frozen collections for
+# verification, whereas Cassandra 5.0 can. The write path is plain CQL, identical for either target.
+target:
+  type: scylla
+  host: cassandra5
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: collts_pq_dst
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300
+  enableParquetFileTracking: false

--- a/tests/src/test/configurations/scylla2026-to-scylla2026-collection-timestamps.yaml
+++ b/tests/src/test/configurations/scylla2026-to-scylla2026-collection-timestamps.yaml
@@ -1,0 +1,47 @@
+source:
+  type: cassandra
+  host: scylla2026
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: collts_src
+  consistencyLevel: LOCAL_QUORUM
+  preserveTimestamps: true
+  preserveCollectionTimestamps: true
+  splitCount: 8
+  connections: 8
+  fetchSize: 1000
+
+# Both ends are ScyllaDB 2026.2, which reads per-element non-frozen collection WRITETIME()/TTL()
+# via the subscript form WRITETIME(col[key]). The migrator auto-detects this and uses the subscript
+# metadata read path (the Cassandra 5.0 collection-wide WRITETIME(col) list form is rejected by
+# ScyllaDB).
+target:
+  type: scylla
+  host: scylla2026
+  port: 9042
+  localDC: datacenter1
+  credentials:
+    username: dummy
+    password: dummy
+  keyspace: test
+  table: collts_dst
+  consistencyLevel: LOCAL_QUORUM
+  connections: 16
+  stripTrailingZerosForDecimals: false
+
+savepoints:
+  path: /app/savepoints
+  intervalSeconds: 300
+
+validation:
+  compareTimestamps: true
+  ttlToleranceMillis: 60000
+  writetimeToleranceMillis: 1000
+  failuresToFetch: 100
+  floatingPointTolerance: 0.001
+  timestampMsTolerance: 0
+  copyMissingRows: false

--- a/tests/src/test/scala/com/scylladb/migrator/Scylla2026Compat.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/Scylla2026Compat.scala
@@ -1,0 +1,10 @@
+package com.scylladb.migrator
+
+/** Tag for tests that require ScyllaDB >= 2026.2 (per-element non-frozen collection
+  * WRITETIME()/TTL() via the subscript form).
+  *
+  * These run in a dedicated CI job that starts the pinned `scylla2026` service. They are excluded
+  * from the main Scylla integration job, whose shared `scylla` service tracks SCYLLA_VERSION and
+  * may be older (and uses SimpleStrategy fixtures that 2026.2 rejects).
+  */
+class Scylla2026Compat extends munit.Tag("Scylla2026Compat")

--- a/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/SparkUtils.scala
@@ -158,7 +158,8 @@ object SparkUtils {
     "cassandra3"    -> 9045,
     "cassandra5"    -> 9047,
     "scylla"        -> 9042,
-    "scylla-source" -> 9044
+    "scylla-source" -> 9044,
+    "scylla2026"    -> 9048
   )
 
   /** Map from Docker Compose MySQL hostnames to the exposed localhost port. */

--- a/tests/src/test/scala/com/scylladb/migrator/readers/CassandraCopyTypeTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/CassandraCopyTypeTest.scala
@@ -139,4 +139,46 @@ class CassandraCopyTypeTest extends munit.FunSuite {
       Right(CopyType.NoTimestampPreservation)
     )
   }
+
+  test("column named 'ttl' or 'writetime' collides with reserved metadata names and is rejected") {
+    for (name <- Seq("ttl", "writetime")) {
+      val tableDef = tableWith(ColumnDef(name, RegularColumn, IntType))
+      val result = Cassandra.determineCopyType(tableDef, preserveTimesRequest = true)
+      assert(
+        result.isLeft,
+        s"Expected reserved-name column '${name}' to be rejected, got: ${result}"
+      )
+      assert(
+        result.left.exists(_.getMessage.contains("reserves the internal column names")),
+        s"Unexpected error message for '${name}': ${result}"
+      )
+    }
+  }
+
+  test("column shaped like a '<col>_ttl'/'<col>_writetime' sidecar is rejected") {
+    for (name <- Seq("foo_ttl", "foo_writetime")) {
+      val tableDef =
+        tableWith(
+          ColumnDef("foo", RegularColumn, VarCharType),
+          ColumnDef(name, RegularColumn, IntType)
+        )
+      val result = Cassandra.determineCopyType(tableDef, preserveTimesRequest = true)
+      assert(
+        result.isLeft,
+        s"Expected sidecar-colliding column '${name}' to be rejected, got: ${result}"
+      )
+      assert(
+        result.left.exists(_.getMessage.contains("reserves the internal column names")),
+        s"Unexpected error message for '${name}': ${result}"
+      )
+    }
+  }
+
+  test("reserved-name column is harmless when preserveTimestamps is disabled") {
+    val tableDef = tableWith(ColumnDef("ttl", RegularColumn, IntType))
+    assertEquals(
+      Cassandra.determineCopyType(tableDef, preserveTimesRequest = false),
+      Right(CopyType.NoTimestampPreservation)
+    )
+  }
 }

--- a/tests/src/test/scala/com/scylladb/migrator/readers/CassandraCopyTypeTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/CassandraCopyTypeTest.scala
@@ -1,0 +1,142 @@
+package com.scylladb.migrator.readers
+
+import com.datastax.spark.connector.cql.{ ColumnDef, PartitionKeyColumn, RegularColumn, TableDef }
+import com.datastax.spark.connector.types.{
+  IntType,
+  ListType,
+  MapType,
+  SetType,
+  UUIDType,
+  VarCharType
+}
+import com.scylladb.migrator.config.CopyType
+
+/** Unit coverage for [[Cassandra.determineCopyType]] focusing on the frozen vs non-frozen
+  * collection behavior. Frozen collections are single-cell and flow through the timestamp
+  * preservation path; non-frozen (multi-cell) collections are rejected unless the opt-in
+  * `preserveCollectionTimestamps` is set (and then only supported sets/maps are accepted).
+  */
+class CassandraCopyTypeTest extends munit.FunSuite {
+
+  private def tableWith(regular: ColumnDef*): TableDef =
+    TableDef(
+      keyspaceName      = "test",
+      tableName         = "t",
+      partitionKey      = Seq(ColumnDef("id", PartitionKeyColumn, VarCharType)),
+      clusteringColumns = Seq.empty,
+      regularColumns    = regular
+    )
+
+  test("scalar-only table with preserveTimestamps uses WithTimestampPreservation") {
+    val tableDef = tableWith(ColumnDef("foo", RegularColumn, VarCharType))
+    assertEquals(
+      Cassandra.determineCopyType(tableDef, preserveTimesRequest = true),
+      Right(CopyType.WithTimestampPreservation)
+    )
+  }
+
+  test("frozen collection with preserveTimestamps is allowed (single-cell)") {
+    val frozenSet = ColumnDef("tags", RegularColumn, SetType(VarCharType, isFrozen = true))
+    val frozenList = ColumnDef("items", RegularColumn, ListType(IntType, isFrozen = true))
+    val frozenMap =
+      ColumnDef("attrs", RegularColumn, MapType(VarCharType, IntType, isFrozen = true))
+
+    for (col <- Seq(frozenSet, frozenList, frozenMap)) {
+      val tableDef = tableWith(ColumnDef("foo", RegularColumn, VarCharType), col)
+      assertEquals(
+        Cassandra.determineCopyType(tableDef, preserveTimesRequest = true),
+        Right(CopyType.WithTimestampPreservation),
+        s"Expected frozen collection column '${col.columnName}' to be allowed"
+      )
+    }
+  }
+
+  test("non-frozen (multi-cell) collection with preserveTimestamps is rejected") {
+    val nonFrozenSet = ColumnDef("tags", RegularColumn, SetType(VarCharType))
+    val nonFrozenList = ColumnDef("items", RegularColumn, ListType(IntType))
+    val nonFrozenMap = ColumnDef("attrs", RegularColumn, MapType(VarCharType, IntType))
+
+    for (col <- Seq(nonFrozenSet, nonFrozenList, nonFrozenMap)) {
+      val tableDef = tableWith(ColumnDef("foo", RegularColumn, VarCharType), col)
+      val result = Cassandra.determineCopyType(tableDef, preserveTimesRequest = true)
+      assert(
+        result.isLeft,
+        s"Expected non-frozen collection column '${col.columnName}' to be rejected, got: ${result}"
+      )
+      assert(
+        result.left.exists(
+          _.getMessage.contains(
+            "TTL/Writetime preservation is unsupported for tables with non-frozen (multi-cell)"
+          )
+        ),
+        s"Unexpected error message: ${result}"
+      )
+    }
+  }
+
+  test("non-frozen set/map with preserveCollectionTimestamps is allowed") {
+    val nonFrozenSet = ColumnDef("tags", RegularColumn, SetType(IntType))
+    val nonFrozenMap = ColumnDef("attrs", RegularColumn, MapType(VarCharType, IntType))
+
+    for (col <- Seq(nonFrozenSet, nonFrozenMap)) {
+      val tableDef = tableWith(ColumnDef("foo", RegularColumn, VarCharType), col)
+      assertEquals(
+        Cassandra.determineCopyType(
+          tableDef,
+          preserveTimesRequest           = true,
+          preserveCollectionTimesRequest = true
+        ),
+        Right(CopyType.WithTimestampPreservation),
+        s"Expected non-frozen collection column '${col.columnName}' to be allowed under opt-in"
+      )
+    }
+  }
+
+  test("non-frozen list is rejected even with preserveCollectionTimestamps") {
+    val tableDef =
+      tableWith(
+        ColumnDef("foo", RegularColumn, VarCharType),
+        ColumnDef("items", RegularColumn, ListType(IntType))
+      )
+    val result = Cassandra.determineCopyType(
+      tableDef,
+      preserveTimesRequest           = true,
+      preserveCollectionTimesRequest = true
+    )
+    assert(result.isLeft, s"Expected non-frozen list to be rejected, got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("non-frozen list")),
+      s"Unexpected error message: ${result}"
+    )
+  }
+
+  test("non-frozen map with unsupported key type is rejected with preserveCollectionTimestamps") {
+    val tableDef =
+      tableWith(
+        ColumnDef("foo", RegularColumn, VarCharType),
+        ColumnDef("attrs", RegularColumn, MapType(UUIDType, IntType))
+      )
+    val result = Cassandra.determineCopyType(
+      tableDef,
+      preserveTimesRequest           = true,
+      preserveCollectionTimesRequest = true
+    )
+    assert(result.isLeft, s"Expected unsupported map key type to be rejected, got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("unsupported key type")),
+      s"Unexpected error message: ${result}"
+    )
+  }
+
+  test("non-frozen collection without preserveTimestamps uses NoTimestampPreservation") {
+    val tableDef =
+      tableWith(
+        ColumnDef("foo", RegularColumn, VarCharType),
+        ColumnDef("tags", RegularColumn, SetType(VarCharType))
+      )
+    assertEquals(
+      Cassandra.determineCopyType(tableDef, preserveTimesRequest = false),
+      Right(CopyType.NoTimestampPreservation)
+    )
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/readers/CassandraCopyTypeTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/CassandraCopyTypeTest.scala
@@ -1,12 +1,21 @@
 package com.scylladb.migrator.readers
 
-import com.datastax.spark.connector.cql.{ ColumnDef, PartitionKeyColumn, RegularColumn, TableDef }
+import com.datastax.spark.connector.cql.{
+  ClusteringColumn,
+  ColumnDef,
+  PartitionKeyColumn,
+  RegularColumn,
+  StaticColumn,
+  TableDef
+}
 import com.datastax.spark.connector.types.{
   IntType,
   ListType,
   MapType,
   SetType,
+  UDTFieldDef,
   UUIDType,
+  UserDefinedType,
   VarCharType
 }
 import com.scylladb.migrator.config.CopyType
@@ -172,6 +181,63 @@ class CassandraCopyTypeTest extends munit.FunSuite {
         s"Unexpected error message for '${name}': ${result}"
       )
     }
+  }
+
+  test("static non-frozen collection is rejected with preserveCollectionTimestamps") {
+    // A static cell belongs to the partition, not the row, so replaying it per clustering row would
+    // both duplicate the appends and produce an UPDATE that CQL rejects (clustering restrictions on
+    // a statement modifying only static columns).
+    val tableDef = TableDef(
+      keyspaceName      = "test",
+      tableName         = "t",
+      partitionKey      = Seq(ColumnDef("id", PartitionKeyColumn, VarCharType)),
+      clusteringColumns = Seq(ColumnDef("ck", ClusteringColumn(0), IntType)),
+      regularColumns    = Seq(ColumnDef("tags", StaticColumn, SetType(IntType)))
+    )
+    val result = Cassandra.determineCopyType(
+      tableDef,
+      preserveTimesRequest           = true,
+      preserveCollectionTimesRequest = true
+    )
+    assert(result.isLeft, s"Expected static non-frozen collection to be rejected, got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("static non-frozen collection")),
+      s"Unexpected error message: ${result}"
+    )
+  }
+
+  test("non-frozen UDT is rejected (multi-cell but not a collection)") {
+    // The connector reports `isCollection == false` for UDTs while `isMultiCell == !isFrozen`, so a
+    // non-frozen UDT is invisible to the collection gate yet its TTL()/WRITETIME() still return one
+    // value per subfield. Without an explicit gate it would get scalar sidecars for list metadata.
+    val udt = UserDefinedType(
+      name     = "addr",
+      columns  = IndexedSeq(UDTFieldDef("street", VarCharType), UDTFieldDef("zip", IntType)),
+      isFrozen = false
+    )
+    assert(!udt.isCollection, "Expected the connector to report a UDT as not a collection")
+    assert(udt.isMultiCell, "Expected a non-frozen UDT to be multi-cell")
+
+    val tableDef = tableWith(ColumnDef("home", RegularColumn, udt))
+    val result = Cassandra.determineCopyType(tableDef, preserveTimesRequest = true)
+    assert(result.isLeft, s"Expected non-frozen UDT to be rejected, got: ${result}")
+    assert(
+      result.left.exists(_.getMessage.contains("non-collection")),
+      s"Unexpected error message: ${result}"
+    )
+  }
+
+  test("frozen UDT with preserveTimestamps is allowed (single-cell)") {
+    val frozen = UserDefinedType(
+      name     = "addr",
+      columns  = IndexedSeq(UDTFieldDef("street", VarCharType)),
+      isFrozen = true
+    )
+    val tableDef = tableWith(ColumnDef("home", RegularColumn, frozen))
+    assertEquals(
+      Cassandra.determineCopyType(tableDef, preserveTimesRequest = true),
+      Right(CopyType.WithTimestampPreservation)
+    )
   }
 
   test("reserved-name column is harmless when preserveTimestamps is disabled") {

--- a/tests/src/test/scala/com/scylladb/migrator/readers/CollectionParquetRoundtripTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/CollectionParquetRoundtripTest.scala
@@ -1,0 +1,186 @@
+package com.scylladb.migrator.readers
+
+import com.datastax.spark.connector.types.CassandraOption
+import org.apache.spark.sql.{ Row, SparkSession }
+import org.apache.spark.sql.types.{
+  ArrayType,
+  IntegerType,
+  LongType,
+  MapType,
+  MetadataBuilder,
+  StringType,
+  StructField,
+  StructType
+}
+
+/** Unit coverage for the Parquet restore path of per-element collection TTL/WRITETIME
+  * (`explodeRowsFromPerColumnMetaCollectionAware`): array-typed `_ttl`/`_writetime` sidecars are
+  * split off into collection-append passes, the base explode keeps only scalar columns, and
+  * elements are re-aligned with their metadata by the same ordering as the direct Cassandra path.
+  */
+class CollectionParquetRoundtripTest extends munit.FunSuite {
+
+  private lazy val spark: SparkSession = SparkSession
+    .builder()
+    .appName("CollectionParquetRoundtripTest")
+    .master("local[*]")
+    .config("spark.sql.shuffle.partitions", "1")
+    .getOrCreate()
+
+  override def afterAll(): Unit = {
+    spark.stop()
+    super.afterAll()
+  }
+
+  // The Parquet restore path only trusts an array-sidecar column as a per-element collection when
+  // it carries the collection-kind marker a real `preserveCollectionTimestamps` export stamps.
+  private def kindMeta(kind: String) =
+    new MetadataBuilder().putString(Cassandra.CollectionKindMetaKey, kind).build()
+
+  // id (PK) + scalar name (scalar metadata) + non-frozen set tags + non-frozen map attrs.
+  private val schema = StructType(
+    Seq(
+      StructField("id", StringType),
+      StructField("name", StringType),
+      StructField("name_ttl", IntegerType),
+      StructField("name_writetime", LongType),
+      StructField("tags", ArrayType(IntegerType), metadata = kindMeta(Cassandra.CollectionKindSet)),
+      StructField("tags_ttl", ArrayType(IntegerType)),
+      StructField("tags_writetime", ArrayType(LongType)),
+      StructField(
+        "attrs",
+        MapType(StringType, IntegerType),
+        metadata = kindMeta(Cassandra.CollectionKindMap)
+      ),
+      StructField("attrs_ttl", ArrayType(IntegerType)),
+      StructField("attrs_writetime", ArrayType(LongType))
+    )
+  )
+
+  private def sampleDf = {
+    // Collection values are stored in an arbitrary (non-sorted) order, mirroring the connector's
+    // decode; metadata arrays are in server (sorted) order. The explode must re-sort the elements
+    // to re-pair them: tags 10->100, 20->200, 30->300; attrs a->10, b->20.
+    val rows = java.util.Arrays.asList(
+      Row(
+        "r1",
+        "alice",
+        0,
+        1000L,
+        Seq(30, 10, 20), // unsorted set
+        Seq(0, 0, 0),
+        Seq(100L, 200L, 300L),
+        Map("b" -> 2, "a" -> 1), // unsorted map
+        Seq(0, 0),
+        Seq(10L, 20L)
+      )
+    )
+    spark.createDataFrame(rows, schema)
+  }
+
+  test("base explode keeps only scalar columns; collections become append passes") {
+    val (baseRdd, baseSchema, timestampColumns, appends) =
+      Cassandra.explodeRowsFromPerColumnMetaCollectionAware(spark, sampleDf)
+
+    assertEquals(timestampColumns, TimestampColumns("ttl", "writetime"))
+
+    // Base schema excludes the per-element collection columns and their sidecars.
+    assertEquals(baseSchema.fieldNames.toSeq, Seq("id", "name", "ttl", "writetime"))
+
+    val baseRows = baseRdd.collect().toList
+    assertEquals(baseRows.length, 1)
+    val baseRow = baseRows.head
+    // PK values are plain; regular columns keep CassandraOption tri-state for the RDD write path.
+    assertEquals(baseRow.getString(0), "r1")
+    assertEquals(baseRow.get(1), CassandraOption.Value("alice"))
+    assertEquals(baseRow.getLong(3), 1000L)
+
+    // One append pass per non-frozen collection column, ordered by column name.
+    assertEquals(appends.map(_.columnName), Seq("attrs", "tags"))
+  }
+
+  test("set append rows are element-aligned with their WRITETIMEs") {
+    val (_, _, _, appends) =
+      Cassandra.explodeRowsFromPerColumnMetaCollectionAware(spark, sampleDf)
+
+    val tags = appends.find(_.columnName == "tags").get
+    // schema: [id, tags, ttl, writetime]
+    assertEquals(tags.schema.fieldNames.toSeq, Seq("id", "tags", "ttl", "writetime"))
+
+    val byWritetime = tags.rdd
+      .collect()
+      .map { r =>
+        val elems = r.getSeq[Int](1).toSet
+        r.getLong(3) -> elems
+      }
+      .toMap
+
+    assertEquals(byWritetime(100L), Set(10))
+    assertEquals(byWritetime(200L), Set(20))
+    assertEquals(byWritetime(300L), Set(30))
+  }
+
+  test("map append rows are key-sorted and aligned with their WRITETIMEs") {
+    val (_, _, _, appends) =
+      Cassandra.explodeRowsFromPerColumnMetaCollectionAware(spark, sampleDf)
+
+    val attrs = appends.find(_.columnName == "attrs").get
+    assertEquals(attrs.schema.fieldNames.toSeq, Seq("id", "attrs", "ttl", "writetime"))
+
+    val byWritetime = attrs.rdd
+      .collect()
+      .map { r =>
+        val m = r.getMap[String, Int](1).toMap
+        r.getLong(3) -> m
+      }
+      .toMap
+
+    // Keys sorted: a -> 10, b -> 20.
+    assertEquals(byWritetime(10L), Map("a" -> 1))
+    assertEquals(byWritetime(20L), Map("b" -> 2))
+  }
+
+  test("array-sidecar column WITHOUT the collection-kind marker is rejected (foreign Parquet)") {
+    // Same shape as `sampleDf` but the collection columns carry no migrator marker, as a
+    // hand-crafted / foreign Parquet (or a CQL list decoded as an array) would. The restore must
+    // refuse rather than silently replay it as a set-append.
+    val foreignSchema = StructType(
+      Seq(
+        StructField("id", StringType),
+        StructField("tags", ArrayType(IntegerType)),
+        StructField("tags_ttl", ArrayType(IntegerType)),
+        StructField("tags_writetime", ArrayType(LongType))
+      )
+    )
+    val df = spark.createDataFrame(
+      java.util.Arrays.asList(Row("r1", Seq(10, 20), Seq(0, 0), Seq(100L, 200L))),
+      foreignSchema
+    )
+    val ex = intercept[IllegalArgumentException] {
+      Cassandra.explodeRowsFromPerColumnMetaCollectionAware(spark, df)
+    }
+    assert(ex.getMessage.contains(Cassandra.CollectionKindMetaKey))
+  }
+
+  test("no per-element columns => base explode matches scalar path with no append passes") {
+    val scalarSchema = StructType(
+      Seq(
+        StructField("id", StringType),
+        StructField("name", StringType),
+        StructField("name_ttl", IntegerType),
+        StructField("name_writetime", LongType)
+      )
+    )
+    val df = spark.createDataFrame(
+      java.util.Arrays.asList(Row("r1", "alice", 0, 1000L)),
+      scalarSchema
+    )
+
+    val (baseRdd, baseSchema, _, appends) =
+      Cassandra.explodeRowsFromPerColumnMetaCollectionAware(spark, df)
+
+    assert(appends.isEmpty)
+    assertEquals(baseSchema.fieldNames.toSeq, Seq("id", "name", "ttl", "writetime"))
+    assertEquals(baseRdd.collect().length, 1)
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/readers/CollectionParquetRoundtripTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/CollectionParquetRoundtripTest.scala
@@ -162,6 +162,58 @@ class CollectionParquetRoundtripTest extends munit.FunSuite {
     assert(ex.getMessage.contains(Cassandra.CollectionKindMetaKey))
   }
 
+  /** A mixed scalar+collection row whose ONLY live cells are collection elements: `name` is null,
+    * so the scalar explode yields a single all-null group with an Unset writetime. Its base row is
+    * a bare primary-key marker whose liveness must be derived from the collection cells.
+    */
+  private def mixedRowWithNoLiveScalar(tagTtls: Seq[Int]) = {
+    val rows = java.util.Arrays.asList(
+      Row(
+        "r1",
+        null,
+        null,
+        null,
+        Seq(10, 20),
+        tagTtls,
+        Seq(100L, 200L),
+        null,
+        null,
+        null
+      )
+    )
+    spark.createDataFrame(rows, schema)
+  }
+
+  test("mixed-table base marker takes BOTH writetime and TTL from the collection elements") {
+    // Regression: the marker's TTL was hardcoded to 0 (= permanently live) in this branch even
+    // though the row's liveness comes only from TTL'd collection cells. Once those expired, the
+    // target kept a live, empty, never-expiring row the source no longer had.
+    val (baseRdd, baseSchema, _, _) =
+      Cassandra.explodeRowsFromPerColumnMetaCollectionAware(
+        spark,
+        mixedRowWithNoLiveScalar(Seq(60, 120))
+      )
+
+    assertEquals(baseSchema.fieldNames.toSeq, Seq("id", "name", "ttl", "writetime"))
+    val baseRow = baseRdd.collect().head
+    // Writetime floored to the max element writetime, TTL to the max element TTL (latest expiry).
+    assertEquals(baseRow.getLong(3), 200L)
+    assertEquals(baseRow.getInt(2), 120)
+  }
+
+  test("mixed-table base marker stays permanent when any element has no TTL") {
+    // TTL 0 / absent means a permanent element, so the row marker must outlive every TTL'd one.
+    val (baseRdd, _, _, _) =
+      Cassandra.explodeRowsFromPerColumnMetaCollectionAware(
+        spark,
+        mixedRowWithNoLiveScalar(Seq(0, 120))
+      )
+
+    val baseRow = baseRdd.collect().head
+    assertEquals(baseRow.getInt(2), 0)
+    assertEquals(baseRow.getLong(3), 200L)
+  }
+
   test("no per-element columns => base explode matches scalar path with no append passes") {
     val scalarSchema = StructType(
       Seq(

--- a/tests/src/test/scala/com/scylladb/migrator/readers/ParquetPathRedactionTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/readers/ParquetPathRedactionTest.scala
@@ -1,0 +1,51 @@
+package com.scylladb.migrator.readers
+
+/** Unit coverage for [[Parquet.redactPathForLog]]. Source paths reach the logs on every Parquet
+  * read, and object-store URIs routinely carry credentials in the userinfo component or a signed
+  * token in the query string. The helper must fail CLOSED: anything it cannot prove credential-free
+  * is redacted, so a malformed or unusual URI never leaks a secret into a log file.
+  */
+class ParquetPathRedactionTest extends munit.FunSuite {
+
+  test("plain paths and URIs are logged as-is") {
+    for (
+      path <- Seq(
+                "/tmp/data/part-0.parquet",
+                "file:///home/user/data",
+                "s3a://bucket/prefix/table",
+                "gs://bucket/prefix"
+              )
+    )
+      assertEquals(Parquet.redactPathForLog(path), path, s"expected '$path' to be logged verbatim")
+  }
+
+  test("credentials in the userinfo component are redacted") {
+    for (
+      path <- Seq(
+                "s3a://AKIAEXAMPLE:secretkey@bucket/prefix",
+                "//user:secret@host/prefix" // schemeless but still parses: must not be echoed
+              )
+    )
+      assert(
+        !Parquet.redactPathForLog(path).contains("secret"),
+        s"expected credentials in '$path' to be redacted, got '${Parquet.redactPathForLog(path)}'"
+      )
+  }
+
+  test("a signed query string or fragment is redacted") {
+    val signed = "https://bucket.s3.amazonaws.com/key?X-Amz-Signature=deadbeef&X-Amz-Expires=60"
+    assert(
+      !Parquet.redactPathForLog(signed).contains("deadbeef"),
+      s"expected the signature to be redacted, got '${Parquet.redactPathForLog(signed)}'"
+    )
+    assert(!Parquet.redactPathForLog("s3a://bucket/key#tok=secret").contains("secret"))
+  }
+
+  test("an unparseable path carrying credential markers is redacted, not echoed") {
+    // `[` is illegal in a URI, so parsing throws; the fail-closed branch must still redact.
+    val malformed = "s3a://user:secret@bucket/pre[fix"
+    assertEquals(Parquet.redactPathForLog(malformed), "<redacted-path>")
+    // ...while a malformed but plainly credential-free local path stays readable for diagnostics.
+    assertEquals(Parquet.redactPathForLog("/tmp/pre[fix"), "/tmp/pre[fix")
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/Cassandra5CollectionTimestampParquetRoundTripTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/Cassandra5CollectionTimestampParquetRoundTripTest.scala
@@ -2,7 +2,7 @@ package com.scylladb.migrator.scylla
 
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.Row
-import com.scylladb.migrator.{ Integration, TestFileUtils }
+import com.scylladb.migrator.{ CassandraCompat, Integration, TestFileUtils }
 import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
 import org.junit.experimental.categories.Category
 
@@ -18,8 +18,8 @@ import scala.jdk.CollectionConverters._
   * both ends because ScyllaDB cannot read back `WRITETIME()`/`TTL()` of non-frozen collections for
   * verification.
   */
-@Category(Array(classOf[Integration]))
-class CollectionTimestampParquetRoundTripTest extends munit.FunSuite {
+@Category(Array(classOf[Integration], classOf[CassandraCompat]))
+class Cassandra5CollectionTimestampParquetRoundTripTest extends munit.FunSuite {
 
   private val keyspace = "test"
   private val sourceTbl = "collts_pq_src"

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/Cassandra5CollectionTimestampPreservationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/Cassandra5CollectionTimestampPreservationTest.scala
@@ -2,27 +2,28 @@ package com.scylladb.migrator.scylla
 
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.Row
-import com.scylladb.migrator.Integration
-import com.scylladb.migrator.SparkUtils.performValidation
+import com.scylladb.migrator.{ CassandraCompat, Integration }
+import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
 import org.junit.experimental.categories.Category
 
 import java.net.InetSocketAddress
 import scala.jdk.CollectionConverters._
 
-/** End-to-end coverage for element-level repair of non-frozen collections: the validator's
-  * `copyMissingRows` path restores missing rows with a scalar/frozen base write plus per-element
-  * collection-append passes, so the repaired rows regain their original per-element TTL/WRITETIME.
+/** End-to-end coverage for per-element TTL/WRITETIME preservation of non-frozen collections
+  * (`preserveCollectionTimestamps`).
   *
-  * Cassandra 5.0 is used for both ends because ScyllaDB cannot read back `WRITETIME()`/`TTL()` of
-  * non-frozen collections for verification.
+  * The migration runs Cassandra 5.0 -> Cassandra 5.0 (the target host in the config is
+  * `cassandra5`, remapped to the C*5.0 host port by the harness) because ScyllaDB cannot read back
+  * `WRITETIME()`/`TTL()` of non-frozen collections for verification, while Cassandra 5.0 can. The
+  * write path is plain CQL, identical whether the target is Scylla or Cassandra.
   */
-@Category(Array(classOf[Integration]))
-class CollectionTimestampRepairTest extends munit.FunSuite {
+@Category(Array(classOf[Integration], classOf[CassandraCompat]))
+class Cassandra5CollectionTimestampPreservationTest extends munit.FunSuite {
 
   private val keyspace = "test"
-  private val sourceTbl = "collts_rep_src"
-  private val targetTbl = "collts_rep_dst"
-  private val configFile = "cassandra5-to-cassandra5-collection-timestamps-repair.yaml"
+  private val sourceTbl = "collts_src"
+  private val targetTbl = "collts_dst"
+  private val configFile = "cassandra5-to-cassandra5-collection-timestamps.yaml"
 
   private val cassandra5: Fixture[CqlSession] = new Fixture[CqlSession]("cassandra5") {
     private var session: CqlSession = null
@@ -87,30 +88,44 @@ class CollectionTimestampRepairTest extends munit.FunSuite {
     )
   }
 
-  private def populateSource(session: CqlSession, id: String): Unit = {
+  test("preserves per-element TTL/WRITETIME of non-frozen set and map columns") {
+    val session = cassandra5()
+    createTable(session, sourceTbl)
+    createTable(session, targetTbl)
+
+    val id = "r1"
+    // Scalar written with an explicit timestamp (exercises the base write path alongside appends).
     session.execute(
       s"INSERT INTO ${keyspace}.${sourceTbl} (id, name) VALUES ('${id}', 'alice') " +
         s"USING TIMESTAMP 1000000000000"
     )
-    Seq(
+
+    // Set elements, each with its own WRITETIME, no TTL. 5+ elements to exceed small-collection
+    // special cases, inserted out of natural order.
+    val tagWrites = Seq(
       50 -> 5000000000000L,
       10 -> 1000000000000L,
       30 -> 3000000000000L,
       20 -> 2000000000000L,
       40 -> 4000000000000L
-    ).foreach { case (v, wt) =>
+    )
+    tagWrites.foreach { case (v, wt) =>
       session.execute(
         s"UPDATE ${keyspace}.${sourceTbl} USING TIMESTAMP ${wt} SET tags = tags + {${v}} WHERE id='${id}'"
       )
     }
-    Seq(
+
+    // Map entries with distinct WRITETIMEs, mixed TTLs, keys inserted out of sort order (exercises
+    // the connector's unordered decode + key-sort re-alignment). 6 entries => HashMap on decode.
+    val attrWrites = Seq(
       ("f", 6, 6000000000000L, Some(1000000)),
       ("a", 1, 1000000000000L, None),
       ("e", 5, 5000000000000L, Some(2000000)),
       ("b", 2, 2000000000000L, None),
       ("d", 4, 4000000000000L, Some(3000000)),
       ("c", 3, 3000000000000L, None)
-    ).foreach { case (k, v, wt, ttlOpt) =>
+    )
+    attrWrites.foreach { case (k, v, wt, ttlOpt) =>
       val using = ttlOpt match {
         case Some(ttl) => s"USING TIMESTAMP ${wt} AND TTL ${ttl}"
         case None      => s"USING TIMESTAMP ${wt}"
@@ -119,37 +134,32 @@ class CollectionTimestampRepairTest extends munit.FunSuite {
         s"UPDATE ${keyspace}.${sourceTbl} ${using} SET attrs = attrs + {'${k}': ${v}} WHERE id='${id}'"
       )
     }
-  }
 
-  test("copyMissingRows restores per-element collection TTL/WRITETIME for missing rows") {
-    val session = cassandra5()
-    createTable(session, sourceTbl)
-    createTable(session, targetTbl) // target starts empty
-
-    val id = "r1"
-    populateSource(session, id)
-
-    // Validation must detect the missing row (snapshot is taken before the repair copy).
-    assertEquals(performValidation(configFile), 1, "Should detect the missing target row")
+    successfullyPerformMigration(configFile)
 
     val src = readMeta(session, sourceTbl, id)
     val dst = readMeta(session, targetTbl, id)
 
-    // Scalar base write preserved (repairWritetimeStrategy=source).
+    // Scalar preserved.
     assertEquals(dst.name, src.name)
-    assertEquals(dst.nameWt, src.nameWt, "scalar WRITETIME must be preserved by the repair")
+    assertEquals(dst.nameWt, src.nameWt, "scalar WRITETIME must be preserved")
 
-    // Collection-append passes preserved element-level metadata.
+    // Set: same elements and element-aligned WRITETIMEs (Cassandra returns both in sorted order).
     assertEquals(dst.tags.sorted, src.tags.sorted, "set elements must match")
     assertEquals(dst.tagsWt, src.tagsWt, "set element WRITETIMEs must be preserved")
+
+    // Map: same entries and element-aligned WRITETIMEs (both returned in key-sorted order).
     assertEquals(dst.attrs, src.attrs, "map entries must match")
     assertEquals(dst.attrsWt, src.attrsWt, "map element WRITETIMEs must be preserved")
 
+    // Map TTLs: null stays null; non-null preserved within a small tolerance for elapsed time.
     assertEquals(dst.attrsTtl.length, src.attrsTtl.length)
     dst.attrsTtl.zip(src.attrsTtl).zipWithIndex.foreach { case ((dTtl, sTtl), i) =>
       if (sTtl == null) assert(dTtl == null, s"attrs TTL[$i] expected null, got ${dTtl}")
       else {
         assert(dTtl != null, s"attrs TTL[$i] expected non-null")
+        // The target TTL may differ from the source by the read->write elapsed time (and the
+        // source keeps aging), so compare with an absolute tolerance rather than a direction.
         val diff = math.abs(sTtl.intValue() - dTtl.intValue())
         assert(
           diff <= 600,
@@ -157,8 +167,5 @@ class CollectionTimestampRepairTest extends munit.FunSuite {
         )
       }
     }
-
-    // A second validation pass should now converge (row present, timestamps within tolerance).
-    assertEquals(performValidation(configFile), 0, "Re-validation after repair should pass")
   }
 }

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/Cassandra5CollectionTimestampRepairTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/Cassandra5CollectionTimestampRepairTest.scala
@@ -1,0 +1,164 @@
+package com.scylladb.migrator.scylla
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.cql.Row
+import com.scylladb.migrator.{ CassandraCompat, Integration }
+import com.scylladb.migrator.SparkUtils.performValidation
+import org.junit.experimental.categories.Category
+
+import java.net.InetSocketAddress
+import scala.jdk.CollectionConverters._
+
+/** End-to-end coverage for element-level repair of non-frozen collections: the validator's
+  * `copyMissingRows` path restores missing rows with a scalar/frozen base write plus per-element
+  * collection-append passes, so the repaired rows regain their original per-element TTL/WRITETIME.
+  *
+  * Cassandra 5.0 is used for both ends because ScyllaDB cannot read back `WRITETIME()`/`TTL()` of
+  * non-frozen collections for verification.
+  */
+@Category(Array(classOf[Integration], classOf[CassandraCompat]))
+class Cassandra5CollectionTimestampRepairTest extends munit.FunSuite {
+
+  private val keyspace = "test"
+  private val sourceTbl = "collts_rep_src"
+  private val targetTbl = "collts_rep_dst"
+  private val configFile = "cassandra5-to-cassandra5-collection-timestamps-repair.yaml"
+
+  private val cassandra5: Fixture[CqlSession] = new Fixture[CqlSession]("cassandra5") {
+    private var session: CqlSession = null
+    def apply(): CqlSession = session
+    override def beforeAll(): Unit = {
+      session = CqlSession
+        .builder()
+        .addContactPoint(new InetSocketAddress("localhost", 9047))
+        .withLocalDatacenter("datacenter1")
+        .withAuthCredentials("dummy", "dummy")
+        .build()
+      session.execute(
+        s"CREATE KEYSPACE IF NOT EXISTS ${keyspace} WITH replication = " +
+          "{'class':'SimpleStrategy','replication_factor':1}"
+      )
+    }
+    override def afterAll(): Unit = if (session != null) session.close()
+  }
+
+  override def munitFixtures: Seq[Fixture[_]] = Seq(cassandra5)
+
+  private def createTable(session: CqlSession, table: String): Unit = {
+    session.execute(s"DROP TABLE IF EXISTS ${keyspace}.${table}")
+    session.execute(
+      s"CREATE TABLE ${keyspace}.${table} " +
+        "(id text PRIMARY KEY, name text, tags set<int>, attrs map<text,int>)"
+    )
+  }
+
+  private case class CollectionMeta(
+    tags: List[Int],
+    tagsWt: List[Long],
+    attrs: Map[String, Int],
+    attrsWt: List[Long],
+    attrsTtl: List[Integer],
+    name: String,
+    nameWt: Long
+  )
+
+  private def readMeta(session: CqlSession, table: String, id: String): CollectionMeta = {
+    val row: Row = session
+      .execute(
+        s"SELECT name, WRITETIME(name) AS name_wt, " +
+          s"tags, WRITETIME(tags) AS tags_wt, " +
+          s"attrs, WRITETIME(attrs) AS attrs_wt, TTL(attrs) AS attrs_ttl " +
+          s"FROM ${keyspace}.${table} WHERE id = '${id}'"
+      )
+      .one()
+    assert(row != null, s"expected a row for id=${id} in ${table}")
+    CollectionMeta(
+      tags   = row.getSet("tags", classOf[Integer]).asScala.toList.map(_.intValue()),
+      tagsWt = row.getList("tags_wt", classOf[java.lang.Long]).asScala.toList.map(_.longValue()),
+      attrs = row
+        .getMap("attrs", classOf[String], classOf[Integer])
+        .asScala
+        .toMap
+        .map { case (k, v) => k -> v.intValue() },
+      attrsWt  = row.getList("attrs_wt", classOf[java.lang.Long]).asScala.toList.map(_.longValue()),
+      attrsTtl = row.getList("attrs_ttl", classOf[Integer]).asScala.toList,
+      name     = row.getString("name"),
+      nameWt   = row.getLong("name_wt")
+    )
+  }
+
+  private def populateSource(session: CqlSession, id: String): Unit = {
+    session.execute(
+      s"INSERT INTO ${keyspace}.${sourceTbl} (id, name) VALUES ('${id}', 'alice') " +
+        s"USING TIMESTAMP 1000000000000"
+    )
+    Seq(
+      50 -> 5000000000000L,
+      10 -> 1000000000000L,
+      30 -> 3000000000000L,
+      20 -> 2000000000000L,
+      40 -> 4000000000000L
+    ).foreach { case (v, wt) =>
+      session.execute(
+        s"UPDATE ${keyspace}.${sourceTbl} USING TIMESTAMP ${wt} SET tags = tags + {${v}} WHERE id='${id}'"
+      )
+    }
+    Seq(
+      ("f", 6, 6000000000000L, Some(1000000)),
+      ("a", 1, 1000000000000L, None),
+      ("e", 5, 5000000000000L, Some(2000000)),
+      ("b", 2, 2000000000000L, None),
+      ("d", 4, 4000000000000L, Some(3000000)),
+      ("c", 3, 3000000000000L, None)
+    ).foreach { case (k, v, wt, ttlOpt) =>
+      val using = ttlOpt match {
+        case Some(ttl) => s"USING TIMESTAMP ${wt} AND TTL ${ttl}"
+        case None      => s"USING TIMESTAMP ${wt}"
+      }
+      session.execute(
+        s"UPDATE ${keyspace}.${sourceTbl} ${using} SET attrs = attrs + {'${k}': ${v}} WHERE id='${id}'"
+      )
+    }
+  }
+
+  test("copyMissingRows restores per-element collection TTL/WRITETIME for missing rows") {
+    val session = cassandra5()
+    createTable(session, sourceTbl)
+    createTable(session, targetTbl) // target starts empty
+
+    val id = "r1"
+    populateSource(session, id)
+
+    // Validation must detect the missing row (snapshot is taken before the repair copy).
+    assertEquals(performValidation(configFile), 1, "Should detect the missing target row")
+
+    val src = readMeta(session, sourceTbl, id)
+    val dst = readMeta(session, targetTbl, id)
+
+    // Scalar base write preserved (repairWritetimeStrategy=source).
+    assertEquals(dst.name, src.name)
+    assertEquals(dst.nameWt, src.nameWt, "scalar WRITETIME must be preserved by the repair")
+
+    // Collection-append passes preserved element-level metadata.
+    assertEquals(dst.tags.sorted, src.tags.sorted, "set elements must match")
+    assertEquals(dst.tagsWt, src.tagsWt, "set element WRITETIMEs must be preserved")
+    assertEquals(dst.attrs, src.attrs, "map entries must match")
+    assertEquals(dst.attrsWt, src.attrsWt, "map element WRITETIMEs must be preserved")
+
+    assertEquals(dst.attrsTtl.length, src.attrsTtl.length)
+    dst.attrsTtl.zip(src.attrsTtl).zipWithIndex.foreach { case ((dTtl, sTtl), i) =>
+      if (sTtl == null) assert(dTtl == null, s"attrs TTL[$i] expected null, got ${dTtl}")
+      else {
+        assert(dTtl != null, s"attrs TTL[$i] expected non-null")
+        val diff = math.abs(sTtl.intValue() - dTtl.intValue())
+        assert(
+          diff <= 600,
+          s"attrs TTL[$i] not preserved within tolerance: src=${sTtl} dst=${dTtl}"
+        )
+      }
+    }
+
+    // A second validation pass should now converge (row present, timestamps within tolerance).
+    assertEquals(performValidation(configFile), 0, "Re-validation after repair should pass")
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/CollectionTimestampParquetRoundTripTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/CollectionTimestampParquetRoundTripTest.scala
@@ -1,0 +1,172 @@
+package com.scylladb.migrator.scylla
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.cql.Row
+import com.scylladb.migrator.{ Integration, TestFileUtils }
+import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
+import org.junit.experimental.categories.Category
+
+import java.net.InetSocketAddress
+import java.nio.file.{ Files, Paths }
+import scala.jdk.CollectionConverters._
+
+/** End-to-end coverage for per-element TTL/WRITETIME preservation of non-frozen collections across
+  * the Parquet intermediate format: Cassandra 5.0 -> Parquet -> Cassandra 5.0.
+  *
+  * The export writes each non-frozen collection's per-element metadata as `__migrator_meta_*` array
+  * sidecars; the restore re-hydrates them into collection-append passes. Cassandra 5.0 is used for
+  * both ends because ScyllaDB cannot read back `WRITETIME()`/`TTL()` of non-frozen collections for
+  * verification.
+  */
+@Category(Array(classOf[Integration]))
+class CollectionTimestampParquetRoundTripTest extends munit.FunSuite {
+
+  private val keyspace = "test"
+  private val sourceTbl = "collts_pq_src"
+  private val targetTbl = "collts_pq_dst"
+  private val exportConfig = "cassandra5-to-parquet-collection-timestamps.yaml"
+  private val restoreConfig = "parquet-to-cassandra5-collection-timestamps.yaml"
+  private val parquetDir = Paths.get("docker/parquet/collection-timestamps")
+
+  private val cassandra5: Fixture[CqlSession] = new Fixture[CqlSession]("cassandra5") {
+    private var session: CqlSession = null
+    def apply(): CqlSession = session
+    override def beforeAll(): Unit = {
+      session = CqlSession
+        .builder()
+        .addContactPoint(new InetSocketAddress("localhost", 9047))
+        .withLocalDatacenter("datacenter1")
+        .withAuthCredentials("dummy", "dummy")
+        .build()
+      session.execute(
+        s"CREATE KEYSPACE IF NOT EXISTS ${keyspace} WITH replication = " +
+          "{'class':'SimpleStrategy','replication_factor':1}"
+      )
+    }
+    override def afterAll(): Unit = if (session != null) session.close()
+  }
+
+  override def munitFixtures: Seq[Fixture[_]] = Seq(cassandra5)
+
+  private def createTable(session: CqlSession, table: String): Unit = {
+    session.execute(s"DROP TABLE IF EXISTS ${keyspace}.${table}")
+    session.execute(
+      s"CREATE TABLE ${keyspace}.${table} " +
+        "(id text PRIMARY KEY, name text, tags set<int>, attrs map<text,int>)"
+    )
+  }
+
+  private case class CollectionMeta(
+    tags: List[Int],
+    tagsWt: List[Long],
+    attrs: Map[String, Int],
+    attrsWt: List[Long],
+    attrsTtl: List[Integer],
+    name: String,
+    nameWt: Long
+  )
+
+  private def readMeta(session: CqlSession, table: String, id: String): CollectionMeta = {
+    val row: Row = session
+      .execute(
+        s"SELECT name, WRITETIME(name) AS name_wt, " +
+          s"tags, WRITETIME(tags) AS tags_wt, " +
+          s"attrs, WRITETIME(attrs) AS attrs_wt, TTL(attrs) AS attrs_ttl " +
+          s"FROM ${keyspace}.${table} WHERE id = '${id}'"
+      )
+      .one()
+    assert(row != null, s"expected a row for id=${id} in ${table}")
+    CollectionMeta(
+      tags   = row.getSet("tags", classOf[Integer]).asScala.toList.map(_.intValue()),
+      tagsWt = row.getList("tags_wt", classOf[java.lang.Long]).asScala.toList.map(_.longValue()),
+      attrs = row
+        .getMap("attrs", classOf[String], classOf[Integer])
+        .asScala
+        .toMap
+        .map { case (k, v) => k -> v.intValue() },
+      attrsWt  = row.getList("attrs_wt", classOf[java.lang.Long]).asScala.toList.map(_.longValue()),
+      attrsTtl = row.getList("attrs_ttl", classOf[Integer]).asScala.toList,
+      name     = row.getString("name"),
+      nameWt   = row.getLong("name_wt")
+    )
+  }
+
+  test("preserves per-element TTL/WRITETIME of non-frozen collections through Parquet") {
+    val session = cassandra5()
+    createTable(session, sourceTbl)
+    createTable(session, targetTbl)
+    TestFileUtils.deleteRecursive(parquetDir.toFile)
+
+    val id = "r1"
+    session.execute(
+      s"INSERT INTO ${keyspace}.${sourceTbl} (id, name) VALUES ('${id}', 'alice') " +
+        s"USING TIMESTAMP 1000000000000"
+    )
+
+    val tagWrites = Seq(
+      50 -> 5000000000000L,
+      10 -> 1000000000000L,
+      30 -> 3000000000000L,
+      20 -> 2000000000000L,
+      40 -> 4000000000000L
+    )
+    tagWrites.foreach { case (v, wt) =>
+      session.execute(
+        s"UPDATE ${keyspace}.${sourceTbl} USING TIMESTAMP ${wt} SET tags = tags + {${v}} WHERE id='${id}'"
+      )
+    }
+
+    val attrWrites = Seq(
+      ("f", 6, 6000000000000L, Some(1000000)),
+      ("a", 1, 1000000000000L, None),
+      ("e", 5, 5000000000000L, Some(2000000)),
+      ("b", 2, 2000000000000L, None),
+      ("d", 4, 4000000000000L, Some(3000000)),
+      ("c", 3, 3000000000000L, None)
+    )
+    attrWrites.foreach { case (k, v, wt, ttlOpt) =>
+      val using = ttlOpt match {
+        case Some(ttl) => s"USING TIMESTAMP ${wt} AND TTL ${ttl}"
+        case None      => s"USING TIMESTAMP ${wt}"
+      }
+      session.execute(
+        s"UPDATE ${keyspace}.${sourceTbl} ${using} SET attrs = attrs + {'${k}': ${v}} WHERE id='${id}'"
+      )
+    }
+
+    // 1) Cassandra 5.0 -> Parquet (array metadata sidecars).
+    successfullyPerformMigration(exportConfig)
+    assert(
+      Files.exists(parquetDir) && Files.list(parquetDir).iterator().asScala.nonEmpty,
+      "Parquet output directory should contain files"
+    )
+
+    // 2) Parquet -> Cassandra 5.0 (collection-append replay).
+    successfullyPerformMigration(restoreConfig)
+
+    val src = readMeta(session, sourceTbl, id)
+    val dst = readMeta(session, targetTbl, id)
+
+    assertEquals(dst.name, src.name)
+    assertEquals(dst.nameWt, src.nameWt, "scalar WRITETIME must survive the Parquet round-trip")
+
+    assertEquals(dst.tags.sorted, src.tags.sorted, "set elements must match")
+    assertEquals(dst.tagsWt, src.tagsWt, "set element WRITETIMEs must be preserved")
+
+    assertEquals(dst.attrs, src.attrs, "map entries must match")
+    assertEquals(dst.attrsWt, src.attrsWt, "map element WRITETIMEs must be preserved")
+
+    assertEquals(dst.attrsTtl.length, src.attrsTtl.length)
+    dst.attrsTtl.zip(src.attrsTtl).zipWithIndex.foreach { case ((dTtl, sTtl), i) =>
+      if (sTtl == null) assert(dTtl == null, s"attrs TTL[$i] expected null, got ${dTtl}")
+      else {
+        assert(dTtl != null, s"attrs TTL[$i] expected non-null")
+        val diff = math.abs(sTtl.intValue() - dTtl.intValue())
+        assert(
+          diff <= 600,
+          s"attrs TTL[$i] not preserved within tolerance: src=${sTtl} dst=${dTtl}"
+        )
+      }
+    }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/CollectionTimestampPreservationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/CollectionTimestampPreservationTest.scala
@@ -1,0 +1,171 @@
+package com.scylladb.migrator.scylla
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.cql.Row
+import com.scylladb.migrator.Integration
+import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
+import org.junit.experimental.categories.Category
+
+import java.net.InetSocketAddress
+import scala.jdk.CollectionConverters._
+
+/** End-to-end coverage for per-element TTL/WRITETIME preservation of non-frozen collections
+  * (`preserveCollectionTimestamps`).
+  *
+  * The migration runs Cassandra 5.0 -> Cassandra 5.0 (the target host in the config is
+  * `cassandra5`, remapped to the C*5.0 host port by the harness) because ScyllaDB cannot read back
+  * `WRITETIME()`/`TTL()` of non-frozen collections for verification, while Cassandra 5.0 can. The
+  * write path is plain CQL, identical whether the target is Scylla or Cassandra.
+  */
+@Category(Array(classOf[Integration]))
+class CollectionTimestampPreservationTest extends munit.FunSuite {
+
+  private val keyspace = "test"
+  private val sourceTbl = "collts_src"
+  private val targetTbl = "collts_dst"
+  private val configFile = "cassandra5-to-cassandra5-collection-timestamps.yaml"
+
+  private val cassandra5: Fixture[CqlSession] = new Fixture[CqlSession]("cassandra5") {
+    private var session: CqlSession = null
+    def apply(): CqlSession = session
+    override def beforeAll(): Unit = {
+      session = CqlSession
+        .builder()
+        .addContactPoint(new InetSocketAddress("localhost", 9047))
+        .withLocalDatacenter("datacenter1")
+        .withAuthCredentials("dummy", "dummy")
+        .build()
+      session.execute(
+        s"CREATE KEYSPACE IF NOT EXISTS ${keyspace} WITH replication = " +
+          "{'class':'SimpleStrategy','replication_factor':1}"
+      )
+    }
+    override def afterAll(): Unit = if (session != null) session.close()
+  }
+
+  override def munitFixtures: Seq[Fixture[_]] = Seq(cassandra5)
+
+  private def createTable(session: CqlSession, table: String): Unit = {
+    session.execute(s"DROP TABLE IF EXISTS ${keyspace}.${table}")
+    session.execute(
+      s"CREATE TABLE ${keyspace}.${table} " +
+        "(id text PRIMARY KEY, name text, tags set<int>, attrs map<text,int>)"
+    )
+  }
+
+  private case class CollectionMeta(
+    tags: List[Int],
+    tagsWt: List[Long],
+    attrs: Map[String, Int],
+    attrsWt: List[Long],
+    attrsTtl: List[Integer],
+    name: String,
+    nameWt: Long
+  )
+
+  private def readMeta(session: CqlSession, table: String, id: String): CollectionMeta = {
+    val row: Row = session
+      .execute(
+        s"SELECT name, WRITETIME(name) AS name_wt, " +
+          s"tags, WRITETIME(tags) AS tags_wt, " +
+          s"attrs, WRITETIME(attrs) AS attrs_wt, TTL(attrs) AS attrs_ttl " +
+          s"FROM ${keyspace}.${table} WHERE id = '${id}'"
+      )
+      .one()
+    assert(row != null, s"expected a row for id=${id} in ${table}")
+    CollectionMeta(
+      tags   = row.getSet("tags", classOf[Integer]).asScala.toList.map(_.intValue()),
+      tagsWt = row.getList("tags_wt", classOf[java.lang.Long]).asScala.toList.map(_.longValue()),
+      attrs = row
+        .getMap("attrs", classOf[String], classOf[Integer])
+        .asScala
+        .toMap
+        .map { case (k, v) => k -> v.intValue() },
+      attrsWt  = row.getList("attrs_wt", classOf[java.lang.Long]).asScala.toList.map(_.longValue()),
+      attrsTtl = row.getList("attrs_ttl", classOf[Integer]).asScala.toList,
+      name     = row.getString("name"),
+      nameWt   = row.getLong("name_wt")
+    )
+  }
+
+  test("preserves per-element TTL/WRITETIME of non-frozen set and map columns") {
+    val session = cassandra5()
+    createTable(session, sourceTbl)
+    createTable(session, targetTbl)
+
+    val id = "r1"
+    // Scalar written with an explicit timestamp (exercises the base write path alongside appends).
+    session.execute(
+      s"INSERT INTO ${keyspace}.${sourceTbl} (id, name) VALUES ('${id}', 'alice') " +
+        s"USING TIMESTAMP 1000000000000"
+    )
+
+    // Set elements, each with its own WRITETIME, no TTL. 5+ elements to exceed small-collection
+    // special cases, inserted out of natural order.
+    val tagWrites = Seq(
+      50 -> 5000000000000L,
+      10 -> 1000000000000L,
+      30 -> 3000000000000L,
+      20 -> 2000000000000L,
+      40 -> 4000000000000L
+    )
+    tagWrites.foreach { case (v, wt) =>
+      session.execute(
+        s"UPDATE ${keyspace}.${sourceTbl} USING TIMESTAMP ${wt} SET tags = tags + {${v}} WHERE id='${id}'"
+      )
+    }
+
+    // Map entries with distinct WRITETIMEs, mixed TTLs, keys inserted out of sort order (exercises
+    // the connector's unordered decode + key-sort re-alignment). 6 entries => HashMap on decode.
+    val attrWrites = Seq(
+      ("f", 6, 6000000000000L, Some(1000000)),
+      ("a", 1, 1000000000000L, None),
+      ("e", 5, 5000000000000L, Some(2000000)),
+      ("b", 2, 2000000000000L, None),
+      ("d", 4, 4000000000000L, Some(3000000)),
+      ("c", 3, 3000000000000L, None)
+    )
+    attrWrites.foreach { case (k, v, wt, ttlOpt) =>
+      val using = ttlOpt match {
+        case Some(ttl) => s"USING TIMESTAMP ${wt} AND TTL ${ttl}"
+        case None      => s"USING TIMESTAMP ${wt}"
+      }
+      session.execute(
+        s"UPDATE ${keyspace}.${sourceTbl} ${using} SET attrs = attrs + {'${k}': ${v}} WHERE id='${id}'"
+      )
+    }
+
+    successfullyPerformMigration(configFile)
+
+    val src = readMeta(session, sourceTbl, id)
+    val dst = readMeta(session, targetTbl, id)
+
+    // Scalar preserved.
+    assertEquals(dst.name, src.name)
+    assertEquals(dst.nameWt, src.nameWt, "scalar WRITETIME must be preserved")
+
+    // Set: same elements and element-aligned WRITETIMEs (Cassandra returns both in sorted order).
+    assertEquals(dst.tags.sorted, src.tags.sorted, "set elements must match")
+    assertEquals(dst.tagsWt, src.tagsWt, "set element WRITETIMEs must be preserved")
+
+    // Map: same entries and element-aligned WRITETIMEs (both returned in key-sorted order).
+    assertEquals(dst.attrs, src.attrs, "map entries must match")
+    assertEquals(dst.attrsWt, src.attrsWt, "map element WRITETIMEs must be preserved")
+
+    // Map TTLs: null stays null; non-null preserved within a small tolerance for elapsed time.
+    assertEquals(dst.attrsTtl.length, src.attrsTtl.length)
+    dst.attrsTtl.zip(src.attrsTtl).zipWithIndex.foreach { case ((dTtl, sTtl), i) =>
+      if (sTtl == null) assert(dTtl == null, s"attrs TTL[$i] expected null, got ${dTtl}")
+      else {
+        assert(dTtl != null, s"attrs TTL[$i] expected non-null")
+        // The target TTL may differ from the source by the read->write elapsed time (and the
+        // source keeps aging), so compare with an absolute tolerance rather than a direction.
+        val diff = math.abs(sTtl.intValue() - dTtl.intValue())
+        assert(
+          diff <= 600,
+          s"attrs TTL[$i] not preserved within tolerance: src=${sTtl} dst=${dTtl}"
+        )
+      }
+    }
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/CollectionTimestampRepairTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/CollectionTimestampRepairTest.scala
@@ -1,0 +1,164 @@
+package com.scylladb.migrator.scylla
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.cql.Row
+import com.scylladb.migrator.Integration
+import com.scylladb.migrator.SparkUtils.performValidation
+import org.junit.experimental.categories.Category
+
+import java.net.InetSocketAddress
+import scala.jdk.CollectionConverters._
+
+/** End-to-end coverage for element-level repair of non-frozen collections: the validator's
+  * `copyMissingRows` path restores missing rows with a scalar/frozen base write plus per-element
+  * collection-append passes, so the repaired rows regain their original per-element TTL/WRITETIME.
+  *
+  * Cassandra 5.0 is used for both ends because ScyllaDB cannot read back `WRITETIME()`/`TTL()` of
+  * non-frozen collections for verification.
+  */
+@Category(Array(classOf[Integration]))
+class CollectionTimestampRepairTest extends munit.FunSuite {
+
+  private val keyspace = "test"
+  private val sourceTbl = "collts_rep_src"
+  private val targetTbl = "collts_rep_dst"
+  private val configFile = "cassandra5-to-cassandra5-collection-timestamps-repair.yaml"
+
+  private val cassandra5: Fixture[CqlSession] = new Fixture[CqlSession]("cassandra5") {
+    private var session: CqlSession = null
+    def apply(): CqlSession = session
+    override def beforeAll(): Unit = {
+      session = CqlSession
+        .builder()
+        .addContactPoint(new InetSocketAddress("localhost", 9047))
+        .withLocalDatacenter("datacenter1")
+        .withAuthCredentials("dummy", "dummy")
+        .build()
+      session.execute(
+        s"CREATE KEYSPACE IF NOT EXISTS ${keyspace} WITH replication = " +
+          "{'class':'SimpleStrategy','replication_factor':1}"
+      )
+    }
+    override def afterAll(): Unit = if (session != null) session.close()
+  }
+
+  override def munitFixtures: Seq[Fixture[_]] = Seq(cassandra5)
+
+  private def createTable(session: CqlSession, table: String): Unit = {
+    session.execute(s"DROP TABLE IF EXISTS ${keyspace}.${table}")
+    session.execute(
+      s"CREATE TABLE ${keyspace}.${table} " +
+        "(id text PRIMARY KEY, name text, tags set<int>, attrs map<text,int>)"
+    )
+  }
+
+  private case class CollectionMeta(
+    tags: List[Int],
+    tagsWt: List[Long],
+    attrs: Map[String, Int],
+    attrsWt: List[Long],
+    attrsTtl: List[Integer],
+    name: String,
+    nameWt: Long
+  )
+
+  private def readMeta(session: CqlSession, table: String, id: String): CollectionMeta = {
+    val row: Row = session
+      .execute(
+        s"SELECT name, WRITETIME(name) AS name_wt, " +
+          s"tags, WRITETIME(tags) AS tags_wt, " +
+          s"attrs, WRITETIME(attrs) AS attrs_wt, TTL(attrs) AS attrs_ttl " +
+          s"FROM ${keyspace}.${table} WHERE id = '${id}'"
+      )
+      .one()
+    assert(row != null, s"expected a row for id=${id} in ${table}")
+    CollectionMeta(
+      tags   = row.getSet("tags", classOf[Integer]).asScala.toList.map(_.intValue()),
+      tagsWt = row.getList("tags_wt", classOf[java.lang.Long]).asScala.toList.map(_.longValue()),
+      attrs = row
+        .getMap("attrs", classOf[String], classOf[Integer])
+        .asScala
+        .toMap
+        .map { case (k, v) => k -> v.intValue() },
+      attrsWt  = row.getList("attrs_wt", classOf[java.lang.Long]).asScala.toList.map(_.longValue()),
+      attrsTtl = row.getList("attrs_ttl", classOf[Integer]).asScala.toList,
+      name     = row.getString("name"),
+      nameWt   = row.getLong("name_wt")
+    )
+  }
+
+  private def populateSource(session: CqlSession, id: String): Unit = {
+    session.execute(
+      s"INSERT INTO ${keyspace}.${sourceTbl} (id, name) VALUES ('${id}', 'alice') " +
+        s"USING TIMESTAMP 1000000000000"
+    )
+    Seq(
+      50 -> 5000000000000L,
+      10 -> 1000000000000L,
+      30 -> 3000000000000L,
+      20 -> 2000000000000L,
+      40 -> 4000000000000L
+    ).foreach { case (v, wt) =>
+      session.execute(
+        s"UPDATE ${keyspace}.${sourceTbl} USING TIMESTAMP ${wt} SET tags = tags + {${v}} WHERE id='${id}'"
+      )
+    }
+    Seq(
+      ("f", 6, 6000000000000L, Some(1000000)),
+      ("a", 1, 1000000000000L, None),
+      ("e", 5, 5000000000000L, Some(2000000)),
+      ("b", 2, 2000000000000L, None),
+      ("d", 4, 4000000000000L, Some(3000000)),
+      ("c", 3, 3000000000000L, None)
+    ).foreach { case (k, v, wt, ttlOpt) =>
+      val using = ttlOpt match {
+        case Some(ttl) => s"USING TIMESTAMP ${wt} AND TTL ${ttl}"
+        case None      => s"USING TIMESTAMP ${wt}"
+      }
+      session.execute(
+        s"UPDATE ${keyspace}.${sourceTbl} ${using} SET attrs = attrs + {'${k}': ${v}} WHERE id='${id}'"
+      )
+    }
+  }
+
+  test("copyMissingRows restores per-element collection TTL/WRITETIME for missing rows") {
+    val session = cassandra5()
+    createTable(session, sourceTbl)
+    createTable(session, targetTbl) // target starts empty
+
+    val id = "r1"
+    populateSource(session, id)
+
+    // Validation must detect the missing row (snapshot is taken before the repair copy).
+    assertEquals(performValidation(configFile), 1, "Should detect the missing target row")
+
+    val src = readMeta(session, sourceTbl, id)
+    val dst = readMeta(session, targetTbl, id)
+
+    // Scalar base write preserved (repairWritetimeStrategy=source).
+    assertEquals(dst.name, src.name)
+    assertEquals(dst.nameWt, src.nameWt, "scalar WRITETIME must be preserved by the repair")
+
+    // Collection-append passes preserved element-level metadata.
+    assertEquals(dst.tags.sorted, src.tags.sorted, "set elements must match")
+    assertEquals(dst.tagsWt, src.tagsWt, "set element WRITETIMEs must be preserved")
+    assertEquals(dst.attrs, src.attrs, "map entries must match")
+    assertEquals(dst.attrsWt, src.attrsWt, "map element WRITETIMEs must be preserved")
+
+    assertEquals(dst.attrsTtl.length, src.attrsTtl.length)
+    dst.attrsTtl.zip(src.attrsTtl).zipWithIndex.foreach { case ((dTtl, sTtl), i) =>
+      if (sTtl == null) assert(dTtl == null, s"attrs TTL[$i] expected null, got ${dTtl}")
+      else {
+        assert(dTtl != null, s"attrs TTL[$i] expected non-null")
+        val diff = math.abs(sTtl.intValue() - dTtl.intValue())
+        assert(
+          diff <= 600,
+          s"attrs TTL[$i] not preserved within tolerance: src=${sTtl} dst=${dTtl}"
+        )
+      }
+    }
+
+    // A second validation pass should now converge (row present, timestamps within tolerance).
+    assertEquals(performValidation(configFile), 0, "Re-validation after repair should pass")
+  }
+}

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/CopyMissingRowsTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/CopyMissingRowsTest.scala
@@ -137,7 +137,7 @@ abstract class CopyMissingRowsTest(version: CassandraVersion) extends MigratorSu
   }
 
   withTable("BasicTest").test(
-    s"Cassandra ${version.label}: copyMissingRows rejects timestamp preservation for collection columns"
+    s"Cassandra ${version.label}: copyMissingRows rejects timestamp preservation for non-frozen collection columns"
   ) { tableName =>
     val alterTable =
       s"ALTER TABLE ${keyspace}.${tableName} ADD tags set<text>"
@@ -155,7 +155,7 @@ abstract class CopyMissingRowsTest(version: CassandraVersion) extends MigratorSu
 
     assert(
       err.getMessage.contains(
-        "TTL/Writetime preservation is unsupported for tables with collection types"
+        "TTL/Writetime preservation is unsupported for tables with non-frozen (multi-cell)"
       ),
       s"Unexpected error: ${err.getMessage}"
     )

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/Scylla2026CollectionTimestampPreservationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/Scylla2026CollectionTimestampPreservationTest.scala
@@ -2,48 +2,54 @@ package com.scylladb.migrator.scylla
 
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.Row
-import com.scylladb.migrator.Integration
+import com.scylladb.migrator.{ Integration, Scylla2026Compat }
 import com.scylladb.migrator.SparkUtils.successfullyPerformMigration
 import org.junit.experimental.categories.Category
 
 import java.net.InetSocketAddress
 import scala.jdk.CollectionConverters._
 
-/** End-to-end coverage for per-element TTL/WRITETIME preservation of non-frozen collections
-  * (`preserveCollectionTimestamps`).
+/** End-to-end coverage for per-element TTL/WRITETIME preservation of non-frozen collections with
+  * ScyllaDB as BOTH source and target (`preserveCollectionTimestamps`).
   *
-  * The migration runs Cassandra 5.0 -> Cassandra 5.0 (the target host in the config is
-  * `cassandra5`, remapped to the C*5.0 host port by the harness) because ScyllaDB cannot read back
-  * `WRITETIME()`/`TTL()` of non-frozen collections for verification, while Cassandra 5.0 can. The
-  * write path is plain CQL, identical whether the target is Scylla or Cassandra.
+  * ScyllaDB (verified on 2026.2) rejects the Cassandra 5.0 collection-wide `WRITETIME(col)` list
+  * form on non-frozen collections but supports the per-element subscript form
+  * `WRITETIME(col[key])`. The migrator auto-detects this and reads element metadata via per-row
+  * point reads. This test both migrates through that path AND verifies the result using the same
+  * subscript form (Scylla can read it back, unlike the Cassandra 5.0-only array form).
+  *
+  * Runs against a dedicated `scylla2026` service (host port 9048) rather than the shared `scylla`
+  * service, because the feature needs ScyllaDB >= 2026.2 and 2026.2 rejects `SimpleStrategy`
+  * keyspaces.
   */
-@Category(Array(classOf[Integration]))
-class CollectionTimestampPreservationTest extends munit.FunSuite {
+@Category(Array(classOf[Integration], classOf[Scylla2026Compat]))
+class Scylla2026CollectionTimestampPreservationTest extends munit.FunSuite {
 
   private val keyspace = "test"
   private val sourceTbl = "collts_src"
   private val targetTbl = "collts_dst"
-  private val configFile = "cassandra5-to-cassandra5-collection-timestamps.yaml"
+  private val configFile = "scylla2026-to-scylla2026-collection-timestamps.yaml"
 
-  private val cassandra5: Fixture[CqlSession] = new Fixture[CqlSession]("cassandra5") {
+  private val scylla2026: Fixture[CqlSession] = new Fixture[CqlSession]("scylla2026") {
     private var session: CqlSession = null
     def apply(): CqlSession = session
     override def beforeAll(): Unit = {
       session = CqlSession
         .builder()
-        .addContactPoint(new InetSocketAddress("localhost", 9047))
+        .addContactPoint(new InetSocketAddress("localhost", 9048))
         .withLocalDatacenter("datacenter1")
         .withAuthCredentials("dummy", "dummy")
         .build()
+      // 2026.2 rejects SimpleStrategy; NetworkTopologyStrategy is required.
       session.execute(
         s"CREATE KEYSPACE IF NOT EXISTS ${keyspace} WITH replication = " +
-          "{'class':'SimpleStrategy','replication_factor':1}"
+          "{'class':'NetworkTopologyStrategy','replication_factor':1}"
       )
     }
     override def afterAll(): Unit = if (session != null) session.close()
   }
 
-  override def munitFixtures: Seq[Fixture[_]] = Seq(cassandra5)
+  override def munitFixtures: Seq[Fixture[_]] = Seq(scylla2026)
 
   private def createTable(session: CqlSession, table: String): Unit = {
     session.execute(s"DROP TABLE IF EXISTS ${keyspace}.${table}")
@@ -63,45 +69,67 @@ class CollectionTimestampPreservationTest extends munit.FunSuite {
     nameWt: Long
   )
 
+  /** Read per-element metadata via ScyllaDB's subscript form. Arrays are ordered by ascending set
+    * element / map key so source and target compare element-wise.
+    */
   private def readMeta(session: CqlSession, table: String, id: String): CollectionMeta = {
-    val row: Row = session
+    val base: Row = session
       .execute(
-        s"SELECT name, WRITETIME(name) AS name_wt, " +
-          s"tags, WRITETIME(tags) AS tags_wt, " +
-          s"attrs, WRITETIME(attrs) AS attrs_wt, TTL(attrs) AS attrs_ttl " +
+        s"SELECT name, WRITETIME(name) AS name_wt, tags, attrs " +
           s"FROM ${keyspace}.${table} WHERE id = '${id}'"
       )
       .one()
-    assert(row != null, s"expected a row for id=${id} in ${table}")
+    assert(base != null, s"expected a row for id=${id} in ${table}")
+
+    val tags = base.getSet("tags", classOf[Integer]).asScala.toList.map(_.intValue()).sorted
+    val tagsWt = tags.map { t =>
+      session
+        .execute(s"SELECT WRITETIME(tags[${t}]) AS wt FROM ${keyspace}.${table} WHERE id = '${id}'")
+        .one()
+        .getLong("wt")
+    }
+
+    val attrs = base
+      .getMap("attrs", classOf[String], classOf[Integer])
+      .asScala
+      .toMap
+      .map { case (k, v) => k -> v.intValue() }
+    val attrKeys = attrs.keys.toList.sorted
+    val (attrsWt, attrsTtl) = attrKeys.map { k =>
+      val r = session
+        .execute(
+          s"SELECT WRITETIME(attrs['${k}']) AS wt, TTL(attrs['${k}']) AS ttl " +
+            s"FROM ${keyspace}.${table} WHERE id = '${id}'"
+        )
+        .one()
+      val ttl: Integer = if (r.isNull("ttl")) null else Integer.valueOf(r.getInt("ttl"))
+      (r.getLong("wt"), ttl)
+    }.unzip
+
     CollectionMeta(
-      tags   = row.getSet("tags", classOf[Integer]).asScala.toList.map(_.intValue()),
-      tagsWt = row.getList("tags_wt", classOf[java.lang.Long]).asScala.toList.map(_.longValue()),
-      attrs = row
-        .getMap("attrs", classOf[String], classOf[Integer])
-        .asScala
-        .toMap
-        .map { case (k, v) => k -> v.intValue() },
-      attrsWt  = row.getList("attrs_wt", classOf[java.lang.Long]).asScala.toList.map(_.longValue()),
-      attrsTtl = row.getList("attrs_ttl", classOf[Integer]).asScala.toList,
-      name     = row.getString("name"),
-      nameWt   = row.getLong("name_wt")
+      tags     = tags,
+      tagsWt   = tagsWt,
+      attrs    = attrs,
+      attrsWt  = attrsWt,
+      attrsTtl = attrsTtl,
+      name     = base.getString("name"),
+      nameWt   = base.getLong("name_wt")
     )
   }
 
-  test("preserves per-element TTL/WRITETIME of non-frozen set and map columns") {
-    val session = cassandra5()
+  test(
+    "preserves per-element TTL/WRITETIME of non-frozen collections (Scylla source via subscript)"
+  ) {
+    val session = scylla2026()
     createTable(session, sourceTbl)
     createTable(session, targetTbl)
 
     val id = "r1"
-    // Scalar written with an explicit timestamp (exercises the base write path alongside appends).
     session.execute(
       s"INSERT INTO ${keyspace}.${sourceTbl} (id, name) VALUES ('${id}', 'alice') " +
         s"USING TIMESTAMP 1000000000000"
     )
 
-    // Set elements, each with its own WRITETIME, no TTL. 5+ elements to exceed small-collection
-    // special cases, inserted out of natural order.
     val tagWrites = Seq(
       50 -> 5000000000000L,
       10 -> 1000000000000L,
@@ -115,8 +143,6 @@ class CollectionTimestampPreservationTest extends munit.FunSuite {
       )
     }
 
-    // Map entries with distinct WRITETIMEs, mixed TTLs, keys inserted out of sort order (exercises
-    // the connector's unordered decode + key-sort re-alignment). 6 entries => HashMap on decode.
     val attrWrites = Seq(
       ("f", 6, 6000000000000L, Some(1000000)),
       ("a", 1, 1000000000000L, None),
@@ -140,26 +166,20 @@ class CollectionTimestampPreservationTest extends munit.FunSuite {
     val src = readMeta(session, sourceTbl, id)
     val dst = readMeta(session, targetTbl, id)
 
-    // Scalar preserved.
     assertEquals(dst.name, src.name)
     assertEquals(dst.nameWt, src.nameWt, "scalar WRITETIME must be preserved")
 
-    // Set: same elements and element-aligned WRITETIMEs (Cassandra returns both in sorted order).
-    assertEquals(dst.tags.sorted, src.tags.sorted, "set elements must match")
+    assertEquals(dst.tags, src.tags, "set elements must match")
     assertEquals(dst.tagsWt, src.tagsWt, "set element WRITETIMEs must be preserved")
 
-    // Map: same entries and element-aligned WRITETIMEs (both returned in key-sorted order).
     assertEquals(dst.attrs, src.attrs, "map entries must match")
     assertEquals(dst.attrsWt, src.attrsWt, "map element WRITETIMEs must be preserved")
 
-    // Map TTLs: null stays null; non-null preserved within a small tolerance for elapsed time.
     assertEquals(dst.attrsTtl.length, src.attrsTtl.length)
     dst.attrsTtl.zip(src.attrsTtl).zipWithIndex.foreach { case ((dTtl, sTtl), i) =>
       if (sTtl == null) assert(dTtl == null, s"attrs TTL[$i] expected null, got ${dTtl}")
       else {
         assert(dTtl != null, s"attrs TTL[$i] expected non-null")
-        // The target TTL may differ from the source by the read->write elapsed time (and the
-        // source keeps aging), so compare with an absolute tolerance rather than a direction.
         val diff = math.abs(sTtl.intValue() - dTtl.intValue())
         assert(
           diff <= 600,

--- a/tests/src/test/scala/com/scylladb/migrator/scylla/Scylla2026CollectionTimestampPreservationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/scylla/Scylla2026CollectionTimestampPreservationTest.scala
@@ -69,22 +69,25 @@ class Scylla2026CollectionTimestampPreservationTest extends munit.FunSuite {
     nameWt: Long
   )
 
+  private def readMeta(session: CqlSession, table: String, id: String): CollectionMeta =
+    readMetaWhere(session, table, s"id = '${id}'")
+
   /** Read per-element metadata via ScyllaDB's subscript form. Arrays are ordered by ascending set
     * element / map key so source and target compare element-wise.
     */
-  private def readMeta(session: CqlSession, table: String, id: String): CollectionMeta = {
+  private def readMetaWhere(session: CqlSession, table: String, where: String): CollectionMeta = {
     val base: Row = session
       .execute(
         s"SELECT name, WRITETIME(name) AS name_wt, tags, attrs " +
-          s"FROM ${keyspace}.${table} WHERE id = '${id}'"
+          s"FROM ${keyspace}.${table} WHERE ${where}"
       )
       .one()
-    assert(base != null, s"expected a row for id=${id} in ${table}")
+    assert(base != null, s"expected a row matching '${where}' in ${table}")
 
     val tags = base.getSet("tags", classOf[Integer]).asScala.toList.map(_.intValue()).sorted
     val tagsWt = tags.map { t =>
       session
-        .execute(s"SELECT WRITETIME(tags[${t}]) AS wt FROM ${keyspace}.${table} WHERE id = '${id}'")
+        .execute(s"SELECT WRITETIME(tags[${t}]) AS wt FROM ${keyspace}.${table} WHERE ${where}")
         .one()
         .getLong("wt")
     }
@@ -99,7 +102,7 @@ class Scylla2026CollectionTimestampPreservationTest extends munit.FunSuite {
       val r = session
         .execute(
           s"SELECT WRITETIME(attrs['${k}']) AS wt, TTL(attrs['${k}']) AS ttl " +
-            s"FROM ${keyspace}.${table} WHERE id = '${id}'"
+            s"FROM ${keyspace}.${table} WHERE ${where}"
         )
         .one()
       val ttl: Integer = if (r.isNull("ttl")) null else Integer.valueOf(r.getInt("ttl"))
@@ -187,5 +190,59 @@ class Scylla2026CollectionTimestampPreservationTest extends munit.FunSuite {
         )
       }
     }
+  }
+
+  /** The subscript path re-binds each row's primary key into per-row point reads. The connector's
+    * base scan decodes `uuid` to a `String` and `timestamp` to epoch-millis, neither of which has a
+    * matching driver codec, so binding them by runtime class throws `CodecNotFoundException` on the
+    * first point read. This covers the declared-type conversion for both; the `id text` test above
+    * cannot, because text is the one type that happens to bind correctly either way.
+    */
+  test("preserves per-element metadata for a compound uuid + timestamp primary key") {
+    val session = scylla2026()
+    for (table <- Seq(sourceTbl, targetTbl)) {
+      session.execute(s"DROP TABLE IF EXISTS ${keyspace}.${table}")
+      session.execute(
+        s"CREATE TABLE ${keyspace}.${table} " +
+          "(id uuid, ts timestamp, name text, tags set<int>, attrs map<text,int>, " +
+          "PRIMARY KEY ((id), ts))"
+      )
+    }
+
+    val id = "8f2a6c1e-3b7d-4a52-9c0e-1d4f6a8b2c39"
+    val ts = "2024-03-05T11:22:33.000Z"
+    val where = s"id = ${id} AND ts = '${ts}'"
+
+    session.execute(
+      s"INSERT INTO ${keyspace}.${sourceTbl} (id, ts, name) VALUES (${id}, '${ts}', 'alice') " +
+        "USING TIMESTAMP 1000000000000"
+    )
+    Seq(30 -> 3000000000000L, 10 -> 1000000000000L, 20 -> 2000000000000L).foreach { case (v, wt) =>
+      session.execute(
+        s"UPDATE ${keyspace}.${sourceTbl} USING TIMESTAMP ${wt} SET tags = tags + {${v}} " +
+          s"WHERE ${where}"
+      )
+    }
+    Seq(("b", 2, 2000000000000L, Some(1000000)), ("a", 1, 1000000000000L, None)).foreach {
+      case (k, v, wt, ttlOpt) =>
+        val using =
+          ttlOpt.fold(s"USING TIMESTAMP ${wt}")(t => s"USING TIMESTAMP ${wt} AND TTL ${t}")
+        session.execute(
+          s"UPDATE ${keyspace}.${sourceTbl} ${using} SET attrs = attrs + {'${k}': ${v}} " +
+            s"WHERE ${where}"
+        )
+    }
+
+    successfullyPerformMigration(configFile)
+
+    val src = readMetaWhere(session, sourceTbl, where)
+    val dst = readMetaWhere(session, targetTbl, where)
+
+    assertEquals(dst.name, src.name)
+    assertEquals(dst.nameWt, src.nameWt, "scalar WRITETIME must be preserved")
+    assertEquals(dst.tags, src.tags, "set elements must match")
+    assertEquals(dst.tagsWt, src.tagsWt, "set element WRITETIMEs must be preserved")
+    assertEquals(dst.attrs, src.attrs, "map entries must match")
+    assertEquals(dst.attrsWt, src.attrsWt, "map element WRITETIMEs must be preserved")
   }
 }

--- a/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
@@ -217,6 +217,33 @@ class CassandraRowComparisonTest extends munit.FunSuite {
     )
   }
 
+  test("Extreme writetime difference saturates instead of overflowing into a false match") {
+    // `|l - r| * scale` overflows for adversarial metadata (e.g. a hand-crafted Parquet writetime of
+    // Long.MinValue), and a WRAPPED negative difference silently passes the `diff > tolerance` test,
+    // reporting a corrupt row as identical. The comparison must saturate and still flag the row.
+    val left = CassandraRow.fromMap(
+      Map(
+        "id"             -> "r1",
+        "tags"           -> Set(10),
+        "tags_writetime" -> List(Long.MaxValue)
+      )
+    )
+    val right = CassandraRow.fromMap(
+      Map(
+        "id"             -> "r1",
+        "tags"           -> Set(10),
+        "tags_writetime" -> List(Long.MinValue)
+      )
+    )
+    val result = compareItems(left, Some(right), writetimeToleranceMillis = 0L)
+    val diffs = result.toList.flatMap(_.items).collect { case d: Item.DifferingWritetimes => d }
+    assert(diffs.nonEmpty, s"expected a DifferingWritetimes failure, got ${result}")
+    assert(
+      diffs.flatMap(_.details.map(_._2)).forall(_ > 0L),
+      s"expected a positive (saturated) difference, got ${diffs.flatMap(_.details)}"
+    )
+  }
+
   test("Per-element collection metadata length mismatch is reported as a cardinality mismatch") {
     val left = CassandraRow.fromMap(
       Map("id" -> "r1", "tags_writetime" -> List(1000L, 2000L, 3000L))

--- a/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
@@ -217,7 +217,7 @@ class CassandraRowComparisonTest extends munit.FunSuite {
     )
   }
 
-  test("Per-element collection metadata length mismatch is reported") {
+  test("Per-element collection metadata length mismatch is reported as a cardinality mismatch") {
     val left = CassandraRow.fromMap(
       Map("id" -> "r1", "tags_writetime" -> List(1000L, 2000L, 3000L))
     )
@@ -226,8 +226,45 @@ class CassandraRowComparisonTest extends munit.FunSuite {
     )
     val result = compareItems(left, Some(right))
     assert(
-      result.exists(_.items.exists(_.isInstanceOf[Item.DifferingWritetimes])),
-      s"expected a DifferingWritetimes failure for length mismatch, got ${result}"
+      result.exists(_.items.exists(_.isInstanceOf[Item.MetadataCardinalityMismatch])),
+      s"expected a MetadataCardinalityMismatch failure for length mismatch, got ${result}"
+    )
+    // A length mismatch is structural, not a time delta, so it must NOT be a DifferingWritetimes.
+    assert(
+      !result.exists(_.items.exists(_.isInstanceOf[Item.DifferingWritetimes])),
+      s"length mismatch should not be reported as DifferingWritetimes, got ${result}"
+    )
+  }
+
+  test("Malformed per-element metadata is reported as MalformedMetadata, not a time delta") {
+    val left = CassandraRow.fromMap(
+      Map("id" -> "r1", "tags_writetime" -> List(1000L, "oops", 3000L))
+    )
+    val right = CassandraRow.fromMap(
+      Map("id" -> "r1", "tags_writetime" -> List(1000L, 2000L, 3000L))
+    )
+    val result = compareItems(left, Some(right))
+    assert(
+      result.exists(_.items.exists(_.isInstanceOf[Item.MalformedMetadata])),
+      s"expected a MalformedMetadata failure, got ${result}"
+    )
+    assert(
+      !result.exists(_.items.exists(_.isInstanceOf[Item.DifferingWritetimes])),
+      s"malformed metadata should not be reported as DifferingWritetimes, got ${result}"
+    )
+  }
+
+  test("Per-element metadata vs collection cardinality mismatch is reported") {
+    val left = CassandraRow.fromMap(
+      Map("id" -> "r1", "tags" -> Set(10, 20, 30), "tags_writetime" -> List(1000L, 2000L))
+    )
+    val right = CassandraRow.fromMap(
+      Map("id" -> "r1", "tags" -> Set(10, 20, 30), "tags_writetime" -> List(1000L, 2000L))
+    )
+    val result = compareItems(left, Some(right))
+    assert(
+      result.exists(_.items.exists(_.isInstanceOf[Item.MetadataCardinalityMismatch])),
+      s"expected a MetadataCardinalityMismatch failure (2 writetimes for 3 elements), got ${result}"
     )
   }
 

--- a/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/validation/CassandraRowComparisonTest.scala
@@ -175,6 +175,86 @@ class CassandraRowComparisonTest extends munit.FunSuite {
     )
   }
 
+  test("Per-element collection WRITETIMEs match when element-aligned lists are equal") {
+    val left = CassandraRow.fromMap(
+      Map(
+        "id"             -> "r1",
+        "tags"           -> Set(10, 20, 30),
+        "tags_ttl"       -> List(0, 0, 0),
+        "tags_writetime" -> List(1000L, 2000L, 3000L)
+      )
+    )
+    val right = CassandraRow.fromMap(
+      Map(
+        "id"             -> "r1",
+        "tags"           -> Set(10, 20, 30),
+        "tags_ttl"       -> List(0, 0, 0),
+        "tags_writetime" -> List(1000L, 2000L, 3000L)
+      )
+    )
+    assertEquals(compareItems(left, Some(right)), None)
+  }
+
+  test("Per-element collection WRITETIME mismatch is reported for the differing column") {
+    val left = CassandraRow.fromMap(
+      Map(
+        "id"             -> "r1",
+        "tags"           -> Set(10, 20, 30),
+        "tags_writetime" -> List(1000L, 2000L, 3000L)
+      )
+    )
+    val right = CassandraRow.fromMap(
+      Map(
+        "id"             -> "r1",
+        "tags"           -> Set(10, 20, 30),
+        "tags_writetime" -> List(1000L, 2000L, 9999L) // last element differs beyond tolerance
+      )
+    )
+    val result = compareItems(left, Some(right), writetimeToleranceMillis = 0L)
+    assert(
+      result.exists(_.items.exists(_.isInstanceOf[Item.DifferingWritetimes])),
+      s"expected a DifferingWritetimes failure, got ${result}"
+    )
+  }
+
+  test("Per-element collection metadata length mismatch is reported") {
+    val left = CassandraRow.fromMap(
+      Map("id" -> "r1", "tags_writetime" -> List(1000L, 2000L, 3000L))
+    )
+    val right = CassandraRow.fromMap(
+      Map("id" -> "r1", "tags_writetime" -> List(1000L, 2000L))
+    )
+    val result = compareItems(left, Some(right))
+    assert(
+      result.exists(_.items.exists(_.isInstanceOf[Item.DifferingWritetimes])),
+      s"expected a DifferingWritetimes failure for length mismatch, got ${result}"
+    )
+  }
+
+  test("Per-element metadata comparison skipped when compareTimestamps is false") {
+    val left = CassandraRow.fromMap(
+      Map("id" -> "r1", "tags" -> Set(1), "tags_writetime" -> List(1000L))
+    )
+    val right = CassandraRow.fromMap(
+      Map("id" -> "r1", "tags" -> Set(1), "tags_writetime" -> List(9999L))
+    )
+    assertEquals(compareItems(left, Some(right), compareTimestamps = false), None)
+  }
+
+  test("metadataAsLongs handles scalar, list, and null metadata") {
+    val row = CassandraRow.fromMap(
+      Map(
+        "scalar_writetime" -> 1234L,
+        "list_writetime"   -> List(1L, 2L, 3L),
+        "null_writetime"   -> null
+      )
+    )
+    assertEquals(RowComparisonFailure.metadataAsLongs(row, "scalar_writetime"), Some(Seq(1234L)))
+    assertEquals(RowComparisonFailure.metadataAsLongs(row, "list_writetime"), Some(Seq(1L, 2L, 3L)))
+    // A null metadata value (e.g. empty/null collection) yields None.
+    assertEquals(RowComparisonFailure.metadataAsLongs(row, "null_writetime"), None)
+  }
+
   test("Direct areDifferent flags Float(1.5f) vs Double(1.5d) before hash comparison") {
     val floatVal: Option[Any] = Some(java.lang.Float.valueOf(1.5f))
     val doubleVal: Option[Any] = Some(java.lang.Double.valueOf(1.5))


### PR DESCRIPTION
This PR is to resolve https://github.com/scylladb/scylla-migrator/issues/76 and  https://github.com/scylladb/scylla-migrator/issues/70

- Frozen collections (frozen<map<..>> etc.) are a SINGLE cell. TTL()/WRITETIME() work on all Cassandra/Scylla versions and return scalars -> they fit the existing preservation path unchanged.
- Non-frozen collections need per-item metadata, only readable via CQL on Cassandra 5.0+ / ScyllaDB 2026.2 ([scylladb#15427](https://github.com/scylladb/scylladb/issues/15427), [CASSANDRA-8877](https://issues.apache.org/jira/browse/CASSANDRA-8877)). Requires new element-level read + write plumbing.

## Part 1. Frozen collections (single-cell)

Frozen collections behave exactly like scalars for TTL/writetime, so the only real change is relaxing the guard.

- In [`Cassandra.determineCopyType`](migrator/src/main/scala/com/scylladb/migrator/readers/Cassandra.scala) change the rejection predicate from `_.isCollection` to `_.isMultiCell`. This lets frozen collections (and frozen UDTs) flow through `CopyType.WithTimestampPreservation`, while still blocking non-frozen columns (until next part). Everything downstream (`createSelection` `_ttl`/`_writetime` scalar sidecars, `explodeRow` `getInt`/`getLong`, `TTLOption.perRow`/`TimestampOption.perRow` write) already handles single scalar values, so no other read/write change is required.
- `convertValue`/`widenTimestampValue` already recurse into frozen collection VALUES, so the collection payload round-trips as-is.

Tests / docs:
- Replace the collection-rejection assertion in [`CopyMissingRowsTest.scala`](tests/src/test/scala/com/scylladb/migrator/scylla/CopyMissingRowsTest.scala) (lines ~139-161) so frozen collections are accepted; keep a rejection case for a non-frozen collection.
- Add a CQL->Scylla (and Parquet round-trip) test with a `frozen<map>`/`frozen<set>` column asserting preserved TTL + writetime.

## Part 2. Non-frozen per-item TTL/writetime (maps + sets, Cassandra 5.0+)

Reuses the existing explode -> `RDD[Row]` -> `saveToCassandra(..., perRow ttl/timestamp)` pattern, but at ELEMENT granularity and with collection-append writes. Gated behind a source support flag + version check.

### Read (element-level metadata)
- Spike first: confirm how the connector returns `WRITETIME(col)`/`TTL(col)` for a multi-cell column on Cassandra 5.0 (expected `list<bigint>` / `list<int>` aligned to element order). Determine whether `colName.ttl`/`colName.writeTime` via `cassandraTable[CassandraSQLRow]` yield the list, or whether a raw function-call selector / raw CQL projection is needed. This decides the read approach.
- In `createSelection`, for non-frozen map/set regular columns, add the element-metadata selectors and declare sidecar schema as `ArrayType(IntegerType)` (ttl) and `ArrayType(LongType)` (writetime), instead of scalar. Scalar/frozen columns keep the current scalar sidecars.

### Transform (element explosion)
- New explode step: for each non-frozen collection column, zip elements (map: key order; set: element order) with their ttl/writetime lists, group elements by `(ttl, writetime)`, and emit one write row per group carrying a SINGLETON collection (`{k:v}` / `{v}`) plus that group's `(ttl, writetime)`. Keep `CassandraOption` semantics for the base (scalar) columns as today.

### Write (multi-pass, collection-append)
`saveToCassandra` applies ONE column selector per call, so per-item collection writes need separate passes from the scalar INSERT:
- Pass A (existing): base INSERT for PK + scalar/frozen regular columns via current exploded path.
- Pass B (per non-frozen collection column): `saveToCassandra` with `SomeColumns(pk..., CollectionColumnName(col, behavior = CollectionAppend))` + `TTLOption.perRow`/`TimestampOption.perRow`, producing `UPDATE ... SET col = col + ? USING TTL ? AND TIMESTAMP ?` per element-group row.
- Add the pass orchestration in [`ScyllaMigrator.migrate`](migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaMigrator.scala) and helper(s) in [`writers/Scylla.scala`](migrator/src/main/scala/com/scylladb/migrator/writers/Scylla.scala), keeping `writeCleanedRdd` reusable.

### Config, validation, parquet
- Add an opt-in source flag (e.g. `preserveCollectionItemTimestamps: true`, default false) in [`SourceSettings.scala`](migrator/src/main/scala/com/scylladb/migrator/config/SourceSettings.scala); relax the Phase 1 `isMultiCell` guard only for map/set when the flag is on, and validate the source supports it (probe C* version / feature), else fail fast with a clear message. Non-frozen lists stay rejected.
- Validation: extend `compareCassandraRows` in [`RowComparisonFailure.scala`](migrator/src/main/scala/com/scylladb/migrator/validation/RowComparisonFailure.scala) and repair schema in [`ScyllaValidator.scala`](migrator/src/main/scala/com/scylladb/migrator/scylla/ScyllaValidator.scala) to compare element-level metadata.
- Parquet round-trip: extend `TimestampColumns` naming + `explodeRowsFromPerColumnMeta`/`indexFieldsFromSchema` for array-typed element metadata. 

### Multi-pass caveats to handle
- Savepoints/`TokenRangeAccumulator` are per `saveToCassandra`. Per-element append idempotency alone is NOT sufficient for resume correctness — see the dedicated savepoint section below. The initial implementation shipped with the accumulator attached to the base write only, which is incorrect (CRITICAL, review finding F1).
- Tests: per-item round-trip for `map` and `set` with mixed per-element TTL/writetime on a Cassandra 5.0 / ScyllaDB 2026.2 fixture.
